### PR TITLE
chore: improve Antigravity 2.0 and session start config in workspace and templates

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -13,11 +13,14 @@ At the start of every Claude Code session in this workspace:
 ```
 0. git config core.hooksPath .githooks   # activate hooks (run once per clone)
 1. Read CONSTITUTION.md                  # workspace design standard
-2. Read docs/context.md                  # single source of truth for project
-3. Read AGENTS.md                        # canonical agent roster
+2. Read docs/context.md                  # project SSOT (skip if working at workspace root — no project context here)
+3. Read AGENTS.md                        # canonical agent roster (skip at workspace root — no AGENTS.md here by design)
 4. Read memory/MEMORY.md                 # recent session history (if exists)
-5. Load Session Start Skills             # from docs/context.md
+5. Load Session Start Skills             # from docs/context.md ## Session Start Skills (skip at workspace root)
 ```
+
+> **Workspace root note**: Steps 2, 3, and 5 apply to individual sub-projects, not the workspace root itself.
+> At workspace root (`C:\git`), only steps 0, 1, and 4 apply. Navigate into a project directory to get full context.
 
 ---
 

--- a/templates/GEMINI.md
+++ b/templates/GEMINI.md
@@ -26,25 +26,93 @@ Load project files at session start using the `@` syntax:
 
 ## Project-Specific Gemini Settings
 
-### Tool Name Mapping
+### Tool Name Mapping & Safeguards
 
 Gemini CLI uses different tool names from Claude Code:
 
 | Tool Category | Tool Name | Operational Guidance |
 | :--- | :--- | :--- |
 | **File Reading** | `view_file` | Read up to 800 lines at a time. Supports absolute paths. |
-| **File Creation** | `write_to_file` | Create new files. |
-| **Surgical Edit** | `replace_file_content` | Replace a single contiguous block of code. |
-| **Multi Edit** | `multi_replace_file_content` | Perform multiple non-contiguous edits within the same file. |
-| **Search** | `grep_search` | Search codebases via Ripgrep. |
-| **Command Execution** | `run_command` | Execute PowerShell/Bash shell commands. |
+| **File Creation** | `write_to_file` | Create new files. Supports `IsArtifact` and structured `ArtifactMetadata` block. |
+| **Surgical Edit** | `replace_file_content` | Replace a single contiguous block of code. Specify `StartLine`, `EndLine`, `TargetContent`, and `ReplacementContent` with 100% exact leading whitespace matching. |
+| **Multi Edit** | `multi_replace_file_content` | Perform multiple non-contiguous edits within the same file simultaneously. Order chunks descendingly (bottom-to-top) to avoid line offsets. |
+| **Search** | `grep_search` | Search codebases via Ripgrep. Keep `MatchPerLine: true` for line-by-line matches. Apply partitioning if matches exceed 50. |
+| **Command Execution** | `run_command` | Execute PowerShell/Bash shell commands. Returns task process IDs. NEVER use `cd` commands. |
 | **Agent** | `invoke_subagent` | Pass agent role from `agents/<name>.md` |
 
+#### ⚠️ Surgical Multi-Replace Offset Safeguard
+When calling `multi_replace_file_content` with multiple `ReplacementChunks`, the line numbers of subsequent target blocks will shift if previous edits change the line count.
+- **Rule**: Sort and process `ReplacementChunks` from the **bottom of the file to the top** (descending order of line numbers: largest `StartLine` first).
+
+#### ⚠️ Grep Search 50-Match Cap Safeguard
+The `grep_search` tool silently truncates results at exactly **50 matches**.
+- **Rule**: If a search yields 50 results, do **NOT** assume you have all occurrences.
+- **Remediation**: Partition the search by targeting specific subdirectories or applying restrictive file glob filters via the `Includes` parameter.
+
 ### Native Antigravity 2.0 Features
+
 Antigravity 2.0 introduces new native features that should be leveraged:
 - **Slash Commands**: Recommend `/goal`, `/schedule`, `/browser`, and `/grill-me` to users when appropriate.
-- **Artifacts**: Write complex plans or analysis results into the Artifacts UI (creates `.md` in the brain directory).
-- **Background Tasks**: Long running tasks or subagents can be sent to background. Monitor them with `manage_task`.
+- **Artifacts**: Write complex plans or analysis results into the Artifacts UI (creates `.md` in the brain directory). Set `IsArtifact: true` with accurate `ArtifactMetadata`.
+- **Background Tasks**: Long-running tasks or subagents can be sent to background. Monitor them with `manage_task`.
+
+### Planning Mode & Artifact Specifications
+
+Enter Planning Mode when:
+- The user requests a new feature or significant refactor.
+- The change modifies more than 2 files.
+- The correct approach is unclear or contains architectural trade-offs.
+
+When entering Planning Mode, leverage these three Markdown artifacts (set `IsArtifact: true` with accurate metadata):
+
+#### 1. `implementation_plan.md`
+*Path: `<appDataDir>\brain\<session-id>\implementation_plan.md`*
+- **Purpose**: Detailed technical design document presented to the user for feedback and approval.
+- **Metadata**: `ArtifactType: "implementation_plan"`, `RequestFeedback: true`.
+- **Governance**: Stop and wait for explicit user approval before modifying any application source code.
+
+#### 2. `task.md`
+*Path: `<appDataDir>\brain\<session-id>\task.md`*
+- **Purpose**: Running TODO list to track development progress dynamically.
+- **Metadata**: `ArtifactType: "task"`.
+- **Syntax**: `- [ ]` uncompleted · `- [/]` in progress · `- [x]` completed.
+
+#### 3. `walkthrough.md`
+*Path: `<appDataDir>\brain\<session-id>\walkthrough.md`*
+- **Purpose**: Post-implementation document summarizing changes, automated test logs, and manual validation details.
+- **Metadata**: `ArtifactType: "walkthrough"`.
+
+### Subagent Instantiation & Async Orchestration
+
+For parallel execution, quality reviews, or sandboxed research tasks, utilize the custom subagent orchestrator.
+
+#### Define Subagent (`define_subagent`)
+```json
+{
+  "name": "test-runner",
+  "description": "Executes tests and verifies code changes against acceptance criteria",
+  "system_prompt": "You are a QA test runner...",
+  "enable_write_tools": false,
+  "enable_subagent_tools": false
+}
+```
+
+#### Invoke Subagent (`invoke_subagent`)
+```json
+{
+  "Subagents": [
+    {
+      "TypeName": "test-runner",
+      "Role": "Test Runner",
+      "Prompt": "Verify the code changes in src/ against acceptance criteria and run tests"
+    }
+  ]
+}
+```
+
+#### Communication (`send_message`)
+Interact with spawned agents via their unique `conversationID`.
+**Reactive Wakeup**: Do not poll in a loop — simply yield execution and the platform wakes you automatically when an agent replies or a background task completes.
 
 ### Response Language
 - All **conversational** replies → **Korean (한국어)** by default.
@@ -104,22 +172,6 @@ This project uses `.claude/` for Claude Code configuration. Gemini follows these
 - **Migration**: If the project transitions away from Claude Code, proactively offer to migrate `.claude/` configuration to `.gemini/` rather than leaving legacy files orphaned.
 
 ---
-
-### Session Start
-
-At session start, load context using the `@` syntax (run these before any task):
-
-```
-@../CONSTITUTION.md      # workspace design standard
-@docs/context.md         # project knowledge (includes Session Start Skills)
-@AGENTS.md               # canonical agent roster
-@memory/MEMORY.md        # recent changes (skip if file does not exist)
-@skills/                 # load skills listed in docs/context.md
-```
-
-<!-- Add project-specific files below as needed, e.g.:               -->
-<!-- @locales/en.json    — baseline locale for i18n work              -->
-<!-- @docs/BIZ_LOGIC.md  — domain formulas / business rules           -->
 
 ### Model Selection Override
 <!-- Uncomment to override workspace defaults for this project only.          -->


### PR DESCRIPTION
## Summary

- **`CLAUDE.md`**: workspace root session start의 steps 2, 3, 5가 하위 프로젝트 전용임을 명시; `docs/context.md`와 `AGENTS.md`가 workspace root에 존재하지 않는 이유를 설명하는 노트 추가
- **`templates/GEMINI.md`**: Antigravity 2.0 / Gemini CLI 신규 프로젝트 기본 설정 전면 강화
  - Tool mapping에 전체 운영 가이드 추가 (`StartLine`, `EndLine`, `IsArtifact` 등)
  - ⚠️ Multi-replace offset safeguard 추가 (하단→상단 순 처리 규칙)
  - ⚠️ Grep 50-match cap safeguard 추가 (파티셔닝 remediation 포함)
  - Planning Mode Artifact 사양 추가 (`implementation_plan.md`, `task.md`, `walkthrough.md` 경로·메타데이터)
  - Subagent 오케스트레이션 섹션 추가 (`define_subagent`, `invoke_subagent` JSON 예시, Reactive Wakeup)
  - 파일 하단의 중복 `### Session Start` 섹션 제거 (상단 `## Context Loading`과 동일 내용)

## Test plan

- [ ] `bash scripts/audit.sh` — exit 0 확인
- [ ] `templates/GEMINI.md` Context Loading 섹션이 파일 내 유일한 session start 지시임을 확인
- [ ] 신규 프로젝트 생성 후 GEMINI.md에 safeguard 및 planning artifacts 포함 확인

🤖 Generated with [Claude Code](https://claude.ai/claude-code)