### PR TITLE
feat: smart pre-commit hook, dev-sync pipeline reorder, changelog auto-add

### DIFF
--- a/.claude/commands/changelog.md
+++ b/.claude/commands/changelog.md
@@ -1,0 +1,18 @@
+Add a changelog entry to CHANGELOG.md under the `## [Unreleased]` section.
+
+Arguments: $ARGUMENTS
+
+Steps:
+1. Read the current CHANGELOG.md.
+2. Locate the `## [Unreleased]` section.
+3. Determine the entry type from the argument text:
+   - "add / new / create / implement" → `### Added`
+   - "change / update / improve / refactor / rename" → `### Changed`
+   - "fix / bug / correct / repair" → `### Fixed`
+   - "remove / delete / drop / deprecate" → `### Removed`
+   - Unclear → add as a plain `- ` bullet directly under `## [Unreleased]`
+4. If the matching `### Type` subsection already exists under `[Unreleased]`, append the entry there.
+   If it does not exist, create it above any existing subsections.
+5. Write only the minimum edit — do not touch any other part of the file.
+
+Entry format: `- $ARGUMENTS` (one line, no trailing period)

--- a/.claude/commands/sync.md
+++ b/.claude/commands/sync.md
@@ -1,0 +1,18 @@
+Run the full project sync pipeline.
+
+Arguments: $ARGUMENTS
+
+Execute the following bash command exactly as written:
+
+```bash
+bash scripts/dev-sync.sh "$ARGUMENTS"
+```
+
+The pipeline will:
+1. Append a session entry to `memory/YYYY-MM-DD.md`
+2. Update `memory/MEMORY.md` index via `sync-md.sh`
+3. Auto-add `$ARGUMENTS` to `CHANGELOG.md [Unreleased]` if the section has no entries yet
+4. Run `audit.sh` — must exit 0 before proceeding
+5. Create a new PR branch, commit all staged changes, push, and open a GitHub PR
+
+If audit fails, fix the reported issue before re-running `/sync`.

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,15 +1,1 @@
-{
-  "hooks": {
-    "PostToolUse": [
-      {
-        "matcher": "Write|Edit",
-        "hooks": [
-          {
-            "type": "command",
-            "command": "bash scripts/audit.sh"
-          }
-        ]
-      }
-    ]
-  }
-}
+{}

--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -1,3 +1,13 @@
 #!/usr/bin/env bash
-# pre-commit: run audit check before every commit
+# pre-commit: run audit only when structural files are staged.
+# memory/ session logs are exempt.
+
+STAGED=$(git diff --cached --name-only)
+[ -z "$STAGED" ] && exit 0
+
+# If every staged file is inside memory/ → skip audit (log-only commit)
+if ! echo "$STAGED" | grep -qv "^memory/"; then
+  exit 0
+fi
+
 bash scripts/audit.sh || exit 1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,13 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
 
+### Changed — workspace `.githooks/pre-commit` + `.claude/settings.json` + `.claude/commands/`
+- Applied same changes as templates/ to the workspace root itself
+- `.githooks/pre-commit`: conditional audit (memory/ exempt)
+- `.claude/settings.json`: PostToolUse hook 제거
+- `.claude/commands/changelog.md` + `sync.md`: 신규 추가
+- `scripts/dev-sync.sh`: 신규 추가 (memlog → sync-md → changelog → audit → commit)
+
 ### Changed — `templates/.githooks/pre-commit`
 - Smart conditional audit: skips `audit.sh` when only `memory/` files are staged (session logs, daily entries)
 - Runs audit only when structural files outside `memory/` are staged — prevents spurious failures on log-only commits

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,26 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
 
+### Changed — `templates/.githooks/pre-commit`
+- Smart conditional audit: skips `audit.sh` when only `memory/` files are staged (session logs, daily entries)
+- Runs audit only when structural files outside `memory/` are staged — prevents spurious failures on log-only commits
+
+### Changed — `templates/.claude/settings.json`
+- Removed PostToolUse hook — audit no longer fires on every Write/Edit
+- Audit is now enforced exclusively via pre-commit hook and `dev-sync.sh` pipeline
+
+### Changed — `templates/scripts/dev-sync.sh` + `dev-sync.ps1`
+- Reordered pipeline: `memlog → sync-md → changelog → audit → commit → PR`
+  (was: `audit → memlog → sync-md → commit`)
+- Added auto-changelog step: if `[Unreleased]` section has no entries, inserts the commit message automatically
+- Audit now runs after memory and changelog are updated — logically correct order
+
+### Added — `templates/.claude/commands/changelog.md`
+- `/changelog "description"` command: adds a typed entry (`### Added/Changed/Fixed/Removed`) to `CHANGELOG.md [Unreleased]`
+
+### Added — `templates/.claude/commands/sync.md`
+- `/sync "feat: ..."` command: wraps `bash scripts/dev-sync.sh` with pipeline description
+
 ### Added — `templates/agents/designer.md` (new)
 - UI/UX design agent for Phase 3 — Design group
 - Produces wireframes (text-based), component specs, design tokens, and accessibility checklists

--- a/scripts/dev-sync.sh
+++ b/scripts/dev-sync.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+# dev-sync.sh — Full pipeline: memlog → sync-md → changelog → audit → commit → PR
+# Usage: bash scripts/dev-sync.sh "feat: description"
+set -euo pipefail
+
+MSG="${1:-chore: update}"
+DATE=$(date +%Y-%m-%d)
+
+# ── 1. Write daily session log ─────────────────────────────────────────────────
+mkdir -p memory
+echo "## Session — $MSG" >> "memory/$DATE.md"
+
+# ── 2. Update MEMORY.md index ─────────────────────────────────────────────────
+bash scripts/sync-md.sh "$DATE" "$MSG"
+
+# ── 3. Auto-add to CHANGELOG.md [Unreleased] if the section has no entries ────
+if [ -f "CHANGELOG.md" ]; then
+  SECTION=$(awk '/\[Unreleased\]/{f=1;next} f && /^## /{exit} f{print}' CHANGELOG.md)
+  if ! echo "$SECTION" | grep -qE "^[[:space:]]*[-*]|^### "; then
+    perl -pi -e 's/## \[Unreleased\]/## [Unreleased]\n\n- '"$MSG"'/' CHANGELOG.md
+    echo "📝 Auto-added changelog entry: $MSG"
+  fi
+fi
+
+# ── 4. Audit gate ──────────────────────────────────────────────────────────────
+bash scripts/audit.sh
+
+# ── 5. Branch → commit → push → PR ────────────────────────────────────────────
+BRANCH="pr/$(date +%Y%m%d-%H%M%S)-$(echo "$MSG" | sed 's/[^a-z0-9]/-/g' | sed 's/--*/-/g' | cut -c1-40)"
+git checkout -b "$BRANCH"
+git add -A
+git commit -m "$MSG
+
+Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>"
+git push -u origin "$BRANCH"
+gh pr create --fill

--- a/templates/.claude/commands/changelog.md
+++ b/templates/.claude/commands/changelog.md
@@ -1,0 +1,18 @@
+Add a changelog entry to CHANGELOG.md under the `## [Unreleased]` section.
+
+Arguments: $ARGUMENTS
+
+Steps:
+1. Read the current CHANGELOG.md.
+2. Locate the `## [Unreleased]` section.
+3. Determine the entry type from the argument text:
+   - "add / new / create / implement" → `### Added`
+   - "change / update / improve / refactor / rename" → `### Changed`
+   - "fix / bug / correct / repair" → `### Fixed`
+   - "remove / delete / drop / deprecate" → `### Removed`
+   - Unclear → add as a plain `- ` bullet directly under `## [Unreleased]`
+4. If the matching `### Type` subsection already exists under `[Unreleased]`, append the entry there.
+   If it does not exist, create it above any existing subsections.
+5. Write only the minimum edit — do not touch any other part of the file.
+
+Entry format: `- $ARGUMENTS` (one line, no trailing period)

--- a/templates/.claude/commands/sync.md
+++ b/templates/.claude/commands/sync.md
@@ -1,0 +1,18 @@
+Run the full project sync pipeline.
+
+Arguments: $ARGUMENTS
+
+Execute the following bash command exactly as written:
+
+```bash
+bash scripts/dev-sync.sh "$ARGUMENTS"
+```
+
+The pipeline will:
+1. Append a session entry to `memory/YYYY-MM-DD.md`
+2. Update `memory/MEMORY.md` index via `sync-md.sh`
+3. Auto-add `$ARGUMENTS` to `CHANGELOG.md [Unreleased]` if the section has no entries yet
+4. Run `audit.sh` — must exit 0 before proceeding
+5. Create a new PR branch, commit all staged changes, push, and open a GitHub PR
+
+If audit fails, fix the reported issue before re-running `/sync`.

--- a/templates/.claude/settings.json
+++ b/templates/.claude/settings.json
@@ -1,15 +1,1 @@
-{
-  "hooks": {
-    "PostToolUse": [
-      {
-        "matcher": "Write|Edit",
-        "hooks": [
-          {
-            "type": "command",
-            "command": "bash scripts/audit.sh"
-          }
-        ]
-      }
-    ]
-  }
-}
+{}

--- a/templates/.githooks/pre-commit
+++ b/templates/.githooks/pre-commit
@@ -1,2 +1,13 @@
 #!/usr/bin/env bash
+# pre-commit: run audit only when key project files are staged.
+# memory/ session logs and other non-structural files are exempt.
+
+STAGED=$(git diff --cached --name-only)
+[ -z "$STAGED" ] && exit 0
+
+# If every staged file is inside memory/ → skip audit (log-only commit)
+if ! echo "$STAGED" | grep -qv "^memory/"; then
+  exit 0
+fi
+
 bash scripts/audit.sh || exit 1

--- a/templates/scripts/dev-sync.ps1
+++ b/templates/scripts/dev-sync.ps1
@@ -1,17 +1,37 @@
-# dev-sync.ps1 — Full pipeline: audit → memlog → commit → PR (Windows)
+# dev-sync.ps1 — Full pipeline: memlog → sync-md → changelog → audit → commit → PR (Windows)
 # Usage: .\scripts\dev-sync.ps1 "feat: description"
 param([string]$Msg = "chore: update")
 
+$Date = Get-Date -Format "yyyy-MM-dd"
+
+# ── 1. Write daily session log ─────────────────────────────────────────────────
+New-Item -ItemType Directory -Path "memory" -Force | Out-Null
+Add-Content "memory\$Date.md" "## Session — $Msg"
+
+# ── 2. Update MEMORY.md index ─────────────────────────────────────────────────
+.\scripts\sync-md.ps1 $Date $Msg
+
+# ── 3. Auto-add to CHANGELOG.md [Unreleased] if the section has no entries ────
+if (Test-Path "CHANGELOG.md") {
+    $cl = Get-Content "CHANGELOG.md" -Raw
+    # Extract [Unreleased] section content
+    if ($cl -match '## \[Unreleased\]([\s\S]*?)(?=\n## |\z)') {
+        $section = $Matches[1]
+        if ($section -notmatch '(?m)^\s*[-*]' -and $section -notmatch '(?m)^### ') {
+            $cl = $cl -replace '(## \[Unreleased\])', "`$1`n`n- $Msg"
+            Set-Content "CHANGELOG.md" $cl -Encoding UTF8 -NoNewline
+            Write-Host "📝 Auto-added changelog entry: $Msg" -ForegroundColor Cyan
+        }
+    }
+}
+
+# ── 4. Audit gate ──────────────────────────────────────────────────────────────
 .\scripts\audit.ps1
 if ($LASTEXITCODE -ne 0) { exit 1 }
 
-$Date = Get-Date -Format "yyyy-MM-dd"
-New-Item -ItemType Directory -Path "memory" -Force | Out-Null
-Add-Content "memory\$Date.md" "## Session — $Msg"
-.\scripts\sync-md.ps1 $Date $Msg
-
-$Slug = ($Msg -replace '[^a-z0-9]', '-' -replace '-+', '-').ToLower()
-$Slug = $Slug.Substring(0, [Math]::Min(40, $Slug.Length)).TrimEnd('-')
+# ── 5. Branch → commit → push → PR ────────────────────────────────────────────
+$Slug = ($Msg -replace '[^a-z0-9]', '-' -replace '-+', '-').ToLower().TrimEnd('-')
+$Slug = $Slug.Substring(0, [Math]::Min(40, $Slug.Length))
 $Branch = "pr/$(Get-Date -Format 'yyyyMMdd-HHmmss')-$Slug"
 git checkout -b $Branch
 git add -A

--- a/templates/scripts/dev-sync.sh
+++ b/templates/scripts/dev-sync.sh
@@ -1,16 +1,31 @@
 #!/usr/bin/env bash
-# dev-sync.sh — Full pipeline: audit → memlog → commit → PR
+# dev-sync.sh — Full pipeline: memlog → sync-md → changelog → audit → commit → PR
 # Usage: bash scripts/dev-sync.sh "feat: description"
 set -euo pipefail
 
 MSG="${1:-chore: update}"
-bash scripts/audit.sh
-
 DATE=$(date +%Y-%m-%d)
+
+# ── 1. Write daily session log ─────────────────────────────────────────────────
 mkdir -p memory
 echo "## Session — $MSG" >> "memory/$DATE.md"
+
+# ── 2. Update MEMORY.md index ─────────────────────────────────────────────────
 bash scripts/sync-md.sh "$DATE" "$MSG"
 
+# ── 3. Auto-add to CHANGELOG.md [Unreleased] if the section has no entries ────
+if [ -f "CHANGELOG.md" ]; then
+  SECTION=$(awk '/\[Unreleased\]/{f=1;next} f && /^## /{exit} f{print}' CHANGELOG.md)
+  if ! echo "$SECTION" | grep -qE "^[[:space:]]*[-*]|^### "; then
+    perl -pi -e 's/## \[Unreleased\]/## [Unreleased]\n\n- '"$MSG"'/' CHANGELOG.md
+    echo "📝 Auto-added changelog entry: $MSG"
+  fi
+fi
+
+# ── 4. Audit gate ──────────────────────────────────────────────────────────────
+bash scripts/audit.sh
+
+# ── 5. Branch → commit → push → PR ────────────────────────────────────────────
 BRANCH="pr/$(date +%Y%m%d-%H%M%S)-$(echo "$MSG" | sed 's/[^a-z0-9]/-/g' | sed 's/--*/-/g' | cut -c1-40)"
 git checkout -b "$BRANCH"
 git add -A


### PR DESCRIPTION
## Summary

- **pre-commit hook**: `memory/` 파일만 스테이지할 때는 audit 생략 — 로그 커밋 시 불필요한 실패 제거
- **`.claude/settings.json`**: PostToolUse hook 제거 — Write/Edit 시 자동 audit 비활성화
- **`dev-sync.sh/ps1`**: 파이프라인 순서 변경 `memlog → sync-md → changelog → audit → commit`
- **changelog 자동 추가**: `[Unreleased]` 섹션이 비어있으면 커밋 메시지를 자동 삽입
- **`/changelog` 명령**: `### Added/Changed/Fixed/Removed` 타입 분류 지원
- **`/sync` 명령**: `dev-sync.sh` 래퍼, 파이프라인 단계 안내 포함

## Changes

| File | Change |
|------|--------|
| `templates/.githooks/pre-commit` | `memory/`만 스테이지 시 audit 스킵 |
| `templates/.claude/settings.json` | PostToolUse hook 제거 (`{}`) |
| `templates/scripts/dev-sync.sh` | 순서 변경 + changelog 자동 추가 |
| `templates/scripts/dev-sync.ps1` | 동일 (Windows) |
| `templates/.claude/commands/changelog.md` | 신규 `/changelog` 커맨드 |
| `templates/.claude/commands/sync.md` | 신규 `/sync` 커맨드 |

## Test plan
- [x] `memory/`만 스테이지 → pre-commit audit SKIP 확인
- [x] `docs/context.md` 스테이지 → pre-commit audit 실행 확인
- [x] `[Unreleased]` 비어있을 때 dev-sync 실행 → 자동 항목 추가 확인
- [x] audit이 memlog/changelog 업데이트 후 실행되는 순서 확인

🤖 Generated with [Claude Code](https://claude.ai/claude-code)