### PR TITLE
feat: cross-platform setup and explicit project directory navigation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,9 +8,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
 
-### Added — New project setup automation
-- `templates/scripts/setup.sh` + `setup.ps1`: post-scaffold environment setup script with stack auto-detection (Node.js → `npm install`, Python → `.venv` + `pip install`, Ruby → `bundle install`), `.env.sample` → `.env` copy, and initial git commit
-- `scripts/new-project.sh` + `new-project.ps1`: automatically call `setup.sh`/`setup.ps1` after audit (step 8); removed manual "git add && git commit" from Next steps output
+### Added — New project setup automation with cross-platform support
+- `templates/scripts/setup.sh` + `setup.ps1`: OS-aware post-scaffold setup (macOS/Linux/Windows Git Bash/PowerShell); auto-detects stack (Node.js, Python, Ruby), installs deps with toolchain presence check, `.env.sample` → `.env` copy, initial commit
+- `scripts/new-project.sh` + `new-project.ps1`: call `setup.sh`/`setup.ps1` as step 8; add step 9 with prominent directory-change banner showing exact `cd <path>` command to prevent working in wrong directory
 
 
 ### Changed — Antigravity 2.0 / Gemini CLI session start config (workspace + templates + 4 sub-projects)

--- a/scripts/new-project.ps1
+++ b/scripts/new-project.ps1
@@ -74,11 +74,28 @@ if ($LASTEXITCODE -eq 0) {
 # ── 8. Environment setup (env file, deps, initial commit) ─────────────────────
 Write-Host ""
 Write-Host "Running environment setup…" -ForegroundColor Cyan
-& ".\scripts\setup.ps1"
+& "$ProjectDir\scripts\setup.ps1"
 if ($LASTEXITCODE -ne 0) {
     Write-Host ""
     Write-Host "⚠️  Setup encountered an error — run '.\scripts\setup.ps1' manually to retry." -ForegroundColor Yellow
 }
+
+# ── 9. Move into project directory ────────────────────────────────────────────
+Write-Host ""
+Write-Host ("━" * 60) -ForegroundColor DarkGray
+Write-Host "📂 PROJECT DIRECTORY: $ProjectDir" -ForegroundColor Cyan
+Write-Host ""
+Write-Host "⚠️  Your shell is still at the workspace root." -ForegroundColor Yellow
+Write-Host "   Run the following command to move into your new project:"
+Write-Host ""
+Write-Host "   cd `"$ProjectDir`"" -ForegroundColor Green
+Write-Host ""
+Write-Host "   All subsequent work (git, scripts, sessions) must be run"
+Write-Host "   from inside this directory, not the workspace root."
+Write-Host ("━" * 60) -ForegroundColor DarkGray
+
+# Also actually change to project directory (takes effect when dot-sourced)
+Set-Location $ProjectDir
 
 Write-Host ""
 Write-Host "Extension templates (ADR, analyst agent, skill, daily log):" -ForegroundColor DarkGray

--- a/scripts/new-project.sh
+++ b/scripts/new-project.sh
@@ -76,11 +76,24 @@ fi
 # ── 8. Environment setup (env file, deps, initial commit) ─────────────────────
 echo ""
 echo "Running environment setup…"
-bash scripts/setup.sh || {
+bash "$PROJECT_DIR/scripts/setup.sh" || {
   echo ""
   echo "⚠️  Setup encountered an error — run 'bash scripts/setup.sh' manually to retry."
 }
 
+# ── 9. Move into project directory ────────────────────────────────────────────
+echo ""
+echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+echo -e "\033[36m📂 PROJECT DIRECTORY:\033[0m $PROJECT_DIR"
+echo ""
+echo -e "\033[33m⚠️  Your shell is still at the workspace root.\033[0m"
+echo "   Run the following command to move into your new project:"
+echo ""
+echo -e "   \033[32mcd \"$PROJECT_DIR\"\033[0m"
+echo ""
+echo "   All subsequent work (git, scripts, sessions) must be run"
+echo "   from inside this directory, not the workspace root."
+echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
 echo ""
 echo "Extension templates (ADR, analyst agent, skill, daily log):"
 echo "  → $TEMPLATES_DIR/_examples/"

--- a/templates/scripts/setup.ps1
+++ b/templates/scripts/setup.ps1
@@ -14,6 +14,24 @@ function Warn($msg) { Write-Host "[WARN] $msg" -ForegroundColor Yellow }
 
 Write-Host "=== setup.ps1 — environment setup ===" -ForegroundColor Cyan
 
+# ── OS detection ──────────────────────────────────────────────────────────────
+$IsWin   = $env:OS -eq "Windows_NT"
+$IsMac   = $IsMacOS  # Built-in PS 6+ variable; false in PS 5 on Windows
+$IsLin   = $IsLinux  # Built-in PS 6+ variable
+if ($PSVersionTable.PSVersion.Major -lt 6) {
+    # PowerShell 5 (Windows only) — $IsMacOS/$IsLinux don't exist
+    $IsMac = $false
+    $IsLin = $false
+    $IsWin = $true
+}
+$OsLabel = if ($IsMac) { "macOS" } elseif ($IsLin) { "Linux" } else { "Windows" }
+Info "Detected OS: $OsLabel (PowerShell $($PSVersionTable.PSVersion))"
+
+# ── Python binary ─────────────────────────────────────────────────────────────
+$PyBin = $null
+if (Get-Command python3 -ErrorAction SilentlyContinue) { $PyBin = "python3" }
+elseif (Get-Command python -ErrorAction SilentlyContinue) { $PyBin = "python" }
+
 # ── 1. .env.sample → .env ─────────────────────────────────────────────────────
 if (Test-Path ".env.sample") {
     if (-not (Test-Path ".env")) {
@@ -26,34 +44,69 @@ if (Test-Path ".env.sample") {
 
 # ── 2. Dependency install (stack auto-detection) ──────────────────────────────
 if (-not $SkipInstall) {
+
+    # Node.js
     if (Test-Path "package.json") {
-        Info "Node.js project detected — running npm install"
-        npm install
-        if ($LASTEXITCODE -eq 0) { Pass "npm install complete" }
-    }
-
-    if (Test-Path "requirements.txt") {
-        Info "Python project detected — creating .venv and installing dependencies"
-        python -m venv .venv
-        $activateScript = ".venv\Scripts\Activate.ps1"
-        if (Test-Path $activateScript) {
-            & $activateScript
+        if (-not (Get-Command npm -ErrorAction SilentlyContinue)) {
+            Warn "Node.js / npm not found — skipping npm install (install from https://nodejs.org)"
+        } else {
+            Info "Node.js project detected — running npm install"
+            npm install
+            if ($LASTEXITCODE -eq 0) { Pass "npm install complete" }
         }
-        pip install -r requirements.txt
-        if ($LASTEXITCODE -eq 0) { Pass "pip install complete (.venv activated)" }
     }
 
+    # Python (requirements.txt)
+    if (Test-Path "requirements.txt") {
+        if (-not $PyBin) {
+            Warn "Python not found — skipping venv + pip install (install from https://python.org)"
+        } else {
+            Info "Python project detected — creating .venv and installing dependencies"
+            & $PyBin -m venv .venv
+
+            # Activate: Windows PowerShell uses Scripts\Activate.ps1
+            # macOS/Linux PowerShell uses bin/Activate.ps1
+            $activateScript = if (Test-Path ".venv\Scripts\Activate.ps1") {
+                ".venv\Scripts\Activate.ps1"
+            } elseif (Test-Path ".venv/bin/Activate.ps1") {
+                ".venv/bin/Activate.ps1"
+            } else { $null }
+
+            if ($activateScript) { & $activateScript }
+
+            pip install -r requirements.txt
+            if ($LASTEXITCODE -eq 0) { Pass "pip install complete (.venv created)" }
+
+            if ($IsWin) {
+                Info "Activate venv in PowerShell: .venv\Scripts\Activate.ps1"
+            } else {
+                Info "Activate venv in your shell: source .venv/bin/activate"
+            }
+        }
+    }
+
+    # Python (pyproject.toml, no requirements.txt)
     if ((Test-Path "pyproject.toml") -and (-not (Test-Path "requirements.txt"))) {
-        Info "pyproject.toml detected — running pip install -e ."
-        pip install -e .
-        if ($LASTEXITCODE -eq 0) { Pass "pip install -e . complete" }
+        if (-not $PyBin) {
+            Warn "Python not found — skipping pip install -e . (install from https://python.org)"
+        } else {
+            Info "pyproject.toml detected — running pip install -e ."
+            pip install -e .
+            if ($LASTEXITCODE -eq 0) { Pass "pip install -e . complete" }
+        }
     }
 
+    # Ruby
     if (Test-Path "Gemfile") {
-        Info "Ruby project detected — running bundle install"
-        bundle install
-        if ($LASTEXITCODE -eq 0) { Pass "bundle install complete" }
+        if (-not (Get-Command bundle -ErrorAction SilentlyContinue)) {
+            Warn "Bundler not found — skipping bundle install (run: gem install bundler)"
+        } else {
+            Info "Ruby project detected — running bundle install"
+            bundle install
+            if ($LASTEXITCODE -eq 0) { Pass "bundle install complete" }
+        }
     }
+
 } else {
     Info "Skipping dependency install (-SkipInstall)"
 }

--- a/templates/scripts/setup.sh
+++ b/templates/scripts/setup.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 # setup.sh — Post-scaffold environment setup
-# Detects tech stack, installs dependencies, copies .env, and makes initial commit.
+# Detects OS and tech stack, installs dependencies, copies .env, and makes initial commit.
 # Called automatically by new-project.sh; can also be re-run manually at any time.
 #
 # Usage: bash scripts/setup.sh [--skip-install] [--skip-commit]
@@ -18,8 +18,31 @@ done
 pass() { echo -e "\033[32m[PASS]\033[0m $*"; }
 info() { echo -e "\033[36m[INFO]\033[0m $*"; }
 warn() { echo -e "\033[33m[WARN]\033[0m $*"; }
+fail() { echo -e "\033[31m[FAIL]\033[0m $*"; }
 
 echo "=== setup.sh — environment setup ==="
+
+# ── OS detection ──────────────────────────────────────────────────────────────
+OS_TYPE="unknown"
+case "$(uname -s 2>/dev/null)" in
+  Darwin)             OS_TYPE="macos" ;;
+  Linux)              OS_TYPE="linux" ;;
+  MINGW*|MSYS*|CYGWIN*) OS_TYPE="windows-bash" ;;
+  *)
+    if [ -n "${OS:-}" ] && [ "$OS" = "Windows_NT" ]; then
+      OS_TYPE="windows-bash"
+    fi
+    ;;
+esac
+info "Detected OS: $OS_TYPE"
+
+# ── Python binary (python3 on macOS/Linux, python on Windows Git Bash) ───────
+PY_BIN=""
+if command -v python3 &>/dev/null; then
+  PY_BIN="python3"
+elif command -v python &>/dev/null; then
+  PY_BIN="python"
+fi
 
 # ── 1. .env.sample → .env ─────────────────────────────────────────────────────
 if [ -f ".env.sample" ]; then
@@ -33,37 +56,69 @@ fi
 
 # ── 2. Dependency install (stack auto-detection) ──────────────────────────────
 if [ "$SKIP_INSTALL" = false ]; then
+
+  # Node.js
   if [ -f "package.json" ]; then
-    info "Node.js project detected — running npm install"
-    npm install
-    pass "npm install complete"
-  fi
-
-  if [ -f "requirements.txt" ]; then
-    info "Python project detected — creating .venv and installing dependencies"
-    python -m venv .venv
-    if [ -f ".venv/bin/activate" ]; then
-      # shellcheck disable=SC1091
-      source .venv/bin/activate
-    elif [ -f ".venv/Scripts/activate" ]; then
-      # shellcheck disable=SC1091
-      source .venv/Scripts/activate
+    if ! command -v npm &>/dev/null; then
+      warn "Node.js / npm not found — skipping npm install (install from https://nodejs.org)"
+    else
+      info "Node.js project detected — running npm install"
+      npm install
+      pass "npm install complete"
     fi
-    pip install -r requirements.txt
-    pass "pip install complete (.venv activated)"
   fi
 
+  # Python (requirements.txt)
+  if [ -f "requirements.txt" ]; then
+    if [ -z "$PY_BIN" ]; then
+      warn "Python not found — skipping venv + pip install (install from https://python.org)"
+    else
+      info "Python project detected — creating .venv and installing dependencies"
+      "$PY_BIN" -m venv .venv
+
+      # Activate: macOS/Linux use bin/, Windows Git Bash uses Scripts/
+      if [ -f ".venv/bin/activate" ]; then
+        # shellcheck disable=SC1091
+        source .venv/bin/activate
+      elif [ -f ".venv/Scripts/activate" ]; then
+        # shellcheck disable=SC1091
+        source .venv/Scripts/activate
+      fi
+
+      pip install -r requirements.txt
+      pass "pip install complete (.venv created)"
+
+      # macOS: remind user to activate venv in their shell
+      if [ "$OS_TYPE" = "macos" ] || [ "$OS_TYPE" = "linux" ]; then
+        info "Activate venv in your shell: source .venv/bin/activate"
+      else
+        info "Activate venv in Git Bash: source .venv/Scripts/activate"
+      fi
+    fi
+  fi
+
+  # Python (pyproject.toml, no requirements.txt)
   if [ -f "pyproject.toml" ] && [ ! -f "requirements.txt" ]; then
-    info "pyproject.toml detected — running pip install -e ."
-    pip install -e .
-    pass "pip install -e . complete"
+    if [ -z "$PY_BIN" ]; then
+      warn "Python not found — skipping pip install -e . (install from https://python.org)"
+    else
+      info "pyproject.toml detected — running pip install -e ."
+      pip install -e .
+      pass "pip install -e . complete"
+    fi
   fi
 
+  # Ruby
   if [ -f "Gemfile" ]; then
-    info "Ruby project detected — running bundle install"
-    bundle install
-    pass "bundle install complete"
+    if ! command -v bundle &>/dev/null; then
+      warn "Bundler not found — skipping bundle install (run: gem install bundler)"
+    else
+      info "Ruby project detected — running bundle install"
+      bundle install
+      pass "bundle install complete"
+    fi
   fi
+
 else
   info "Skipping dependency install (--skip-install)"
 fi
@@ -72,11 +127,13 @@ fi
 if [ "$SKIP_COMMIT" = false ]; then
   if git rev-parse --git-dir > /dev/null 2>&1; then
     git add -A
-    git commit -m "chore: initial scaffold
+    if git commit -m "chore: initial scaffold
 
-Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>" \
-      --allow-empty 2>/dev/null || warn "Nothing to commit (already committed?)"
-    pass "Initial commit created"
+Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>" 2>/dev/null; then
+      pass "Initial commit created"
+    else
+      warn "Nothing to commit (already committed?)"
+    fi
   else
     warn "Not inside a git repository — skipping initial commit"
   fi


### PR DESCRIPTION
## Summary
- **Cross-platform OS detection** in `setup.sh`/`setup.ps1`:
  - `setup.sh`: `uname -s` → macOS / Linux / windows-bash; `python3` vs `python` bin auto-select; venv activation via `bin/activate` (macOS/Linux) or `Scripts/activate` (Windows Git Bash); toolchain presence guard on npm, python, bundle before each install
  - `setup.ps1`: `$IsMacOS`/`$IsLinux` (PS 6+) with PS 5 Windows fallback; `Scripts\Activate.ps1` vs `bin/Activate.ps1` venv path
- **Project directory navigation banner** (step 9 in both scripts): after setup, prints bordered message with the exact `cd "<path>"` command, warning that shell is still at workspace root

## Test plan
- [x] `bash scripts/new-project.sh "test"` → audit 11 PASS → setup OS detected → .env created → initial commit → cd banner printed
- [x] `bash scripts/audit.sh` still passes at workspace root

🤖 Generated with [Claude Code](https://claude.com/claude-code)