### PR TITLE
chore: change license from MIT to AGPL-3.0

### DIFF
--- a/.claude/commands/memlog.md
+++ b/.claude/commands/memlog.md
@@ -1,0 +1,18 @@
+Append a session summary entry to today's memory log file.
+
+Arguments: $ARGUMENTS
+
+Steps:
+1. Determine today's date in YYYY-MM-DD format.
+2. Ensure `memory/` directory exists.
+3. Append the following to `memory/YYYY-MM-DD.md` (create if missing):
+   ```
+   ## Session — $ARGUMENTS
+   ```
+   If $ARGUMENTS is empty, use `## Session — update` as the heading.
+4. Update `memory/MEMORY.md` index by appending a row:
+   `| [YYYY-MM-DD](YYYY-MM-DD.md) | $ARGUMENTS |`
+   (Create MEMORY.md with header row if it does not exist.)
+5. Confirm: "📝 Session logged to memory/YYYY-MM-DD.md"
+
+Note: `/sync` already runs memlog automatically. Use `/memlog` only when you want to log a session entry without triggering a full sync.

--- a/.claude/commands/new-project.md
+++ b/.claude/commands/new-project.md
@@ -1,0 +1,21 @@
+Scaffold a new project under the workspace root.
+
+Arguments: $ARGUMENTS
+
+Execute the following bash command exactly as written:
+
+```bash
+bash scripts/new-project.sh "$ARGUMENTS"
+```
+
+The script will:
+1. Copy `templates/` into a new `<workspace>/$ARGUMENTS/` directory
+2. Remove `_examples/` (reference-only — not part of a real project)
+3. Remove `.gitkeep` placeholders
+4. Substitute `[Project Name]` placeholder with `$ARGUMENTS` in all text files
+5. Set executable permissions on hooks and scripts
+6. Initialize git with `core.hooksPath .githooks`
+
+After scaffolding, follow the printed "Next steps" to fill in placeholders and run the audit.
+
+> ⚠️ This command is workspace-level only. Run from the workspace root (`C:\git`).

--- a/.claude/commands/new-task.md
+++ b/.claude/commands/new-task.md
@@ -1,0 +1,24 @@
+Create a new task tracking entry in memory for the current session.
+
+Arguments: $ARGUMENTS
+
+Steps:
+1. Determine today's date in YYYY-MM-DD format.
+2. Ensure `memory/` directory exists.
+3. Append the following block to `memory/YYYY-MM-DD.md` (create if missing):
+   ```markdown
+   ## Task: $ARGUMENTS
+
+   **Status**: in_progress
+   **Started**: YYYY-MM-DD
+
+   ### Plan
+   - [ ] (fill in steps)
+
+   ### Notes
+   -
+   ```
+4. Confirm: "📋 Task created: $ARGUMENTS"
+
+This command creates a lightweight in-session task record in the daily memory log.
+For multi-session task tracking, use the TaskCreate tool directly.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,16 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Changed — License
 - MIT → AGPL-3.0
 
+### Fixed — Scaffold guideline consistency (5-round review)
+- `templates/agents/pm.md`: Agent Roster에 `designer.md` 누락 추가
+- `templates/CLAUDE.md`: Session Start 섹션 구체화 (4단계 체크리스트)
+- `templates/GEMINI.md`: Context Loading에 `@AGENTS.md` 추가
+- `templates/agents/architect.md`: ADR 예시 경로 명확화 (workspace 상대경로)
+- `templates/AGENTS.md`: `_examples` 참조 경로 명확화 (workspace 상대경로)
+- `templates/docs/context.md`: Architecture placeholder 구체화, Key Files에 sync-md.sh 추가, Session Start Skills 작성 방법 안내, Development Workflow hook 상태 정정
+- `scripts/new-project.sh`: Perl 치환 특수문자 이스케이프(`\Q...\E`), Next steps에 test-runner 명령 안내 추가
+- `scripts/new-project.ps1`: `.sample` 중복 필터 제거, WSL용 `chmod +x` 패리티(git update-index) 추가, Next steps에 test-runner 명령 안내 추가
+
 ### Fixed — Project consistency (README, CLAUDE.md, CONSTITUTION.md)
 - `CLAUDE.md §1`: PostToolUse hook이 비활성화 상태임을 명확히 표기 (`.claude/settings.json`은 `{}`)
 - `README.md`: 4-role → 5-role agent 모델 수정 (Designer 추가), Repository Structure에 `templates/` 추가, Two Philosophies 설명에 Designer 포함, Multi-Agent Workflow 설명 업데이트

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
 
+### Changed — License
+- MIT → AGPL-3.0
+
 ### Changed — workspace `.githooks/pre-commit` + `.claude/settings.json` + `.claude/commands/`
 - Applied same changes as templates/ to the workspace root itself
 - `.githooks/pre-commit`: conditional audit (memory/ exempt)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,14 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
 
+### Fixed — Missing slash commands / Skill registrations
+- `.claude/commands/memlog.md` 추가 (workspace + templates) — `/memlog` Skill 등록
+- `.claude/commands/new-task.md` 추가 (workspace + templates) — `/new-task` Skill 등록
+- `.claude/commands/new-project.md` 추가 (workspace only) — `/new-project` Skill 등록
+- `CLAUDE.md §2`: 커맨드 테이블 정확한 파일명 반영 및 Skill 등록 원리 설명 추가
+- `templates/CLAUDE.md`: Slash Commands 섹션 추가 (커맨드→Skill 자동 등록 원리 명시)
+- `templates/docs/context.md`: Development Workflow에 `/memlog` 추가, Slash Commands 테이블 추가
+
 ### Changed — License
 - MIT → AGPL-3.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Changed — License
 - MIT → AGPL-3.0
 
+### Fixed — Project consistency (README, CLAUDE.md, CONSTITUTION.md)
+- `CLAUDE.md §1`: PostToolUse hook이 비활성화 상태임을 명확히 표기 (`.claude/settings.json`은 `{}`)
+- `README.md`: 4-role → 5-role agent 모델 수정 (Designer 추가), Repository Structure에 `templates/` 추가, Two Philosophies 설명에 Designer 포함, Multi-Agent Workflow 설명 업데이트
+- `CONSTITUTION.md §7`: Post-scaffold checklist agent 수 4 → 5 수정, `.\scriptsudit.ps1` 오타 수정 (`.\scripts\audit.ps1`)
+- `scripts/dev-sync.ps1`: 워크스페이스 루트에 누락된 파일 추가 (Script Parity 규칙 준수)
+
 ### Changed — workspace `.githooks/pre-commit` + `.claude/settings.json` + `.claude/commands/`
 - Applied same changes as templates/ to the workspace root itself
 - `.githooks/pre-commit`: conditional audit (memory/ exempt)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Changed — License
 - MIT → AGPL-3.0
 
+### Fixed — Scaffold guideline consistency (4th review — final)
+- `CONSTITUTION.md §5`: Phase 3 Governance Workflow에 Designer 병렬 dispatch 명시
+
 ### Fixed — Scaffold guideline consistency (3rd 5-round review)
 - `templates/agents/pm.md`: Governance Workflow Phase 3에 designer parallel dispatch 명시
 - `CONSTITUTION.md §Workspace`: Session Start 체크리스트 순서 정정 (3↔4 교환 — MEMORY.md 먼저, skills 후)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Changed — License
 - MIT → AGPL-3.0
 
+### Fixed — Scaffold guideline consistency (3rd 5-round review)
+- `templates/agents/pm.md`: Governance Workflow Phase 3에 designer parallel dispatch 명시
+- `CONSTITUTION.md §Workspace`: Session Start 체크리스트 순서 정정 (3↔4 교환 — MEMORY.md 먼저, skills 후)
+- `CONSTITUTION.md §3`: /sync 파이프라인 순서를 실제 dev-sync.sh와 일치시킴 (memlog→MEMORY.md→CHANGELOG→audit→branch→commit→push→PR)
+
 ### Fixed — Scaffold guideline consistency (2nd 5-round review)
 - `scripts/new-project.ps1`: git update-index를 git init 이후로 이동 (dead code 제거)
 - `templates/CLAUDE.md`: Hooks Override 주석 정정 (hook 비활성 상태 명확화), Step 0 표현 개선, `model: inherit` 상속 기본값 명시

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,15 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Changed — License
 - MIT → AGPL-3.0
 
+### Fixed — Scaffold guideline consistency (2nd 5-round review)
+- `scripts/new-project.ps1`: git update-index를 git init 이후로 이동 (dead code 제거)
+- `templates/CLAUDE.md`: Hooks Override 주석 정정 (hook 비활성 상태 명확화), Step 0 표현 개선, `model: inherit` 상속 기본값 명시
+- `templates/GEMINI.md`: 이미 수정됨 (이전 라운드)
+- `templates/docs/context.md`: CONSTITUTION.md 링크 경로 수정 (`../` → `../../`)
+- `templates/AGENTS.md`: `_examples` 상대 경로 수정 (`../../templates/` → `../templates/`)
+- `CONSTITUTION.md §7`: "pm.md + 3 others" → "+ 4 others", `.claude/settings.json` 설명 정정
+- `GEMINI.md §3`: Context Loading에 `@AGENTS.md` 추가 (workspace 루트)
+
 ### Fixed — Scaffold guideline consistency (5-round review)
 - `templates/agents/pm.md`: Agent Roster에 `designer.md` 누락 추가
 - `templates/CLAUDE.md`: Session Start 섹션 구체화 (4단계 체크리스트)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -11,7 +11,9 @@ This file provides guidance to Claude Code (claude.ai/code) when working in this
 ## Claude Code-Specific Behaviors
 
 ### 1. Automated Hooks (`.claude/settings.json`)
-Claude Code automatically executes hooks defined in `.claude/settings.json`. The standard `PostToolUse` hook runs `scripts/audit.sh` after every Write or Edit operation to maintain document integrity.
+The workspace `.claude/settings.json` is currently `{}` — **PostToolUse hooks are disabled**. Audit is enforced exclusively via the pre-commit hook and the `dev-sync.sh` pipeline.
+
+To re-enable the PostToolUse hook (fires `audit.sh` after every Write/Edit), add the following to `.claude/settings.json`:
 
 ```json
 {
@@ -31,15 +33,15 @@ Claude Code automatically executes hooks defined in `.claude/settings.json`. The
 }
 ```
 
-> ⚠️ **Desktop App limitation**: `PostToolUse` hooks do **not** fire in the Claude Code Desktop App. After any Write or Edit in the Desktop App, run `bash scripts/audit.sh` manually before committing.
+> ⚠️ **Desktop App limitation**: `PostToolUse` hooks do **not** fire in the Claude Code Desktop App even when configured. After any Write or Edit in the Desktop App, run `bash scripts/audit.sh` manually before committing.
 
-| Environment | Hook fires? | Action if not |
-|-------------|:-----------:|---------------|
-| Claude Code CLI | ✅ | Automatic |
-| Claude Code Desktop App | ❌ | Run `bash scripts/audit.sh` manually |
+| Environment | Hook active by default? | Manual fallback |
+|-------------|:-----------------------:|-----------------|
+| Claude Code CLI | ❌ (disabled) | `bash scripts/audit.sh` |
+| Claude Code Desktop App | ❌ (always) | `bash scripts/audit.sh` |
 
 **Recommended workflow split:**
-- **CLI**: Automated workflows, hook-driven audits, multi-agent orchestration.
+- **CLI**: Automated workflows, pre-commit-enforced audits, multi-agent orchestration.
 - **Desktop App**: PR monitoring, visual diff reviews, parallel sessions.
 
 ### 2. Native Slash Commands

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -49,11 +49,14 @@ Custom slash commands in `.claude/commands/` are natively recognized by Claude C
 
 | Command | Purpose | Underlying Trigger |
 |---------|---------|--------------------|
-| `/sync "feat: ..."` | Full pipeline — audit → commit → PR | Runs project-level `scripts/dev-sync.sh` |
-| `/memlog` | Append today's session summary to YYYY-MM-DD.md | Automatically updates the daily log |
-| `/changelog "..."` | Add entry to `CHANGELOG.md` | Pre-sync user-facing changelog entry |
-| `/new-task "..."` | Create a new task tracking file | Scaffolds a new active task file |
-| `/new-project` | Scaffold a new project | Runs the workspace-global initialization script |
+| `/sync "feat: ..."` | Full pipeline — memlog → changelog → audit → commit → PR | `scripts/dev-sync.sh` |
+| `/changelog "..."` | Add entry to `CHANGELOG.md [Unreleased]` | Pre-sync user-facing changelog entry |
+| `/memlog "summary"` | Append session entry to `memory/YYYY-MM-DD.md` only | Without triggering full sync |
+| `/new-task "name"` | Create task block in today's memory log | In-session task tracking |
+| `/new-project "name"` | Scaffold a new project | `bash scripts/new-project.sh "$ARGUMENTS"` |
+
+> **How commands become Skills**: each `.claude/commands/<name>.md` file is automatically
+> registered as a `<name>` Skill. All 5 commands above have corresponding files in `.claude/commands/`.
 
 ### 3. MCP Configurations & Absolute Resolving
 Config file: `.mcp.json` (project root) — auto-loaded by both the CLI and the Desktop App.

--- a/CONSTITUTION.md
+++ b/CONSTITUTION.md
@@ -402,15 +402,15 @@ live there as **real, editable files** (not embedded strings).
         macOS/Linux : grep "^## " docs/context.md
         Windows     : Select-String -Path docs/context.md -Pattern "^## "
 
-□ agents/ — [Project Name] substituted in all 4 ## Role sections
-    □ agents/pm.md          □ agents/architect.md
+□ agents/ — [Project Name] substituted in all 5 ## Role sections
+    □ agents/pm.md          □ agents/architect.md   □ agents/designer.md
     □ agents/code-writer.md □ agents/test-runner.md
 
 □ README.md — project description filled in
 
 □ Final validation
     □ macOS/Linux : bash scripts/audit.sh    → must exit 0
-      Windows     : .\scriptsudit.ps1   → must exit 0
+      Windows     : .\scripts\audit.ps1   → must exit 0
     □ git config core.hooksPath .githooks    (already set by script — verify it stuck)
 ```
 ---

--- a/CONSTITUTION.md
+++ b/CONSTITUTION.md
@@ -375,9 +375,9 @@ live there as **real, editable files** (not embedded strings).
 |----------------|---------|---------------|
 | `docs/context.md` | Single source of truth — 10 required sections | Fill in `[...]` placeholders |
 | `AGENTS.md` | Canonical agent index | Ready to use |
-| `agents/pm.md` + 3 others | Role definitions | `[Project Name]` already substituted |
+| `agents/pm.md` + 4 others | Role definitions (pm, architect, designer, code-writer, test-runner) | `[Project Name]` already substituted |
 | `CLAUDE.md` / `GEMINI.md` | Platform-specific overrides | Add project-specific settings if needed |
-| `.claude/settings.json` | PostToolUse audit hook | Ready to use |
+| `.claude/settings.json` | Hooks config (disabled by default — `{}`) | Enable PostToolUse if needed |
 | `.gemini/settings.json` | Gemini project settings | Ready to use (add settings as needed) |
 | `scripts/` | audit, dev-sync, sync-md (.sh + .ps1) | Ready to use |
 | `.githooks/` | pre-commit (audit gate) + pre-push (block main) | Ready to use |

--- a/CONSTITUTION.md
+++ b/CONSTITUTION.md
@@ -44,8 +44,8 @@ Navigate to the project directory before starting work. Each project has its own
    ```
 1. **Read this file** (CONSTITUTION.md) — you are reading it now. Complete the section checklist at the top before proceeding.
 2. Read the project's `docs/context.md` — single source of truth for purpose, tech stack, and architecture.
-3. Load any skills listed under `## Session Start Skills` in the project's `docs/context.md`.
-4. Check the project's `memory/MEMORY.md` to understand recent changes.
+3. Check the project's `memory/MEMORY.md` to understand recent changes.
+4. Load any skills listed under `## Session Start Skills` in the project's `docs/context.md`.
 
 If `docs/context.md` does not exist (legacy or external project), fall back to `README.md` and any local `CLAUDE.md` or `GEMINI.md` in the project root.
 
@@ -152,12 +152,13 @@ Edit code
 
 /sync "feat: description" (or running dev-sync scripts directly)
   ↓
-  1. Audit script execution  — abort on failure (includes CHANGELOG.md existence check)
-  2. memory/YYYY-MM-DD.md     — auto-create if missing
-  3. MEMORY.md index         — update entry
-  4. git add -A && git commit
-  5. On main/master          ➔ create pr/<date>-<slug> branch, git reset --soft HEAD~1 on main
-  6. git push + gh pr create ➔ GitHub PR opened (Direct push blocked by local hooks)
+  1. memory/YYYY-MM-DD.md     — append session log entry
+  2. MEMORY.md index         — update entry
+  3. CHANGELOG.md            — auto-insert commit message if [Unreleased] is empty
+  4. Audit script execution  — abort on failure (includes CHANGELOG.md existence check)
+  5. git checkout -b pr/<date>-<slug>
+  6. git add -A && git commit
+  7. git push + gh pr create ➔ GitHub PR opened (Direct push blocked by local hooks)
 ```
 
 **Rules:**

--- a/CONSTITUTION.md
+++ b/CONSTITUTION.md
@@ -281,7 +281,8 @@ Phase 2 — Analysis
   Agents return findings → PM synthesizes into requirements + acceptance criteria
 
 Phase 3 — Design
-  Architect designs the implementation plan
+  Architect designs the implementation plan + ADR
+  Designer produces UI/UX specs (parallel with Architect, if task has UI/UX surface)
   PM obtains explicit user approval before proceeding
 
 Phase 4 — Implementation

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -66,6 +66,7 @@ Session Start Checklist steps are loaded into the conversation context using the
 ```
 @../CONSTITUTION.md          # Step 1 — workspace design standard
 @docs/context.md             # Step 2 — project knowledge
+@AGENTS.md                   # Step 3 — canonical agent roster
 @memory/MEMORY.md            # Step 4 — recent changes (skip if file does not exist)
 ```
 

--- a/LICENSE
+++ b/LICENSE
@@ -1,21 +1,662 @@
-MIT License
+                    GNU AFFERO GENERAL PUBLIC LICENSE
+                       Version 3, 19 November 2007
 
-Copyright (c) 2026 5throck
+ Copyright (C) 2007 Free Software Foundation, Inc. <https://fsf.org/>
+ Everyone is permitted to copy and distribute verbatim copies
+ of this license document, but changing it is not allowed.
 
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the "Software"), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
+                            Preamble
 
-The above copyright notice and this permission notice shall be included in all
-copies or substantial portions of the Software.
+  The GNU Affero General Public License is a free, copyleft license for
+software and other kinds of works, specifically designed to ensure
+cooperation with the community in the case of network server software.
 
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-SOFTWARE.
+  The licenses for most software and other practical works are designed
+to take away your freedom to share and change the works.  By contrast,
+our General Public Licenses are intended to guarantee your freedom to
+share and change all versions of a program--to make sure it remains free
+software for all its users.
+
+  When we speak of free software, we are referring to freedom, not
+price.  Our General Public Licenses are designed to make sure that you
+have the freedom to distribute copies of free software (and charge for
+them if you wish), that you receive source code or can get it if you
+want it, that you can change the software or use pieces of it in new
+free programs, and that you know you can do these things.
+
+  Developers that use our General Public Licenses protect your rights
+with two steps: (1) assert copyright on the software, and (2) offer
+you this License which gives you legal permission to copy, distribute
+and/or modify the software.
+
+  A secondary benefit of defending all users' freedom is that
+improvements made in alternate versions of the program, if they
+receive widespread use, become available for other developers to
+incorporate.  Many developers of free software are heartened and
+encouraged by the resulting cooperation.  However, in the case of
+software used on network servers, this result may fail to come about.
+The GNU General Public License permits making a modified version and
+letting the public access it on a server without ever releasing its
+source code to the public.
+
+  The GNU Affero General Public License is designed specifically to
+ensure that, in such cases, the modified source code becomes available
+to the community.  It requires the operator of a network server to
+provide the source code of the modified version running there to the
+users of that server.  Therefore, public use of a modified version, on
+a publicly accessible server, gives the public access to the source
+code of the modified version.
+
+  An older license, called the Affero General Public License and
+published by Affero, was designed to accomplish similar goals.  This is
+a different license, not a version of the Affero GPL, but Affero has
+released a new version of the Affero GPL which permits relicensing under
+this license.
+
+  The precise terms and conditions for copying, distribution and
+modification follow.
+
+                       TERMS AND CONDITIONS
+
+  0. Definitions.
+
+  "This License" refers to version 3 of the GNU Affero General Public License.
+
+  "Copyright" also means copyright-like laws that apply to other kinds of
+works, such as semiconductor masks.
+
+  "The Program" refers to any copyrightable work licensed under this
+License.  Each licensee is addressed as "you".  "Licensees" and
+"recipients" may be individuals or organizations.
+
+  To "modify" a work means to copy from or adapt all or part of the work
+in a fashion requiring copyright permission, other than the making of an
+exact copy.  The resulting work is called a "modified version" of the
+earlier work or a work "based on" the earlier work.
+
+  A "covered work" means either the unmodified Program or a work based
+on the Program.
+
+  To "propagate" a work means to do anything with it that, without
+permission, would make you directly or secondarily liable for
+infringement under applicable copyright law, except executing it on a
+computer or modifying a private copy.  Propagation includes copying,
+distribution (with or without modification), making available to the
+public, and in some countries other activities as well.
+
+  To "convey" a work means any kind of propagation that enables other
+parties to make or receive copies.  Mere interaction with a user through
+a computer network, with no transfer of a copy, is not conveying.
+
+  An interactive user interface displays "Appropriate Legal Notices"
+to the extent that it includes a convenient and prominently visible
+feature that (1) displays an appropriate copyright notice, and (2)
+tells the user that there is no warranty for the work (except to the
+extent that warranties are provided), that licensees may convey the
+work under this License, and how to view a copy of this License.  If
+the interface presents a list of user commands or options, such as a
+menu, a prominent item in the list meets this criterion.
+
+  1. Source Code.
+
+  The "source code" for a work means the preferred form of the work
+for making modifications to it.  "Object code" means any non-source
+form of a work.
+
+  A "Standard Interface" means an interface that either is an official
+standard defined by a recognized standards body, or, in the case of
+interfaces specified for a particular programming language, one that
+is widely used among developers working in that language.
+
+  The "System Libraries" of an executable work include anything, other
+than the work as a whole, that (a) is included in the normal form of
+packaging a Major Component, but which is not part of that Major
+Component, and (b) serves only to enable use of the work with that
+Major Component, or to implement a Standard Interface for which an
+implementation is available to the public in source code form.  A
+"Major Component", in this context, means a major essential component
+(kernel, window system, and so on) of the specific operating system
+(if any) on which the executable work runs, or a compiler used to
+produce the work, or an object code interpreter used to run it.
+
+  The "Corresponding Source" for a work in object code form means all
+the source code needed to generate, install, and (for an executable
+work) run the object code and to modify the work, including scripts to
+control those activities.  However, it does not include the work's
+System Libraries, or general-purpose tools or generally available free
+programs which are used unmodified in performing those activities but
+which are not part of the work.  For example, Corresponding Source
+includes interface definition files associated with source files for
+the work, and the source code for shared libraries and dynamically
+linked subprograms that the work is specifically designed to require,
+such as by intimate data communication or control flow between those
+subprograms and other parts of the work.
+
+  The Corresponding Source need not include anything that users
+can regenerate automatically from other parts of the Corresponding
+Source.
+
+  The Corresponding Source for a work in source code form is that
+same work.
+
+  2. Basic Permissions.
+
+  All rights granted under this License are granted for the term of
+copyright on the Program, and are irrevocable provided the stated
+conditions are met.  This License explicitly affirms your unlimited
+permission to run the unmodified Program.  The output from running a
+covered work is covered by this License only if the output, given its
+content, constitutes a covered work.  This License acknowledges your
+rights of fair use or other equivalent, as provided by copyright law.
+
+  You may make, run and propagate covered works that you do not
+convey, without conditions so long as your license otherwise remains
+in force.  You may convey covered works to others for the sole purpose
+of having them make modifications exclusively for you, or provide you
+with facilities for running those works, provided that you comply with
+the terms of this License in conveying all material for which you do
+not control copyright.  Those thus making or running the covered works
+for you must do so exclusively on your behalf, under your direction
+and control, on terms that prohibit them from making any copies of
+your copyrighted material outside their relationship with you.
+
+  Conveying under any other circumstances is permitted solely under
+the conditions stated below.  Sublicensing is not allowed; section 10
+makes it unnecessary.
+
+  3. Protecting Users' Legal Rights From Anti-Circumvention Law.
+
+  No covered work shall be deemed part of an effective technological
+measure under any applicable law fulfilling obligations under article
+11 of the WIPO copyright treaty adopted on 20 December 1996, or
+similar laws prohibiting or restricting circumvention of such
+measures.
+
+  When you convey a covered work, you waive any legal power to forbid
+circumvention of technological measures to the extent such circumvention
+is effected by exercising rights under this License with respect to
+the covered work, and you disclaim any intention to limit operation or
+modification of the work as a means of enforcing, against the work's
+users, your or third parties' legal rights to forbid circumvention of
+technological measures.
+
+  4. Conveying Verbatim Copies.
+
+  You may convey verbatim copies of the Program's source code as you
+receive it, in any medium, provided that you conspicuously and
+appropriately publish on each copy an appropriate copyright notice;
+keep intact all notices stating that this License and any
+non-permissive terms added in accord with section 7 apply to the code;
+keep intact all notices of the absence of any warranty; and give all
+recipients a copy of this License along with the Program.
+
+  You may charge any price or no price for each copy that you convey,
+and you may offer support or warranty protection for a fee.
+
+  5. Conveying Modified Source Versions.
+
+  You may convey a work based on the Program, or the modifications to
+produce it from the Program, in the form of source code under the
+terms of section 4, provided that you also meet all of these conditions:
+
+    a) The work must carry prominent notices stating that you modified
+    it, and giving a relevant date.
+
+    b) The work must carry prominent notices stating that it is
+    released under this License and any conditions added under section
+    7.  This requirement modifies the requirement in section 4 to
+    "keep intact all notices".
+
+    c) You must license the entire work, as a whole, under this
+    License to anyone who comes into possession of a copy.  This
+    License will therefore apply, along with any applicable section 7
+    additional terms, to the whole of the work, and all its parts,
+    regardless of how they are packaged.  This License gives no
+    permission to license the work in any other way, but it does not
+    invalidate such permission if you have separately received it.
+
+    d) If the work has interactive user interfaces, each must display
+    Appropriate Legal Notices; however, if the Program has interactive
+    interfaces that do not display Appropriate Legal Notices, your
+    work need not make them do so.
+
+  A compilation of a covered work with other separate and independent
+works, which are not by their nature extensions of the covered work,
+and which are not combined with it such as to form a larger program,
+in or on a volume of a storage or distribution medium, is called an
+"aggregate" if the compilation and its resulting copyright are not
+used to limit the access or legal rights of the compilation's users
+beyond what the individual works permit.  Inclusion of a covered work
+in an aggregate does not cause this License to apply to the other
+parts of the aggregate.
+
+  6. Conveying Non-Source Forms.
+
+  You may convey a covered work in object code form under the terms
+of sections 4 and 5, provided that you also convey the
+machine-readable Corresponding Source under the terms of this License,
+in one of these ways:
+
+    a) Convey the object code in, or embodied in, a physical product
+    (including a physical distribution medium), accompanied by the
+    Corresponding Source fixed on a durable physical medium
+    customarily used for software interchange.
+
+    b) Convey the object code in, or embodied in, a physical product
+    (including a physical distribution medium), accompanied by a
+    written offer, valid for at least three years and valid for as
+    long as you offer spare parts or customer support for that product
+    model, to give anyone who possesses the object code either (1) a
+    copy of the Corresponding Source for all the software in the
+    product that is covered by this License, on a durable physical
+    medium customarily used for software interchange, for a price no
+    more than your reasonable cost of physically performing this
+    conveying of source, or (2) access to copy the
+    Corresponding Source from a network server at no charge.
+
+    c) Convey individual copies of the object code with a copy of the
+    written offer to provide the Corresponding Source.  This
+    alternative is allowed only occasionally and noncommercially, and
+    only if you received the object code with such an offer, in accord
+    with subsection 6b.
+
+    d) Convey the object code by offering access from a designated
+    place (gratis or for a charge), and offer equivalent access to the
+    Corresponding Source in the same way through the same place at no
+    further charge.  You need not require recipients to copy the
+    Corresponding Source along with the object code.  If the place to
+    copy the object code is a network server, the Corresponding Source
+    may be on a different server (operated by you or a third party)
+    that supports equivalent copying facilities, provided you maintain
+    clear directions next to the object code saying where to find the
+    Corresponding Source.  Regardless of what server hosts the
+    Corresponding Source, you remain obligated to ensure that it is
+    available for as long as needed to satisfy these requirements.
+
+    e) Convey the object code using peer-to-peer transmission, provided
+    you inform other peers where the object code and Corresponding
+    Source of the work are being offered to the general public at no
+    charge under subsection 6d.
+
+  A separable portion of the object code, whose source code is excluded
+from the Corresponding Source as a System Library, need not be
+included in conveying the object code work.
+
+  A "User Product" is either (1) a "consumer product", which means any
+tangible personal property which is normally used for personal, family,
+or household purposes, or (2) anything designed or sold for incorporation
+into a dwelling.  In determining whether a product is a consumer product,
+doubtful cases shall be resolved in favor of coverage.  For a particular
+product received by a particular user, "normally used" refers to a
+typical or common use of that class of product, regardless of the status
+of the particular user or of the way in which the particular user
+actually uses, or expects or is expected to use, the product.  A product
+is a consumer product regardless of whether the product has substantial
+commercial, industrial or non-consumer uses, unless such uses represent
+the only significant mode of use of the product.
+
+  "Installation Information" for a User Product means any methods,
+procedures, authorization keys, or other information required to install
+and execute modified versions of a covered work in that User Product from
+a modified version of its Corresponding Source.  The information must
+suffice to ensure that the continued functioning of the modified object
+code is in no case prevented or interfered with solely because
+modification has been made.
+
+  If you convey an object code work under this section in, or with, or
+specifically for use in, a User Product, and the conveying occurs as
+part of a transaction in which the right of possession and use of the
+User Product is transferred to the recipient in perpetuity or for a
+fixed term (regardless of how the transaction is characterized), the
+Corresponding Source conveyed under this section must be accompanied
+by the Installation Information.  But this requirement does not apply
+if neither you nor any third party retains the ability to install
+modified object code on the User Product (for example, the work has
+been installed in ROM).
+
+  The requirement to provide Installation Information does not include a
+requirement to continue to provide support service, warranty, or updates
+for a work that has been modified or installed by the recipient, or for
+the User Product in which it has been modified or installed.  Access to a
+network may be denied when the modification itself materially and
+adversely affects the operation of the network or violates the rules and
+protocols for communication across the network.
+
+  Corresponding Source conveyed, and Installation Information provided,
+in accord with this section must be in a format that is publicly
+documented (and with an implementation available to the public in
+source code form), and must require no special password or key for
+unpacking, reading or copying.
+
+  7. Additional Terms.
+
+  "Additional permissions" are terms that supplement the terms of this
+License by making exceptions from one or more of its conditions.
+Additional permissions that are applicable to the entire Program shall
+be treated as though they were included in this License, to the extent
+that they are valid under applicable law.  If additional permissions
+apply only to part of the Program, that part may be used separately
+under those permissions, but the entire Program remains governed by
+this License without regard to the additional permissions.
+
+  When you convey a copy of a covered work, you may at your option
+remove any additional permissions from that copy, or from any part of
+it.  (Additional permissions may be written to require their own
+removal in certain cases when you modify the work.)  You may place
+additional permissions on material, added by you to a covered work,
+for which you have or can give appropriate copyright permission.
+
+  Notwithstanding any other provision of this License, for material you
+add to a covered work, you may (if authorized by the copyright holders of
+that material) supplement the terms of this License with terms:
+
+    a) Disclaiming warranty or limiting liability differently from the
+    terms of sections 15 and 16 of this License; or
+
+    b) Requiring preservation of specified reasonable legal notices or
+    author attributions in that material or in the Appropriate Legal
+    Notices displayed by works containing it; or
+
+    c) Prohibiting misrepresentation of the origin of that material, or
+    requiring that modified versions of such material be marked in
+    reasonable ways as different from the original version; or
+
+    d) Limiting the use for publicity purposes of names of licensors or
+    authors of the material; or
+
+    e) Declining to grant rights under trademark law for use of some
+    trade names, trademarks, or service marks; or
+
+    f) Requiring indemnification of licensors and authors of that
+    material by anyone who conveys the material (or modified versions of
+    it) with contractual assumptions of liability to the recipient, for
+    any liability that these contractual assumptions directly impose on
+    those licensors and authors.
+
+  All other non-permissive additional terms are considered "further
+restrictions" within the meaning of section 10.  If the Program as you
+received it, or any part of it, contains a notice stating that it is
+governed by this License along with a term that is a further
+restriction, you may remove that term.  If a license document contains
+a further restriction but permits relicensing or conveying under this
+License, you may add to a covered work material governed by the terms
+of that license document, provided that the further restriction does
+not survive such relicensing or conveying.
+
+  If you add terms to a covered work in accord with this section, you
+must place, in the relevant source files, a statement of the
+additional terms that apply to those files, or a notice indicating
+where to find the applicable terms.
+
+  Additional terms, permissive or non-permissive, may be stated in the
+form of a separately written license, or stated as exceptions;
+the above requirements apply either way.
+
+  8. Termination.
+
+  You may not propagate or modify a covered work except as expressly
+provided under this License.  Any attempt otherwise to propagate or
+modify it is void, and will automatically terminate your rights under
+this License (including any patent licenses granted under the third
+paragraph of section 11).
+
+  However, if you cease all violation of this License, then your
+license from a particular copyright holder is reinstated (a)
+provisionally, unless and until the copyright holder explicitly and
+finally terminates your license, and (b) permanently, if the copyright
+holder fails to notify you of the violation by some reasonable means
+prior to 60 days after the cessation.
+
+  Moreover, your license from a particular copyright holder is
+reinstated permanently if the copyright holder notifies you of the
+violation by some reasonable means, this is the first time you have
+received notice of violation of this License (for any work) from that
+copyright holder, and you cure the violation prior to 30 days after
+your receipt of the notice.
+
+  Termination of your rights under this section does not terminate the
+licenses of parties who have received copies or rights from you under
+this License.  If your rights have been terminated and not permanently
+reinstated, you do not qualify to receive new licenses for the same
+material under section 10.
+
+  9. Acceptance Not Required for Having Copies.
+
+  You are not required to accept this License in order to receive or
+run a copy of the Program.  Ancillary propagation of a covered work
+occurring solely as a consequence of using peer-to-peer transmission
+to receive a copy likewise does not require acceptance.  However,
+nothing other than this License grants you permission to propagate or
+modify any covered work.  These actions infringe copyright if you do
+not accept this License.  Therefore, by modifying or propagating a
+covered work, you indicate your acceptance of this License to do so.
+
+  10. Automatic Licensing of Downstream Recipients.
+
+  Each time you convey a covered work, the recipient automatically
+receives a license from the original licensors, to run, modify and
+propagate that work, subject to this License.  You are not responsible
+for enforcing compliance by third parties with this License.
+
+  An "entity transaction" is a transaction transferring control of an
+organization, or substantially all assets of one, or subdividing an
+organization, or merging organizations.  If propagation of a covered
+work results from an entity transaction, each party to that
+transaction who receives a copy of the work also receives whatever
+licenses to the work the party's predecessor in interest had or could
+give under the previous paragraph, plus a right to possession of the
+Corresponding Source of the work from the predecessor in interest, if
+the predecessor has it or can get it with reasonable efforts.
+
+  You may not impose any further restrictions on the exercise of the
+rights granted or affirmed under this License.  For example, you may
+not impose a license fee, royalty, or other charge for exercise of
+rights granted under this License, and you may not initiate litigation
+(including a cross-claim or counterclaim in a lawsuit) alleging that
+any patent claim is infringed by making, using, selling, offering for
+sale, or importing the Program or any portion of it.
+
+  11. Patents.
+
+  A "contributor" is a copyright holder who authorizes use under this
+License of the Program or a work on which the Program is based.  The
+work thus licensed is called the contributor's "contributor version".
+
+  A contributor's "essential patent claims" are all patent claims
+owned or controlled by the contributor, whether already acquired or
+hereafter acquired, that would be infringed by some manner, permitted
+by this License, of making, using, or selling its contributor version,
+but do not include claims that would be infringed only as a
+consequence of further modification of the contributor version.  For
+purposes of this definition, "control" includes the right to grant
+patent sublicenses in a manner consistent with the requirements of
+this License.
+
+  Each contributor grants you a non-exclusive, worldwide, royalty-free
+patent license under the contributor's essential patent claims, to
+make, use, sell, offer for sale, import and otherwise run, modify and
+propagate the contents of its contributor version.
+
+  In the following three paragraphs, a "patent license" is any express
+agreement or commitment, however denominated, not to enforce a patent
+(such as an express permission to practice a patent or covenant not to
+sue for patent infringement).  To "grant" such a patent license to a
+party means to make such an agreement or commitment not to enforce a
+patent against the party.
+
+  If you convey a covered work, knowingly relying on a patent license,
+and the Corresponding Source of the work is not available for anyone
+to copy, free of charge and under the terms of this License, through a
+publicly available network server or other readily accessible means,
+then you must either (1) cause the Corresponding Source to be so
+available, or (2) arrange to deprive yourself of the benefit of the
+patent license for this particular work, or (3) arrange, in a manner
+consistent with the requirements of this License, to extend the patent
+license to downstream recipients.  "Knowingly relying" means you have
+actual knowledge that, but for the patent license, your conveying the
+covered work in a country, or your recipient's use of the covered work
+in a country, would infringe one or more identifiable patents in that
+country that you have reason to believe are valid.
+
+  If, pursuant to or in connection with a single transaction or
+arrangement, you convey, or propagate by procuring conveyance of, a
+covered work, and grant a patent license to some of the parties
+receiving the covered work authorizing them to use, propagate, modify
+or convey a specific copy of the covered work, then the patent license
+you grant is automatically extended to all recipients of the covered
+work and works based on it.
+
+  A patent license is "discriminatory" if it does not include within
+the scope of its coverage, prohibits the exercise of, or is
+conditioned on the non-exercise of one or more of the rights that are
+specifically granted under this License.  You may not convey a covered
+work if you are a party to an arrangement with a third party that is
+in the business of distributing software, under which you make payment
+to the third party based on the extent of your activity of conveying
+the work, and under which the third party grants, to any of the
+parties who would receive the covered work from you, a discriminatory
+patent license (a) in connection with copies of the covered work
+conveyed by you (or copies made from those copies), or (b) primarily
+for and in connection with specific products or compilations that
+contain the covered work, unless you entered into that arrangement,
+or that patent license was granted, prior to 28 March 2007.
+
+  Nothing in this License shall be construed as excluding or limiting
+any implied license or other defenses to infringement that may
+otherwise be available to you under applicable patent law.
+
+  12. No Surrender of Others' Freedom.
+
+  If conditions are imposed on you (whether by court order, agreement or
+otherwise) that contradict the conditions of this License, they do not
+excuse you from the conditions of this License.  If you cannot convey a
+covered work so as to satisfy simultaneously your obligations under this
+License and any other pertinent obligations, then as a consequence you may
+not convey it at all.  For example, if you agree to terms that obligate you
+to collect a royalty for further conveying from those to whom you convey
+the Program, the only way you could satisfy both those terms and this
+License would be to refrain entirely from conveying the Program.
+
+  13. Remote Network Interaction; Use with the GNU General Public License.
+
+  Notwithstanding any other provision of this License, if you modify the
+Program, your modified version must prominently offer all users
+interacting with it remotely through a computer network (if your version
+supports such interaction) an opportunity to receive the Corresponding
+Source of your version by providing access to the Corresponding Source
+from a network server at no charge, through some standard or customary
+means of facilitating copying of software.  This Corresponding Source
+shall include the Corresponding Source for any work covered by version 3
+of the GNU General Public License that is incorporated pursuant to the
+following paragraph.
+
+  Notwithstanding any other provision of this License, you have
+permission to link or combine any covered work with a work licensed
+under version 3 of the GNU General Public License into a single
+combined work, and to convey the resulting work.  The terms of this
+License will continue to apply to the part which is the covered work,
+but the work with which it is combined will remain governed by version
+3 of the GNU General Public License.
+
+  14. Revised Versions of this License.
+
+  The Free Software Foundation may publish revised and/or new versions of
+the GNU Affero General Public License from time to time.  Such new versions
+will be similar in spirit to the present version, but may differ in detail to
+address new problems or concerns.
+
+  Each version is given a distinguishing version number.  If the
+Program specifies that a certain numbered version of the GNU Affero General
+Public License "or any later version" applies to it, you have the
+option of following the terms and conditions either of that numbered
+version or of any later version published by the Free Software
+Foundation.  If the Program does not specify a version number of the
+GNU Affero General Public License, you may choose any version ever published
+by the Free Software Foundation.
+
+  If the Program specifies that a proxy can decide which future
+versions of the GNU Affero General Public License can be used, that proxy's
+public statement of acceptance of a version permanently authorizes you
+to choose that version for the Program.
+
+  Later license versions may give you additional or different
+permissions.  However, no additional obligations are imposed on any
+author or copyright holder as a result of your choosing to follow a
+later version.
+
+  15. Disclaimer of Warranty.
+
+  THERE IS NO WARRANTY FOR THE PROGRAM, TO THE EXTENT PERMITTED BY
+APPLICABLE LAW.  EXCEPT WHEN OTHERWISE STATED IN WRITING THE COPYRIGHT
+HOLDERS AND/OR OTHER PARTIES PROVIDE THE PROGRAM "AS IS" WITHOUT WARRANTY
+OF ANY KIND, EITHER EXPRESSED OR IMPLIED, INCLUDING, BUT NOT LIMITED TO,
+THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+PURPOSE.  THE ENTIRE RISK AS TO THE QUALITY AND PERFORMANCE OF THE PROGRAM
+IS WITH YOU.  SHOULD THE PROGRAM PROVE DEFECTIVE, YOU ASSUME THE COST OF
+ALL NECESSARY SERVICING, REPAIR OR CORRECTION.
+
+  16. Limitation of Liability.
+
+  IN NO EVENT UNLESS REQUIRED BY APPLICABLE LAW OR AGREED TO IN WRITING
+WILL ANY COPYRIGHT HOLDER, OR ANY OTHER PARTY WHO MODIFIES AND/OR CONVEYS
+THE PROGRAM AS PERMITTED ABOVE, BE LIABLE TO YOU FOR DAMAGES, INCLUDING ANY
+GENERAL, SPECIAL, INCIDENTAL OR CONSEQUENTIAL DAMAGES ARISING OUT OF THE
+USE OR INABILITY TO USE THE PROGRAM (INCLUDING BUT NOT LIMITED TO LOSS OF
+DATA OR DATA BEING RENDERED INACCURATE OR LOSSES SUSTAINED BY YOU OR THIRD
+PARTIES OR A FAILURE OF THE PROGRAM TO OPERATE WITH ANY OTHER PROGRAMS),
+EVEN IF SUCH HOLDER OR OTHER PARTY HAS BEEN ADVISED OF THE POSSIBILITY OF
+SUCH DAMAGES.
+
+  17. Interpretation of Sections 15 and 16.
+
+  If the disclaimer of warranty and limitation of liability provided
+above cannot be given local legal effect according to their terms,
+reviewing courts shall apply local law that most closely approximates
+an absolute waiver of all civil liability in connection with the
+Program, unless a warranty or assumption of liability accompanies a
+copy of the Program in return for a fee.
+
+                     END OF TERMS AND CONDITIONS
+
+            How to Apply These Terms to Your New Programs
+
+  If you develop a new program, and you want it to be of the greatest
+possible use to the public, the best way to achieve this is to make it
+free software which everyone can redistribute and change under these terms.
+
+  To do so, attach the following notices to the program.  It is safest
+to attach them to the start of each source file to most effectively
+state the exclusion of warranty; and each file should have at least
+the "copyright" line and a pointer to where the full notice is found.
+
+    <one line to give the program's name and a brief idea of what it does.>
+    Copyright (C) 2026 5throck
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU Affero General Public License as published
+    by the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU Affero General Public License for more details.
+
+    You should have received a copy of the GNU Affero General Public License
+    along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+Also add information on how to contact you by electronic and paper mail.
+
+  If your software can interact with users remotely through a computer
+network, you should also make sure that it provides a way for users to
+get its source.  For example, if your program is a web application, its
+interface could display a "Source" link that leads users to an archive
+of the code.  There are many ways you could offer source, and different
+solutions will be better for different programs; see section 13 for the
+specific requirements.
+
+  You should also get your employer (if you work as a programmer) or school,
+if any, to sign a "copyright disclaimer" for the program, if necessary.
+For more information on this, and how to apply and follow the GNU AGPL, see
+<https://www.gnu.org/licenses/>.
+

--- a/README.md
+++ b/README.md
@@ -151,7 +151,7 @@ This is a **private repository**. Access is limited to invited collaborators.
 
 ## License
 
-MIT — see [LICENSE](LICENSE)
+AGPL-3.0 — see [LICENSE](LICENSE)
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Modern AI-assisted development requires more than prompts — it requires **cons
 
 ### Two Philosophies, One Standard
 
-**Vibe Coding** — AI takes the wheel. The developer describes intent; the AI agents (PM → Architect → Code Writer → Test Runner) execute the full workflow autonomously. These standards define the guardrails that keep autonomous execution safe and auditable.
+**Vibe Coding** — AI takes the wheel. The developer describes intent; the AI agents (PM → Architect → Designer → Code Writer → Test Runner) execute the full workflow autonomously. These standards define the guardrails that keep autonomous execution safe and auditable.
 
 **Harness Engineering** — Developer stays in the loop. AI tools are precision instruments: surgical edits, explicit plans, mandatory review gates. These standards define the harness that keeps AI output predictable and reviewable.
 
@@ -69,17 +69,24 @@ C:\git\ (workspace root — this repo)
 ├── GEMINI.md                # Gemini CLI / Antigravity workspace behaviors
 ├── CHANGELOG.md             # Workspace-level change history
 ├── README.md                # This file
+├── templates/               # Authoritative scaffold — new-project.sh copies this
+│   ├── agents/              # pm.md, architect.md, designer.md, code-writer.md, test-runner.md
+│   ├── docs/context.md      # Full 10-section project context template
+│   ├── scripts/             # dev-sync.sh/.ps1, sync-md.sh/.ps1, audit.sh/.ps1
+│   ├── .claude/             # settings.json ({}), commands/changelog.md, sync.md
+│   ├── .githooks/           # pre-commit (smart conditional), pre-push
+│   └── _examples/           # Reference-only ADR, analyst agent, session log, skill
 ├── scripts/
 │   ├── audit.sh / .ps1      # Documentation audit (checks ## Coding Guidelines, CHANGELOG, etc.)
-│   ├── dev-sync.sh / .ps1   # Full pipeline: audit → memlog → commit → PR
+│   ├── dev-sync.sh / .ps1   # Full pipeline: memlog → sync-md → changelog → audit → commit → PR
 │   ├── sync-md.sh / .ps1    # MEMORY.md index updater
-│   └── new-project.sh / .ps1 # New project scaffolding
+│   └── new-project.sh / .ps1 # New project scaffolding (copies templates/)
 ├── .githooks/
-│   ├── pre-commit           # Enforces CHANGELOG entry on commit
+│   ├── pre-commit           # Smart conditional audit (memory/ files exempt)
 │   └── pre-push             # Blocks direct push to main
 └── .claude/
-    ├── settings.json        # PostToolUse hook (audit.sh after Write/Edit)
-    └── commands/            # Custom slash commands (/sync, /memlog, etc.)
+    ├── settings.json        # {} (hooks disabled; enforced via pre-commit + dev-sync)
+    └── commands/            # Custom slash commands (/sync, /changelog, /memlog, etc.)
 ```
 
 Each sub-project lives in its own directory and git repository:
@@ -110,19 +117,19 @@ Every AI session begins by running this checklist (defined in `CONSTITUTION.md`)
 
 ## Multi-Agent Workflow
 
-Projects use a 4-role agent model across 6 governance phases:
+Projects use a 5-role agent model across 6 governance phases:
 
 ```
 PM Orchestrator
   │
   ├─ Phase 1-2: Analysis agents (parallel)  →  findings + acceptance criteria
-  ├─ Phase 3:   Architect                   →  implementation plan (user approval required)
+  ├─ Phase 3:   Architect + Designer        →  implementation plan + design spec (user approval required)
   ├─ Phase 4:   Code Writer + Test Runner   →  implementation + verification
   ├─ Phase 5:   QA gate                     →  audit.sh + tests pass
   └─ Phase 6:   Finalization                →  memlog → sync → PR
 ```
 
-Agent scaffold templates for all roles live in `CONSTITUTION.md §7`.
+Agent scaffold templates for all roles live in `templates/agents/`.
 
 ---
 

--- a/scripts/dev-sync.ps1
+++ b/scripts/dev-sync.ps1
@@ -1,0 +1,40 @@
+# dev-sync.ps1 — Full pipeline: memlog → sync-md → changelog → audit → commit → PR (Windows)
+# Usage: .\scripts\dev-sync.ps1 "feat: description"
+param([string]$Msg = "chore: update")
+
+$Date = Get-Date -Format "yyyy-MM-dd"
+
+# ── 1. Write daily session log ─────────────────────────────────────────────────
+New-Item -ItemType Directory -Path "memory" -Force | Out-Null
+Add-Content "memory\$Date.md" "## Session — $Msg"
+
+# ── 2. Update MEMORY.md index ─────────────────────────────────────────────────
+.\scripts\sync-md.ps1 $Date $Msg
+
+# ── 3. Auto-add to CHANGELOG.md [Unreleased] if the section has no entries ────
+if (Test-Path "CHANGELOG.md") {
+    $cl = Get-Content "CHANGELOG.md" -Raw
+    # Extract [Unreleased] section content
+    if ($cl -match '## \[Unreleased\]([\s\S]*?)(?=\n## |\z)') {
+        $section = $Matches[1]
+        if ($section -notmatch '(?m)^\s*[-*]' -and $section -notmatch '(?m)^### ') {
+            $cl = $cl -replace '(## \[Unreleased\])', "`$1`n`n- $Msg"
+            Set-Content "CHANGELOG.md" $cl -Encoding UTF8 -NoNewline
+            Write-Host "📝 Auto-added changelog entry: $Msg" -ForegroundColor Cyan
+        }
+    }
+}
+
+# ── 4. Audit gate ──────────────────────────────────────────────────────────────
+.\scripts\audit.ps1
+if ($LASTEXITCODE -ne 0) { exit 1 }
+
+# ── 5. Branch → commit → push → PR ────────────────────────────────────────────
+$Slug = ($Msg -replace '[^a-z0-9]', '-' -replace '-+', '-').ToLower().TrimEnd('-')
+$Slug = $Slug.Substring(0, [Math]::Min(40, $Slug.Length))
+$Branch = "pr/$(Get-Date -Format 'yyyyMMdd-HHmmss')-$Slug"
+git checkout -b $Branch
+git add -A
+git commit -m "$Msg`n`nCo-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>"
+git push -u origin $Branch
+gh pr create --fill

--- a/scripts/new-project.ps1
+++ b/scripts/new-project.ps1
@@ -41,30 +41,20 @@ Get-ChildItem -Path $ProjectDir -Recurse -File |
     }
   }
 
-# ── 5. Set executable bit on hooks and scripts (for WSL / Git Bash users) ──────
+# ── 5. Initialize git ──────────────────────────────────────────────────────────
+Set-Location $ProjectDir
+git init
+git config core.hooksPath .githooks
+
+# ── 6. Set executable bit on hooks and scripts (for WSL / Git Bash users) ──────
+# Must run AFTER git init so the git index exists
 $executableFiles = @(
     ".githooks\pre-commit", ".githooks\pre-push",
     "scripts\audit.sh", "scripts\dev-sync.sh", "scripts\sync-md.sh"
 )
 foreach ($rel in $executableFiles) {
-    $fullPath = Join-Path $ProjectDir $rel
-    if (Test-Path $fullPath) {
-        $acl = Get-Acl $fullPath  # no-op on Windows — preserves git index bit via git
-        # Mark as executable in git index so WSL/Git Bash sees +x after clone
-        git -C $ProjectDir update-index --chmod=+x $rel 2>$null
-    }
-}
-
-# ── 6. Initialize git ──────────────────────────────────────────────────────────
-Set-Location $ProjectDir
-git init
-git config core.hooksPath .githooks
-
-# Re-apply executable bits after git init (index reset on init)
-foreach ($rel in $executableFiles) {
-    $fullPath = Join-Path $ProjectDir $rel
-    if (Test-Path $fullPath) {
-        git -C $ProjectDir update-index --chmod=+x $rel 2>$null
+    if (Test-Path (Join-Path $ProjectDir $rel)) {
+        git update-index --chmod=+x $rel 2>$null
     }
 }
 

--- a/scripts/new-project.ps1
+++ b/scripts/new-project.ps1
@@ -32,7 +32,7 @@ Get-ChildItem -Path $ProjectDir -Recurse -Filter ".gitkeep" | Remove-Item -Force
 # ── 4. Substitute [Project Name] placeholder in all text files ─────────────────
 $extensions = @('.md', '.json', '.sh', '.ps1', '.yaml', '.yml', '.sample')
 Get-ChildItem -Path $ProjectDir -Recurse -File |
-  Where-Object { $_.Extension -in $extensions -or $_.Name -like '*.sample' } |
+  Where-Object { $_.Extension -in $extensions } |
   ForEach-Object {
     $content = Get-Content $_.FullName -Raw -ErrorAction SilentlyContinue
     if ($content -and $content -match '\[Project Name\]') {
@@ -41,18 +41,41 @@ Get-ChildItem -Path $ProjectDir -Recurse -File |
     }
   }
 
-# ── 5. Initialize git ──────────────────────────────────────────────────────────
+# ── 5. Set executable bit on hooks and scripts (for WSL / Git Bash users) ──────
+$executableFiles = @(
+    ".githooks\pre-commit", ".githooks\pre-push",
+    "scripts\audit.sh", "scripts\dev-sync.sh", "scripts\sync-md.sh"
+)
+foreach ($rel in $executableFiles) {
+    $fullPath = Join-Path $ProjectDir $rel
+    if (Test-Path $fullPath) {
+        $acl = Get-Acl $fullPath  # no-op on Windows — preserves git index bit via git
+        # Mark as executable in git index so WSL/Git Bash sees +x after clone
+        git -C $ProjectDir update-index --chmod=+x $rel 2>$null
+    }
+}
+
+# ── 6. Initialize git ──────────────────────────────────────────────────────────
 Set-Location $ProjectDir
 git init
 git config core.hooksPath .githooks
+
+# Re-apply executable bits after git init (index reset on init)
+foreach ($rel in $executableFiles) {
+    $fullPath = Join-Path $ProjectDir $rel
+    if (Test-Path $fullPath) {
+        git -C $ProjectDir update-index --chmod=+x $rel 2>$null
+    }
+}
 
 Write-Host ""
 Write-Host "✅ Project '$ProjectName' scaffolded at: $ProjectDir" -ForegroundColor Green
 Write-Host ""
 Write-Host "Next steps:" -ForegroundColor Cyan
 Write-Host "  1. Fill in docs\context.md placeholders (## Tech Stack, ## Architecture, [KEY_NAME])"
-Write-Host "  2. .\scripts\audit.ps1                    (verify scaffold passes — must exit 0)"
-Write-Host "  3. git config core.hooksPath .githooks    (already set, verify it stuck)"
+Write-Host "  2. Set your test command in agents\test-runner.md (replace [project test command])"
+Write-Host "  3. .\scripts\audit.ps1                    (verify scaffold passes — must exit 0)"
+Write-Host "  4. git config core.hooksPath .githooks    (already set, verify it stuck)"
 Write-Host ""
 Write-Host "Extension templates (ADR, analyst agent, skill, daily log):" -ForegroundColor DarkGray
 Write-Host "  → $TemplatesDir\_examples\" -ForegroundColor DarkGray

--- a/scripts/new-project.sh
+++ b/scripts/new-project.sh
@@ -38,7 +38,7 @@ find "$PROJECT_DIR" -name ".gitkeep" -delete
 # ── 4. Substitute [Project Name] placeholder in all text files ─────────────────
 # Use perl for cross-platform compatibility (macOS sed -i requires '' suffix)
 while IFS= read -r -d '' file; do
-  perl -pi -e "s/\[Project Name\]/$PROJECT_NAME/g" "$file"
+  perl -pi -e "s/\[Project Name\]/\Q$PROJECT_NAME\E/g" "$file"
 done < <(find "$PROJECT_DIR" -type f \
   \( -name "*.md" -o -name "*.json" -o -name "*.sh" -o -name "*.ps1" \
      -o -name "*.yaml" -o -name "*.yml" -o -name "*.sample" \) \
@@ -61,8 +61,9 @@ echo "✅ Project '$PROJECT_NAME' scaffolded at: $PROJECT_DIR"
 echo ""
 echo "Next steps:"
 echo "  1. Fill in docs/context.md placeholders (## Tech Stack, ## Architecture, [KEY_NAME])"
-echo "  2. bash scripts/audit.sh          (verify scaffold passes — must exit 0)"
-echo "  3. git config core.hooksPath .githooks  (already set, verify it stuck)"
+echo "  2. Set your test command in agents/test-runner.md (replace [project test command])"
+echo "  3. bash scripts/audit.sh          (verify scaffold passes — must exit 0)"
+echo "  4. git config core.hooksPath .githooks  (already set, verify it stuck)"
 echo ""
 echo "Extension templates (ADR, analyst agent, skill, daily log):"
 echo "  → $TEMPLATES_DIR/_examples/"

--- a/templates/.claude/commands/memlog.md
+++ b/templates/.claude/commands/memlog.md
@@ -1,0 +1,18 @@
+Append a session summary entry to today's memory log file.
+
+Arguments: $ARGUMENTS
+
+Steps:
+1. Determine today's date in YYYY-MM-DD format.
+2. Ensure `memory/` directory exists.
+3. Append the following to `memory/YYYY-MM-DD.md` (create if missing):
+   ```
+   ## Session — $ARGUMENTS
+   ```
+   If $ARGUMENTS is empty, use `## Session — update` as the heading.
+4. Update `memory/MEMORY.md` index by appending a row:
+   `| [YYYY-MM-DD](YYYY-MM-DD.md) | $ARGUMENTS |`
+   (Create MEMORY.md with header row if it does not exist.)
+5. Confirm: "📝 Session logged to memory/YYYY-MM-DD.md"
+
+Note: `/sync` already runs memlog automatically. Use `/memlog` only when you want to log a session entry without triggering a full sync.

--- a/templates/.claude/commands/new-task.md
+++ b/templates/.claude/commands/new-task.md
@@ -1,0 +1,24 @@
+Create a new task tracking entry in memory for the current session.
+
+Arguments: $ARGUMENTS
+
+Steps:
+1. Determine today's date in YYYY-MM-DD format.
+2. Ensure `memory/` directory exists.
+3. Append the following block to `memory/YYYY-MM-DD.md` (create if missing):
+   ```markdown
+   ## Task: $ARGUMENTS
+
+   **Status**: in_progress
+   **Started**: YYYY-MM-DD
+
+   ### Plan
+   - [ ] (fill in steps)
+
+   ### Notes
+   -
+   ```
+4. Confirm: "📋 Task created: $ARGUMENTS"
+
+This command creates a lightweight in-session task record in the daily memory log.
+For multi-session task tracking, use the TaskCreate tool directly.

--- a/templates/AGENTS.md
+++ b/templates/AGENTS.md
@@ -13,7 +13,7 @@
 | Execution | Code Writer | `agents/code-writer.md` | Implements approved plans; surgical changes only |
 | Execution | Test Runner | `agents/test-runner.md` | Runs tests and verifies acceptance criteria |
 
-*(Add Analysis agents as needed — see `templates/_examples/agents/analyst-example.md` for the scaffold template.)*
+*(Add Analysis agents as needed — see `../../templates/_examples/agents/analyst-example.md` in the workspace root for the scaffold template.)*
 
 ## Agent Dispatch
 

--- a/templates/AGENTS.md
+++ b/templates/AGENTS.md
@@ -13,7 +13,7 @@
 | Execution | Code Writer | `agents/code-writer.md` | Implements approved plans; surgical changes only |
 | Execution | Test Runner | `agents/test-runner.md` | Runs tests and verifies acceptance criteria |
 
-*(Add Analysis agents as needed — see `../../templates/_examples/agents/analyst-example.md` in the workspace root for the scaffold template.)*
+*(Add Analysis agents as needed — see `../templates/_examples/agents/analyst-example.md` in the workspace root for the scaffold template.)*
 
 ## Agent Dispatch
 

--- a/templates/CLAUDE.md
+++ b/templates/CLAUDE.md
@@ -19,6 +19,20 @@ At the start of every Claude Code session, run this checklist:
 
 <!-- Add entries below ONLY for Claude Code-exclusive session steps not covered above. -->
 
+### Slash Commands (`.claude/commands/`)
+
+These commands are available as both `/slash-commands` and via the `Skill` tool:
+
+| Command | Purpose |
+|---------|---------|
+| `/changelog "description"` | Add entry to `CHANGELOG.md [Unreleased]` |
+| `/sync "feat: ..."` | Full pipeline — memlog → changelog → audit → commit → PR |
+| `/memlog "summary"` | Append session entry to `memory/YYYY-MM-DD.md` only |
+| `/new-task "task name"` | Create task tracking block in today's memory log |
+
+> **How commands become Skills**: each `.claude/commands/<name>.md` file is automatically
+> registered as a `<name>` Skill in Claude Code. Add new commands by creating files here.
+
 ### MCP Servers
 <!-- Document project-specific .mcp.json entries here, if any.             -->
 <!-- General MCP guidance: workspace ../CLAUDE.md §3                        -->

--- a/templates/CLAUDE.md
+++ b/templates/CLAUDE.md
@@ -6,8 +6,18 @@
 ## Project-Specific Claude Code Settings
 
 ### Session Start
-<!-- Skills are loaded from docs/context.md ## Session Start Skills.       -->
-<!-- Add entries here ONLY for Claude Code-exclusive skills not in context.md. -->
+
+At the start of every Claude Code session, run this checklist:
+
+```
+0. git config core.hooksPath .githooks   # verify hooks are active
+1. Read docs/context.md                  # project knowledge — coding guidelines, agents, workflow
+2. Read AGENTS.md                        # agent roster (auto-loaded by Claude Code)
+3. Read memory/MEMORY.md                 # recent changes and session history
+4. Load skills listed in docs/context.md ## Session Start Skills
+```
+
+<!-- Add entries below ONLY for Claude Code-exclusive session steps not covered above. -->
 
 ### MCP Servers
 <!-- Document project-specific .mcp.json entries here, if any.             -->

--- a/templates/CLAUDE.md
+++ b/templates/CLAUDE.md
@@ -10,7 +10,7 @@
 At the start of every Claude Code session, run this checklist:
 
 ```
-0. git config core.hooksPath .githooks   # verify hooks are active
+0. git config core.hooksPath .githooks   # activate hooks (run once per clone; verify it stuck)
 1. Read docs/context.md                  # project knowledge — coding guidelines, agents, workflow
 2. Read AGENTS.md                        # agent roster (auto-loaded by Claude Code)
 3. Read memory/MEMORY.md                 # recent changes and session history
@@ -24,11 +24,16 @@ At the start of every Claude Code session, run this checklist:
 <!-- General MCP guidance: workspace ../CLAUDE.md §3                        -->
 
 ### Hooks Override
-<!-- Override hook behavior for this project only, if needed.              -->
-<!-- Default (.claude/settings.json) runs scripts/audit.sh on Write/Edit.  -->
+<!-- Hooks are disabled by default (.claude/settings.json = {}).           -->
+<!-- Audit is enforced via pre-commit hook and scripts/dev-sync.sh only.   -->
+<!-- To enable PostToolUse audit on every Write/Edit, add to settings.json: -->
+<!--   { "hooks": { "PostToolUse": [{ "matcher": "Write|Edit",             -->
+<!--     "hooks": [{ "type": "command", "command": "bash scripts/audit.sh" }] }] } } -->
 
 ### Model Selection Override
-<!-- Uncomment to override workspace defaults for this project only.       -->
-<!-- - Heavy reasoning  : claude-opus-4-7                                  -->
-<!-- - Default          : claude-sonnet-4-6                                -->
-<!-- - Fast lookups     : claude-haiku-4-5-20251001                        -->
+<!-- agents/*.md use `model: inherit` — inheriting from workspace ../CLAUDE.md defaults: -->
+<!--   - Default (inherit)    : claude-sonnet-4-6                          -->
+<!--   - Heavy reasoning      : claude-opus-4-7                            -->
+<!--   - Fast lookups         : claude-haiku-4-5-20251001                  -->
+<!-- Uncomment below to override workspace defaults for this project only. -->
+<!-- model: claude-opus-4-7                                                -->

--- a/templates/GEMINI.md
+++ b/templates/GEMINI.md
@@ -9,6 +9,7 @@ Load project files at session start using the `@` syntax:
 ```
 @../CONSTITUTION.md      # workspace design standard
 @docs/context.md         # project knowledge (includes Session Start Skills)
+@AGENTS.md               # canonical agent roster
 @memory/MEMORY.md        # recent changes (skip if file does not exist)
 ```
 

--- a/templates/agents/architect.md
+++ b/templates/agents/architect.md
@@ -58,4 +58,4 @@ One paragraph describing what will be built and why this approach was chosen.
 - Surface all ambiguities before finalizing the plan.
 - Flag any change that touches more than 3 files as high-risk and require explicit user confirmation.
 - All ADRs must follow the 3-section format: Context �� Decision → Consequences.
-- ADR template: `../CONSTITUTION.md` → `templates/_examples/adr/0001-example-decision.md`
+- ADR template: see `../../templates/_examples/adr/0001-example-decision.md` in the workspace root (not copied into the project — reference only).

--- a/templates/agents/pm.md
+++ b/templates/agents/pm.md
@@ -20,7 +20,7 @@ Follow the 6-phase PM workflow defined in [CONSTITUTION.md §5](../../CONSTITUTI
 
 1. **Triage** — Classify the request; dispatch read-only agents in parallel (single message).
 2. **Analysis** — Synthesize findings into requirements + acceptance criteria.
-3. **Design** — Have the architect produce an implementation plan; obtain explicit user approval.
+3. **Design** — Dispatch architect (implementation plan + ADR) and, if the task has UI/UX surface, designer (wireframes + component spec) in parallel; obtain explicit user approval before proceeding.
 4. **Implementation** — Dispatch code-writer (serial); test-runner verifies after each change.
 5. **QA** — Verify all acceptance criteria; run audit script + tests.
 6. **Finalization** — Run memlog → sync; open PR; hand off to user.

--- a/templates/agents/pm.md
+++ b/templates/agents/pm.md
@@ -33,6 +33,7 @@ Add rows as specialist agents are created. Start with PM only; expand when the p
 |-------|-------|------------|----------------|
 | Triage / Analysis | Analysis | *(add `agents/<name>-analyst.md`)* | Read-only investigation, findings report |
 | Design | Design | `agents/architect.md` | Implementation plan + ADR; awaits user approval |
+| Design | Design | `agents/designer.md` | UI/UX specs, wireframes, component definitions; awaits user approval |
 | Implementation | Execution | `agents/code-writer.md` | Write code per approved plan |
 | QA / Verification | Execution | `agents/test-runner.md` | Run tests, verify acceptance criteria |
 

--- a/templates/docs/context.md
+++ b/templates/docs/context.md
@@ -60,14 +60,27 @@
 # Audit (enforced via pre-commit hook and dev-sync pipeline; run manually any time)
 bash scripts/audit.sh            # Windows: .\scripts\audit.ps1
 
+# Log a session entry (without syncing)
+# Claude Code:  /memlog "summary"
+# Bash:         echo "## Session — summary" >> memory/$(date +%Y-%m-%d).md
+
 # Add a changelog entry (optional, before sync)
 # Claude Code:  /changelog "added|changed|fixed|removed <description>"
 # Gemini CLI:   append to CHANGELOG.md under [Unreleased]
 
-# Full sync: audit → memlog → commit → PR
+# Full sync: memlog → changelog → audit → commit → PR
 bash scripts/dev-sync.sh "feat: description"   # Windows: .\scripts\dev-sync.ps1 "feat: ..."
 # Claude Code:  /sync "feat: description"
 ```
+
+### Claude Code Slash Commands
+Each `.claude/commands/<name>.md` file is auto-registered as a Skill in Claude Code:
+| Command | Skill name | Purpose |
+|---------|-----------|---------|
+| `/changelog "..."` | `changelog` | Add CHANGELOG.md entry |
+| `/sync "..."` | `sync` | Full sync pipeline |
+| `/memlog "..."` | `memlog` | Log session entry only |
+| `/new-task "..."` | `new-task` | Create task block in memory log |
 
 ## Key Files
 | File | Purpose |

--- a/templates/docs/context.md
+++ b/templates/docs/context.md
@@ -11,9 +11,15 @@
 
 ## Architecture
 ```
-src/
-├── [folder]    # [description]
-└── [folder]    # [description]
+[project root]/
+├── src/                  # [main source — e.g., app logic, API handlers]
+│   ├── [folder]          # [description]
+│   └── [folder]          # [description]
+├── docs/                 # project context, ADRs
+├── agents/               # AI agent definitions
+├── scripts/              # audit, dev-sync, sync-md
+├── memory/               # session logs
+└── [any other top-level dirs]
 ```
 
 ## Environment Setup
@@ -44,11 +50,14 @@ src/
 ## Session Start Skills
 <!-- Skills listed here are loaded at the start of EVERY session by ALL AI tools. -->
 <!-- Format: `skills/<name>/SKILL.md` — reason / trigger                          -->
+<!-- Example: `skills/auth-flow/SKILL.md` — always load when auth-related tasks   -->
+<!-- Add a skill: create skills/<name>/SKILL.md, then add a line below.           -->
+<!-- See ../../templates/_examples/skills/example-skill/SKILL.md for the template.-->
 - *(none yet)*
 
 ## Development Workflow
 ```bash
-# Audit (runs automatically via PostToolUse hook in Claude Code CLI)
+# Audit (enforced via pre-commit hook and dev-sync pipeline; run manually any time)
 bash scripts/audit.sh            # Windows: .\scripts\audit.ps1
 
 # Add a changelog entry (optional, before sync)
@@ -70,8 +79,9 @@ bash scripts/dev-sync.sh "feat: description"   # Windows: .\scripts\dev-sync.ps1
 | `agents/designer.md` | Design agent — UI/UX specs and component definitions |
 | `agents/code-writer.md` | Implementation agent — writes code from approved plans |
 | `agents/test-runner.md` | QA agent — runs tests and verifies acceptance criteria |
-| `scripts/dev-sync.sh` | Full sync pipeline (audit → commit → PR) |
+| `scripts/dev-sync.sh` | Full sync pipeline (memlog → changelog → audit → commit → PR) |
 | `scripts/audit.sh` | Documentation audit script |
+| `scripts/sync-md.sh` | Updates `memory/MEMORY.md` index with today's session entry |
 | `memory/MEMORY.md` | Session log index |
 | `CHANGELOG.md` | User-visible change history |
 | `.env.sample` | Required environment variable template |

--- a/templates/docs/context.md
+++ b/templates/docs/context.md
@@ -89,8 +89,8 @@ bash scripts/dev-sync.sh "feat: description"   # Windows: .\scripts\dev-sync.ps1
 ## Coding Guidelines
 
 > These rules apply to every AI tool working in this project.
-> Full rationale: [CONSTITUTION.md §8](../CONSTITUTION.md#8-coding-behavior-guidelines)
-> *(This file lives in `docs/` — one level up is the project root, two levels up is the workspace root where `CONSTITUTION.md` lives.)*
+> Full rationale: [CONSTITUTION.md §8](../../CONSTITUTION.md#8-coding-behavior-guidelines)
+> *(This file lives in `docs/` — `../` = project root, `../../` = workspace root where `CONSTITUTION.md` lives.)*
 
 ### 1. Think Before Coding
 - State assumptions explicitly before implementing. If uncertain, ask — don't guess silently.


### PR DESCRIPTION
## Summary
- `LICENSE` 파일을 MIT에서 AGPL-3.0 전문으로 교체
- `README.md` 라이센스 섹션 업데이트 (MIT → AGPL-3.0)
- `CHANGELOG.md` [Unreleased] 항목 추가

## Test plan
- [ ] `LICENSE` 첫 줄에 "GNU AFFERO GENERAL PUBLIC LICENSE" 확인
- [ ] `README.md` ## License 섹션에 "AGPL-3.0" 표기 확인
- [ ] GitHub 저장소 라이센스 뱃지 반영 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)