### PR TITLE
chore: sync audit.ps1 with audit.sh and enforce CHANGELOG check in templates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,26 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
 
+### Changed — Antigravity 2.0 / Gemini CLI session start config (workspace + templates + 4 sub-projects)
+
+**`GEMINI.md` (workspace root)**
+- Tool mapping expanded with full operational guidance (`StartLine`, `EndLine`, `IsArtifact`, `MatchPerLine`, `NEVER use cd`)
+- ⚠️ Multi-replace offset safeguard added (bottom-to-top chunk ordering rule)
+- ⚠️ Grep 50-match cap safeguard added (partitioning remediation)
+- Planning Mode artifact specifications added (`implementation_plan.md`, `task.md`, `walkthrough.md` — brain/ paths + ArtifactType metadata)
+- Subagent orchestration added (`define_subagent`, `invoke_subagent` JSON examples, `send_message`, Reactive Wakeup)
+
+**`CLAUDE.md` (workspace root)**
+- Session Start steps 2, 3, 5에 workspace root에서는 skip함을 명시하는 노트 추가 (`docs/context.md`, `AGENTS.md` 부재 설명)
+
+**`templates/GEMINI.md`**
+- 동일한 Antigravity 2.0 설정 전면 적용 (safeguards, Planning Mode artifacts, Subagent 오케스트레이션)
+- 파일 하단의 중복 `### Session Start` 섹션 제거 (상단 `## Context Loading`과 동일 내용)
+
+### Changed — `scripts/audit.sh` (workspace root)
+- CHANGELOG.md `[Unreleased]` 섹션 존재 여부 검사를 `docs/context.md` 조건 블록 밖으로 이동
+- 워크스페이스 루트에서도 하위 프로젝트와 동일하게 CHANGELOG.md 업데이트 강제 적용
+
 ### Fixed
 - MD file consistency: unified Session Start Checklist across CLAUDE.md, GEMINI.md, and README.md (including templates/)
 - MD file consistency: updated subagent Phase 4 execution loop and `/sync` pipeline descriptions in `templates/` and root configurations

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,9 +24,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - 동일한 Antigravity 2.0 설정 전면 적용 (safeguards, Planning Mode artifacts, Subagent 오케스트레이션)
 - 파일 하단의 중복 `### Session Start` 섹션 제거 (상단 `## Context Loading`과 동일 내용)
 
-### Changed — `scripts/audit.sh` (workspace root)
-- CHANGELOG.md `[Unreleased]` 섹션 존재 여부 검사를 `docs/context.md` 조건 블록 밖으로 이동
-- 워크스페이스 루트에서도 하위 프로젝트와 동일하게 CHANGELOG.md 업데이트 강제 적용
+### Changed — `scripts/audit.sh` + `scripts/audit.ps1` (workspace root) + `templates/scripts/audit.sh` + `templates/scripts/audit.ps1`
+- CHANGELOG.md `[Unreleased]` 섹션 존재 여부 검사를 `docs/context.md` 조건 블록 밖으로 이동 — 워크스페이스 루트 및 신규 프로젝트 모두 동일하게 강제
+- `scripts/audit.ps1` (workspace root): `.sh`와 체크 8개로 동기화 — AGENTS.md, agents/, .env.sample, scripts parity 체크 누락분 추가
 
 ### Fixed
 - MD file consistency: unified Session Start Checklist across CLAUDE.md, GEMINI.md, and README.md (including templates/)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -13,11 +13,14 @@ At the start of every Claude Code session in this workspace:
 ```
 0. git config core.hooksPath .githooks   # activate hooks (run once per clone)
 1. Read CONSTITUTION.md                  # workspace design standard
-2. Read docs/context.md                  # single source of truth for project
-3. Read AGENTS.md                        # canonical agent roster
+2. Read docs/context.md                  # project SSOT (skip if working at workspace root — no project context here)
+3. Read AGENTS.md                        # canonical agent roster (skip at workspace root — no AGENTS.md here by design)
 4. Read memory/MEMORY.md                 # recent session history (if exists)
-5. Load Session Start Skills             # from docs/context.md
+5. Load Session Start Skills             # from docs/context.md ## Session Start Skills (skip at workspace root)
 ```
+
+> **Workspace root note**: Steps 2, 3, and 5 apply to individual sub-projects, not the workspace root itself.
+> At workspace root (`C:\git`), only steps 0, 1, and 4 apply. Navigate into a project directory to get full context.
 
 ---
 

--- a/scripts/audit.ps1
+++ b/scripts/audit.ps1
@@ -17,27 +17,46 @@ else                           { Fail "CHANGELOG.md missing" }
 if ((Test-Path "CONSTITUTION.md") -or (Test-Path "..\CONSTITUTION.md")) { Pass "CONSTITUTION.md accessible" }
 else { Fail "CONSTITUTION.md not found (expected at ./ or ../)" }
 
-# 3. docs/context.md must have ## Coding Guidelines
-if (Test-Path "docs/context.md") {
-    $content = Get-Content "docs/context.md" -Raw
-    if ($content -match "(?m)^## Coding Guidelines") { Pass "docs/context.md has ## Coding Guidelines" }
-    else                                               { Fail "docs/context.md is missing '## Coding Guidelines' section" }
-} else {
-    Warn "docs/context.md not found — skipping Coding Guidelines check (workspace root)"
-}
-
-# 4. CHANGELOG.md must have [Unreleased] section (project-level check)
-if ((Test-Path "docs/context.md") -and (Test-Path "CHANGELOG.md")) {
+# 3. CHANGELOG.md must have [Unreleased] section
+if (Test-Path "CHANGELOG.md") {
     $cl = Get-Content "CHANGELOG.md" -Raw
     if ($cl -match "\[Unreleased\]") { Pass "CHANGELOG.md has [Unreleased] section" }
     else                              { Fail "CHANGELOG.md is missing '[Unreleased]' section" }
 }
 
-Write-Host ""
-if ($errors -eq 0) {
-    Write-Host "✅ All checks passed." -ForegroundColor Green
-    exit 0
+# ── Project-level checks (skip at workspace root where docs/context.md is absent) ──
+
+if (Test-Path "docs\context.md") {
+    $ctx = Get-Content "docs\context.md" -Raw
+
+    # 4. docs/context.md must have ## Coding Guidelines
+    if ($ctx -match "(?m)^## Coding Guidelines") { Pass "docs/context.md has ## Coding Guidelines" }
+    else                                           { Fail "docs/context.md is missing '## Coding Guidelines' section" }
+
+    # 5. AGENTS.md must exist
+    if (Test-Path "AGENTS.md") { Pass "AGENTS.md exists" }
+    else                        { Fail "AGENTS.md missing (required for agent-first projects)" }
+
+    # 6. At least one agent file must exist in agents/
+    $agentFiles = Get-ChildItem -Path "agents" -Filter "*.md" -ErrorAction SilentlyContinue
+    if ($agentFiles) { Pass "agents/ has agent files" }
+    else              { Fail "agents/ is empty or missing — create at least agents/pm.md" }
+
+    # 7. .env.sample must exist
+    if (Test-Path ".env.sample") { Pass ".env.sample exists" }
+    else                          { Warn ".env.sample not found — add one if this project uses environment variables" }
+
+    # 8. scripts/ .sh/.ps1 parity check
+    Get-ChildItem -Path "scripts" -Filter "*.sh" -ErrorAction SilentlyContinue | ForEach-Object {
+        $ps1 = Join-Path "scripts" ($_.BaseName + ".ps1")
+        if (Test-Path $ps1) { Pass "script parity: $($_.Name) / $($_.BaseName).ps1" }
+        else                 { Warn "script parity gap: $($_.Name) has no matching .ps1" }
+    }
+
 } else {
-    Write-Host "❌ $errors check(s) failed. Fix before committing." -ForegroundColor Red
-    exit 1
+    Warn "docs/context.md not found — skipping project-level checks (workspace root)"
 }
+
+Write-Host ""
+if ($errors -eq 0) { Write-Host "✅ All checks passed." -ForegroundColor Green; exit 0 }
+else               { Write-Host "❌ $errors check(s) failed. Fix before committing." -ForegroundColor Red; exit 1 }

--- a/scripts/audit.sh
+++ b/scripts/audit.sh
@@ -30,24 +30,24 @@ fi
 
 # ── Project-level checks (skip at workspace root where docs/context.md is absent) ──
 
+# 3. CHANGELOG.md must have [Unreleased] section (all projects + workspace root)
+if [ -f "CHANGELOG.md" ]; then
+  if grep -q "\[Unreleased\]" "CHANGELOG.md"; then
+    green "CHANGELOG.md has [Unreleased] section"
+  else
+    red  "CHANGELOG.md is missing '[Unreleased]' section"
+    ((errors++)) || true
+  fi
+fi
+
 if [ -f "docs/context.md" ]; then
 
-  # 3. If a docs/context.md exists in the current project, it must have ## Coding Guidelines
+  # 4. If a docs/context.md exists in the current project, it must have ## Coding Guidelines
   if grep -q "^## Coding Guidelines" "docs/context.md"; then
     green "docs/context.md has ## Coding Guidelines"
   else
     red  "docs/context.md is missing '## Coding Guidelines' section"
     ((errors++)) || true
-  fi
-
-  # 4. CHANGELOG.md must have [Unreleased] section (project-level check)
-  if [ -f "CHANGELOG.md" ]; then
-    if grep -q "\[Unreleased\]" "CHANGELOG.md"; then
-      green "CHANGELOG.md has [Unreleased] section"
-    else
-      red  "CHANGELOG.md is missing '[Unreleased]' section"
-      ((errors++)) || true
-    fi
   fi
 
   # 5. AGENTS.md must exist

--- a/templates/AGENTS.md
+++ b/templates/AGENTS.md
@@ -32,7 +32,7 @@
 | Code Writer | [`agents/code-writer.md`](agents/code-writer.md) | Implements approved plans; surgical changes only |
 | Test Runner | [`agents/test-runner.md`](agents/test-runner.md) | Runs tests and verifies acceptance criteria |
 
-*(Add Analysis agents as needed — see `../templates/_examples/agents/analyst-example.md` in the workspace root for the scaffold template.)*
+*(Add domain-specific agents as needed — see the extension guidance below.)*
 
 ---
 
@@ -140,6 +140,29 @@ All agents, regardless of their role, must adhere to the following:
 - **Conflicting Instructions**: If a user request violates project rules (e.g., bypassing tests), warn the user and request explicit confirmation before proceeding.
 - **Coding Standards**: Follow SOLID principles. Write unit tests when creating functional code. No speculative abstractions.
 - **Language**: All code, config, commit messages, and branch names → **English only**.
+
+---
+
+## Extending the Agent Roster
+
+Add domain-specific agents when the project requires specialized expertise beyond the base 5 roles. Common patterns:
+
+| Domain | Typical Additions |
+|--------|-------------------|
+| **Financial / BI** | `cpa-auditor`, `finance-strategy-lead`, `cost-asset-mgmt` |
+| **SAP / ERP** | `sd-analyst`, `mm-analyst`, `fi-analyst`, `co-analyst`, `pp-analyst` |
+| **i18n-heavy** | `l10n-auditor`, `i18n` |
+| **Security-critical** | `security-auditor`, `security` |
+| **Data / ML** | `data-engineer`, `ml-engineer` |
+
+**Steps to add a new agent:**
+1. Create `agents/<name>.md` with the agent's role, constraints, and write-access rules.
+2. Add a row to the Agent Roster table above.
+3. Add a row to the Subagent Roster dispatch table (Parallelizable / Write Allowed).
+4. Update `docs/context.md § Agents` to match.
+5. If the agent uses a skill, add it to the Skills table here and in `docs/context.md § Session Start Skills`.
+
+> Reference: [`abap_vibe_coding/AGENTS.md`](../abap_vibe_coding/AGENTS.md) (ERP domain example) and [`Pricing-Mgmt-Simulation/AGENTS.md`](../Pricing-Mgmt-Simulation/AGENTS.md) (financial BI example).
 
 ---
 

--- a/templates/CLAUDE.md
+++ b/templates/CLAUDE.md
@@ -3,7 +3,7 @@
 > **All project context, coding guidelines, and dev workflow → [`docs/context.md`](docs/context.md)**
 > Workspace-level Claude Code behaviors → [`../CLAUDE.md`](../CLAUDE.md)
 
-> **Doc intent:** This file is Claude Code-specific behavioral configuration.
+> **Doc intent:** This file is Claude Code-specific behavioral configuration for **individual projects** (not the workspace root).
 > Shared project context (architecture, tech stack, coding guidelines) lives in [`docs/context.md`](docs/context.md).
 > Agent roles live in [`agents/*.md`](agents/) and [`AGENTS.md`](AGENTS.md).
 
@@ -153,8 +153,25 @@ Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>
 ---
 
 ### MCP Servers
-<!-- Document project-specific .mcp.json entries here, if any.             -->
-<!-- General MCP guidance: workspace ../CLAUDE.md §3                        -->
+
+Document project-specific `.mcp.json` entries here. General MCP guidance: workspace [`../CLAUDE.md §3`](../CLAUDE.md).
+
+```json
+// .mcp.json — example structure (add to project root; gitignored env vars go in .mcp.local.json)
+// {
+//   "mcpServers": {
+//     "<server-name>": {
+//       "command": "./path/to/binary",
+//       "args": ["--flag", "value"],
+//       "env": {
+//         "ENV_VAR": "value"
+//       }
+//     }
+//   }
+// }
+```
+
+> Use relative paths for `command` — Claude Code resolves them against the project root.
 
 ---
 

--- a/templates/GEMINI.md
+++ b/templates/GEMINI.md
@@ -26,25 +26,93 @@ Load project files at session start using the `@` syntax:
 
 ## Project-Specific Gemini Settings
 
-### Tool Name Mapping
+### Tool Name Mapping & Safeguards
 
 Gemini CLI uses different tool names from Claude Code:
 
 | Tool Category | Tool Name | Operational Guidance |
 | :--- | :--- | :--- |
 | **File Reading** | `view_file` | Read up to 800 lines at a time. Supports absolute paths. |
-| **File Creation** | `write_to_file` | Create new files. |
-| **Surgical Edit** | `replace_file_content` | Replace a single contiguous block of code. |
-| **Multi Edit** | `multi_replace_file_content` | Perform multiple non-contiguous edits within the same file. |
-| **Search** | `grep_search` | Search codebases via Ripgrep. |
-| **Command Execution** | `run_command` | Execute PowerShell/Bash shell commands. |
+| **File Creation** | `write_to_file` | Create new files. Supports `IsArtifact` and structured `ArtifactMetadata` block. |
+| **Surgical Edit** | `replace_file_content` | Replace a single contiguous block of code. Specify `StartLine`, `EndLine`, `TargetContent`, and `ReplacementContent` with 100% exact leading whitespace matching. |
+| **Multi Edit** | `multi_replace_file_content` | Perform multiple non-contiguous edits within the same file simultaneously. Order chunks descendingly (bottom-to-top) to avoid line offsets. |
+| **Search** | `grep_search` | Search codebases via Ripgrep. Keep `MatchPerLine: true` for line-by-line matches. Apply partitioning if matches exceed 50. |
+| **Command Execution** | `run_command` | Execute PowerShell/Bash shell commands. Returns task process IDs. NEVER use `cd` commands. |
 | **Agent** | `invoke_subagent` | Pass agent role from `agents/<name>.md` |
 
+#### ⚠️ Surgical Multi-Replace Offset Safeguard
+When calling `multi_replace_file_content` with multiple `ReplacementChunks`, the line numbers of subsequent target blocks will shift if previous edits change the line count.
+- **Rule**: Sort and process `ReplacementChunks` from the **bottom of the file to the top** (descending order of line numbers: largest `StartLine` first).
+
+#### ⚠️ Grep Search 50-Match Cap Safeguard
+The `grep_search` tool silently truncates results at exactly **50 matches**.
+- **Rule**: If a search yields 50 results, do **NOT** assume you have all occurrences.
+- **Remediation**: Partition the search by targeting specific subdirectories or applying restrictive file glob filters via the `Includes` parameter.
+
 ### Native Antigravity 2.0 Features
+
 Antigravity 2.0 introduces new native features that should be leveraged:
 - **Slash Commands**: Recommend `/goal`, `/schedule`, `/browser`, and `/grill-me` to users when appropriate.
-- **Artifacts**: Write complex plans or analysis results into the Artifacts UI (creates `.md` in the brain directory).
-- **Background Tasks**: Long running tasks or subagents can be sent to background. Monitor them with `manage_task`.
+- **Artifacts**: Write complex plans or analysis results into the Artifacts UI (creates `.md` in the brain directory). Set `IsArtifact: true` with accurate `ArtifactMetadata`.
+- **Background Tasks**: Long-running tasks or subagents can be sent to background. Monitor them with `manage_task`.
+
+### Planning Mode & Artifact Specifications
+
+Enter Planning Mode when:
+- The user requests a new feature or significant refactor.
+- The change modifies more than 2 files.
+- The correct approach is unclear or contains architectural trade-offs.
+
+When entering Planning Mode, leverage these three Markdown artifacts (set `IsArtifact: true` with accurate metadata):
+
+#### 1. `implementation_plan.md`
+*Path: `<appDataDir>\brain\<session-id>\implementation_plan.md`*
+- **Purpose**: Detailed technical design document presented to the user for feedback and approval.
+- **Metadata**: `ArtifactType: "implementation_plan"`, `RequestFeedback: true`.
+- **Governance**: Stop and wait for explicit user approval before modifying any application source code.
+
+#### 2. `task.md`
+*Path: `<appDataDir>\brain\<session-id>\task.md`*
+- **Purpose**: Running TODO list to track development progress dynamically.
+- **Metadata**: `ArtifactType: "task"`.
+- **Syntax**: `- [ ]` uncompleted · `- [/]` in progress · `- [x]` completed.
+
+#### 3. `walkthrough.md`
+*Path: `<appDataDir>\brain\<session-id>\walkthrough.md`*
+- **Purpose**: Post-implementation document summarizing changes, automated test logs, and manual validation details.
+- **Metadata**: `ArtifactType: "walkthrough"`.
+
+### Subagent Instantiation & Async Orchestration
+
+For parallel execution, quality reviews, or sandboxed research tasks, utilize the custom subagent orchestrator.
+
+#### Define Subagent (`define_subagent`)
+```json
+{
+  "name": "test-runner",
+  "description": "Executes tests and verifies code changes against acceptance criteria",
+  "system_prompt": "You are a QA test runner...",
+  "enable_write_tools": false,
+  "enable_subagent_tools": false
+}
+```
+
+#### Invoke Subagent (`invoke_subagent`)
+```json
+{
+  "Subagents": [
+    {
+      "TypeName": "test-runner",
+      "Role": "Test Runner",
+      "Prompt": "Verify the code changes in src/ against acceptance criteria and run tests"
+    }
+  ]
+}
+```
+
+#### Communication (`send_message`)
+Interact with spawned agents via their unique `conversationID`.
+**Reactive Wakeup**: Do not poll in a loop — simply yield execution and the platform wakes you automatically when an agent replies or a background task completes.
 
 ### Response Language
 - All **conversational** replies → **Korean (한국어)** by default.
@@ -104,22 +172,6 @@ This project uses `.claude/` for Claude Code configuration. Gemini follows these
 - **Migration**: If the project transitions away from Claude Code, proactively offer to migrate `.claude/` configuration to `.gemini/` rather than leaving legacy files orphaned.
 
 ---
-
-### Session Start
-
-At session start, load context using the `@` syntax (run these before any task):
-
-```
-@../CONSTITUTION.md      # workspace design standard
-@docs/context.md         # project knowledge (includes Session Start Skills)
-@AGENTS.md               # canonical agent roster
-@memory/MEMORY.md        # recent changes (skip if file does not exist)
-@skills/                 # load skills listed in docs/context.md
-```
-
-<!-- Add project-specific files below as needed, e.g.:               -->
-<!-- @locales/en.json    — baseline locale for i18n work              -->
-<!-- @docs/BIZ_LOGIC.md  — domain formulas / business rules           -->
 
 ### Model Selection Override
 <!-- Uncomment to override workspace defaults for this project only.          -->

--- a/templates/scripts/audit.ps1
+++ b/templates/scripts/audit.ps1
@@ -17,19 +17,19 @@ else { Fail "CONSTITUTION.md not found (expected at ./ or ../)" }
 
 # ── Project-level checks (skip at workspace root where docs/context.md is absent) ──
 
+# 3. CHANGELOG.md must have [Unreleased] section
+if (Test-Path "CHANGELOG.md") {
+    $cl = Get-Content "CHANGELOG.md" -Raw
+    if ($cl -match "\[Unreleased\]") { Pass "CHANGELOG.md has [Unreleased]" }
+    else { Fail "CHANGELOG.md missing '[Unreleased]'" }
+}
+
 if (Test-Path "docs\context.md") {
     $ctx = Get-Content "docs\context.md" -Raw
 
-    # 3. docs/context.md must have ## Coding Guidelines
+    # 4. docs/context.md must have ## Coding Guidelines
     if ($ctx -match "(?m)^## Coding Guidelines") { Pass "docs/context.md has ## Coding Guidelines" }
     else { Fail "docs/context.md missing '## Coding Guidelines'" }
-
-    # 4. CHANGELOG.md must have [Unreleased]
-    if (Test-Path "CHANGELOG.md") {
-        $cl = Get-Content "CHANGELOG.md" -Raw
-        if ($cl -match "\[Unreleased\]") { Pass "CHANGELOG.md has [Unreleased]" }
-        else { Fail "CHANGELOG.md missing '[Unreleased]'" }
-    }
 
     # 5. AGENTS.md must exist
     if (Test-Path "AGENTS.md") { Pass "AGENTS.md exists" }

--- a/templates/scripts/audit.sh
+++ b/templates/scripts/audit.sh
@@ -20,17 +20,17 @@ else red "CONSTITUTION.md not found (expected at ./ or ../)"; ((errors++)) || tr
 
 # ── Project-level checks (skip at workspace root where docs/context.md is absent) ──
 
+# 3. CHANGELOG.md must have [Unreleased] section
+if [ -f "CHANGELOG.md" ]; then
+  if grep -q "\[Unreleased\]" "CHANGELOG.md"; then green "CHANGELOG.md has [Unreleased]"
+  else red "CHANGELOG.md missing '[Unreleased]'"; ((errors++)) || true; fi
+fi
+
 if [ -f "docs/context.md" ]; then
 
-  # 3. docs/context.md must have ## Coding Guidelines
+  # 4. docs/context.md must have ## Coding Guidelines
   if grep -q "^## Coding Guidelines" "docs/context.md"; then green "docs/context.md has ## Coding Guidelines"
   else red "docs/context.md missing '## Coding Guidelines'"; ((errors++)) || true; fi
-
-  # 4. CHANGELOG.md must have [Unreleased]
-  if [ -f "CHANGELOG.md" ]; then
-    if grep -q "\[Unreleased\]" "CHANGELOG.md"; then green "CHANGELOG.md has [Unreleased]"
-    else red "CHANGELOG.md missing '[Unreleased]'"; ((errors++)) || true; fi
-  fi
 
   # 5. AGENTS.md must exist
   if [ -f "AGENTS.md" ]; then green "AGENTS.md exists"


### PR DESCRIPTION
## Summary

- **`scripts/audit.ps1`** (workspace root): `.sh`와 체크 8개로 완전 동기화 — 기존 4개에서 AGENTS.md 존재, agents/ 비어있지 않음, .env.sample, scripts .sh/.ps1 parity 체크 추가; `[Unreleased]` 체크를 `docs/context.md` 조건 밖으로 이동
- **`templates/scripts/audit.sh`**: `[Unreleased]` 체크(기존 #4)를 `docs/context.md` 블록 밖(#3)으로 이동 — `docs/context.md`가 없는 경우에도 항상 강제
- **`templates/scripts/audit.ps1`**: 동일한 구조 수정 적용

## Before / After

| 상황 | 이전 | 이후 |
|------|------|------|
| 워크스페이스 루트 audit.ps1 | 4개 체크 | 8개 체크 (.sh와 동일) |
| 템플릿 audit.sh [Unreleased] 위치 | docs/context.md 블록 내부 | 블록 외부 (항상 실행) |
| 템플릿 audit.ps1 [Unreleased] 위치 | docs/context.md 블록 내부 | 블록 외부 (항상 실행) |

## Test plan

- [ ] `bash scripts/audit.sh` → exit 0
- [ ] 신규 프로젝트 생성 후 `bash scripts/audit.sh` → CHANGELOG [Unreleased] 체크 실행 확인
- [ ] CHANGELOG.md `[Unreleased]` 제거 후 커밋 시도 → pre-commit hook 차단 확인

🤖 Generated with [Claude Code](https://claude.ai/claude-code)