### PR TITLE
feat: multi-stack setup with mandatory Python venv and extended stack support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,9 +8,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
 
-### Added — New project setup automation with cross-platform support
-- `templates/scripts/setup.sh` + `setup.ps1`: OS-aware post-scaffold setup (macOS/Linux/Windows Git Bash/PowerShell); auto-detects stack (Node.js, Python, Ruby), installs deps with toolchain presence check, `.env.sample` → `.env` copy, initial commit
-- `scripts/new-project.sh` + `new-project.ps1`: call `setup.sh`/`setup.ps1` as step 8; add step 9 with prominent directory-change banner showing exact `cd <path>` command to prevent working in wrong directory
+### Added — Multi-stack setup automation with mandatory Python venv and cross-platform support
+- `templates/scripts/setup.sh` + `setup.ps1`: multi-stack OS-aware setup — Node.js (`npm install`), Python (`requirements.txt`/`pyproject.toml` → mandatory `.venv` + pip, Python 3 guard), Ruby (`bundle install`), .NET (`dotnet restore`), Java Maven (`mvn dependency:resolve`), Java Gradle (`gradlew`/`gradle`), C/C++ CMake (`cmake -B build`), Makefile (info-only); all stacks guarded by toolchain presence check with install hint
+- `scripts/new-project.sh` + `new-project.ps1`: call `setup.sh`/`setup.ps1` as step 8; step 9 prints prominent directory-change banner with exact `cd <path>` command
 
 
 ### Changed — Antigravity 2.0 / Gemini CLI session start config (workspace + templates + 4 sub-projects)

--- a/templates/scripts/setup.ps1
+++ b/templates/scripts/setup.ps1
@@ -2,6 +2,17 @@
 # Mirrors setup.sh exactly. Called automatically by new-project.ps1;
 # can also be re-run manually at any time.
 #
+# Supported stacks:
+#   Node.js    package.json          → npm install
+#   Python     requirements.txt /    → .venv (mandatory) + pip install
+#              pyproject.toml
+#   Ruby       Gemfile               → bundle install
+#   .NET       *.csproj / *.sln      → dotnet restore
+#   Java       pom.xml (Maven)       → mvn dependency:resolve
+#              build.gradle (Gradle) → gradlew dependencies
+#   C/C++      CMakeLists.txt        → cmake -B build (configure only)
+#              Makefile              → info only (not run automatically)
+#
 # Usage: .\scripts\setup.ps1 [-SkipInstall] [-SkipCommit]
 param(
     [switch]$SkipInstall,
@@ -15,22 +26,72 @@ function Warn($msg) { Write-Host "[WARN] $msg" -ForegroundColor Yellow }
 Write-Host "=== setup.ps1 — environment setup ===" -ForegroundColor Cyan
 
 # ── OS detection ──────────────────────────────────────────────────────────────
-$IsWin   = $env:OS -eq "Windows_NT"
-$IsMac   = $IsMacOS  # Built-in PS 6+ variable; false in PS 5 on Windows
-$IsLin   = $IsLinux  # Built-in PS 6+ variable
-if ($PSVersionTable.PSVersion.Major -lt 6) {
-    # PowerShell 5 (Windows only) — $IsMacOS/$IsLinux don't exist
-    $IsMac = $false
-    $IsLin = $false
-    $IsWin = $true
+$IsWin = $true
+$IsMac = $false
+$IsLin = $false
+if ($PSVersionTable.PSVersion.Major -ge 6) {
+    $IsMac = $IsMacOS
+    $IsLin = $IsLinux
+    $IsWin = -not ($IsMac -or $IsLin)
 }
 $OsLabel = if ($IsMac) { "macOS" } elseif ($IsLin) { "Linux" } else { "Windows" }
 Info "Detected OS: $OsLabel (PowerShell $($PSVersionTable.PSVersion))"
 
-# ── Python binary ─────────────────────────────────────────────────────────────
+# ── Helper: require a command or warn ────────────────────────────────────────
+function Require {
+    param([string]$Cmd, [string]$Hint)
+    if (-not (Get-Command $Cmd -ErrorAction SilentlyContinue)) {
+        Warn "$Cmd not found — $Hint"
+        return $false
+    }
+    return $true
+}
+
+# ── Python binary resolution ──────────────────────────────────────────────────
 $PyBin = $null
-if (Get-Command python3 -ErrorAction SilentlyContinue) { $PyBin = "python3" }
-elseif (Get-Command python -ErrorAction SilentlyContinue) { $PyBin = "python" }
+foreach ($candidate in @("python3", "python")) {
+    if (Get-Command $candidate -ErrorAction SilentlyContinue) {
+        $ver = & $candidate --version 2>&1
+        if ($ver -match "^Python 3") {
+            $PyBin = $candidate
+            break
+        }
+    }
+}
+
+# ── Python venv helpers ───────────────────────────────────────────────────────
+function Activate-Venv {
+    $scripts = @(".venv\Scripts\Activate.ps1", ".venv/bin/Activate.ps1")
+    foreach ($s in $scripts) {
+        if (Test-Path $s) { & $s; return }
+    }
+    Warn "Could not find venv Activate.ps1 — continuing without activation"
+}
+
+function Show-VenvHint {
+    if ($IsWin) {
+        Info "  Activate venv (PowerShell): .venv\Scripts\Activate.ps1"
+        Info "  Activate venv (Git Bash):   source .venv/Scripts/activate"
+    } else {
+        Info "  Activate venv: source .venv/bin/activate"
+    }
+}
+
+function Ensure-Venv {
+    if (-not $PyBin) {
+        Warn "Python 3 not found — skipping venv creation (install from https://python.org)"
+        return $false
+    }
+    if (-not (Test-Path ".venv")) {
+        Info "Creating Python virtual environment (.venv)…"
+        & $PyBin -m venv .venv
+        Pass ".venv created"
+    } else {
+        Info ".venv already exists — reusing"
+    }
+    Activate-Venv
+    return $true
+}
 
 # ── 1. .env.sample → .env ─────────────────────────────────────────────────────
 if (Test-Path ".env.sample") {
@@ -45,65 +106,98 @@ if (Test-Path ".env.sample") {
 # ── 2. Dependency install (stack auto-detection) ──────────────────────────────
 if (-not $SkipInstall) {
 
-    # Node.js
+    # ── Node.js ────────────────────────────────────────────────────────────────
     if (Test-Path "package.json") {
-        if (-not (Get-Command npm -ErrorAction SilentlyContinue)) {
-            Warn "Node.js / npm not found — skipping npm install (install from https://nodejs.org)"
-        } else {
+        if (Require "npm" "install Node.js from https://nodejs.org") {
             Info "Node.js project detected — running npm install"
             npm install
             if ($LASTEXITCODE -eq 0) { Pass "npm install complete" }
         }
     }
 
-    # Python (requirements.txt)
+    # ── Python (requirements.txt) ─────────────────────────────────────────────
     if (Test-Path "requirements.txt") {
-        if (-not $PyBin) {
-            Warn "Python not found — skipping venv + pip install (install from https://python.org)"
-        } else {
-            Info "Python project detected — creating .venv and installing dependencies"
-            & $PyBin -m venv .venv
-
-            # Activate: Windows PowerShell uses Scripts\Activate.ps1
-            # macOS/Linux PowerShell uses bin/Activate.ps1
-            $activateScript = if (Test-Path ".venv\Scripts\Activate.ps1") {
-                ".venv\Scripts\Activate.ps1"
-            } elseif (Test-Path ".venv/bin/Activate.ps1") {
-                ".venv/bin/Activate.ps1"
-            } else { $null }
-
-            if ($activateScript) { & $activateScript }
-
+        Info "Python project detected (requirements.txt)"
+        if (Ensure-Venv) {
             pip install -r requirements.txt
-            if ($LASTEXITCODE -eq 0) { Pass "pip install complete (.venv created)" }
+            if ($LASTEXITCODE -eq 0) { Pass "pip install -r requirements.txt complete" }
+            Show-VenvHint
+        }
+    }
 
-            if ($IsWin) {
-                Info "Activate venv in PowerShell: .venv\Scripts\Activate.ps1"
-            } else {
-                Info "Activate venv in your shell: source .venv/bin/activate"
+    # ── Python (pyproject.toml, no requirements.txt) ──────────────────────────
+    if ((Test-Path "pyproject.toml") -and (-not (Test-Path "requirements.txt"))) {
+        Info "Python project detected (pyproject.toml)"
+        if (Ensure-Venv) {
+            pip install -e .
+            if ($LASTEXITCODE -eq 0) { Pass "pip install -e . complete" }
+            Show-VenvHint
+        }
+    }
+
+    # ── Ruby ──────────────────────────────────────────────────────────────────
+    if (Test-Path "Gemfile") {
+        if (Require "bundle" "run: gem install bundler") {
+            Info "Ruby project detected — running bundle install"
+            bundle install
+            if ($LASTEXITCODE -eq 0) { Pass "bundle install complete" }
+        }
+    }
+
+    # ── .NET ──────────────────────────────────────────────────────────────────
+    $dotnetProj = Get-ChildItem -Path . -Recurse -Depth 3 -Include "*.csproj","*.sln","*.fsproj" -ErrorAction SilentlyContinue |
+                  Where-Object { $_.FullName -notmatch "\\.git\\" } |
+                  Select-Object -First 1
+    if ($dotnetProj) {
+        if (Require "dotnet" "install .NET SDK from https://dotnet.microsoft.com/download") {
+            Info ".NET project detected ($($dotnetProj.Name)) — running dotnet restore"
+            dotnet restore
+            if ($LASTEXITCODE -eq 0) { Pass "dotnet restore complete" }
+        }
+    }
+
+    # ── Java / Maven ──────────────────────────────────────────────────────────
+    if (Test-Path "pom.xml") {
+        if (Require "mvn" "install Maven from https://maven.apache.org or use SDKMAN: sdk install maven") {
+            Info "Maven project detected — running mvn dependency:resolve -q"
+            mvn dependency:resolve -q
+            if ($LASTEXITCODE -eq 0) { Pass "mvn dependency:resolve complete" }
+        }
+    }
+
+    # ── Java / Gradle ─────────────────────────────────────────────────────────
+    $gradleBuild = @("build.gradle", "build.gradle.kts") | Where-Object { Test-Path $_ } | Select-Object -First 1
+    if ($gradleBuild) {
+        $gradleCmd = if (Test-Path "gradlew.bat") { ".\gradlew.bat" } elseif (Test-Path "./gradlew") { "bash ./gradlew" } else { "gradle" }
+        $gradleExe = $gradleCmd.Split(" ")[0]
+        if (Require $gradleExe "install Gradle from https://gradle.org or use SDKMAN: sdk install gradle") {
+            Info "Gradle project detected — running $gradleCmd dependencies"
+            Invoke-Expression "$gradleCmd dependencies -q"
+            if ($LASTEXITCODE -eq 0) { Pass "Gradle dependencies resolved" }
+        }
+    }
+
+    # ── C/C++ (CMake) ─────────────────────────────────────────────────────────
+    if (Test-Path "CMakeLists.txt") {
+        if (Require "cmake" "install CMake from https://cmake.org") {
+            Info "CMake project detected — configuring build (cmake -B build)"
+            cmake -B build -S . 2>&1 | Select-Object -Last 5
+            if ($LASTEXITCODE -eq 0) {
+                Pass "CMake configure complete — build artifacts in build\"
+                Info "  To build: cmake --build build"
             }
         }
     }
 
-    # Python (pyproject.toml, no requirements.txt)
-    if ((Test-Path "pyproject.toml") -and (-not (Test-Path "requirements.txt"))) {
-        if (-not $PyBin) {
-            Warn "Python not found — skipping pip install -e . (install from https://python.org)"
+    # ── C/C++ (plain Makefile, no CMake) ─────────────────────────────────────
+    if ((Test-Path "Makefile") -and (-not (Test-Path "CMakeLists.txt"))) {
+        $makeAvail = (Get-Command make -ErrorAction SilentlyContinue) -or (Get-Command nmake -ErrorAction SilentlyContinue)
+        if ($makeAvail) {
+            Info "Makefile detected — 'make' is available but NOT run automatically"
+            Info "  Run manually: make"
         } else {
-            Info "pyproject.toml detected — running pip install -e ."
-            pip install -e .
-            if ($LASTEXITCODE -eq 0) { Pass "pip install -e . complete" }
-        }
-    }
-
-    # Ruby
-    if (Test-Path "Gemfile") {
-        if (-not (Get-Command bundle -ErrorAction SilentlyContinue)) {
-            Warn "Bundler not found — skipping bundle install (run: gem install bundler)"
-        } else {
-            Info "Ruby project detected — running bundle install"
-            bundle install
-            if ($LASTEXITCODE -eq 0) { Pass "bundle install complete" }
+            Warn "Makefile detected but make/nmake not found"
+            Warn "  Windows: install via 'winget install GnuWin32.Make' or Visual Studio Build Tools"
         }
     }
 

--- a/templates/scripts/setup.sh
+++ b/templates/scripts/setup.sh
@@ -3,6 +3,17 @@
 # Detects OS and tech stack, installs dependencies, copies .env, and makes initial commit.
 # Called automatically by new-project.sh; can also be re-run manually at any time.
 #
+# Supported stacks:
+#   Node.js    package.json          → npm install
+#   Python     requirements.txt /    → .venv (mandatory) + pip install
+#              pyproject.toml
+#   Ruby       Gemfile               → bundle install
+#   .NET       *.csproj / *.sln      → dotnet restore
+#   Java       pom.xml (Maven)       → mvn dependency:resolve
+#              build.gradle (Gradle) → ./gradlew dependencies
+#   C/C++      CMakeLists.txt        → cmake -B build (configure only)
+#              Makefile              → make (info-only, user confirms)
+#
 # Usage: bash scripts/setup.sh [--skip-install] [--skip-commit]
 set -euo pipefail
 
@@ -18,15 +29,14 @@ done
 pass() { echo -e "\033[32m[PASS]\033[0m $*"; }
 info() { echo -e "\033[36m[INFO]\033[0m $*"; }
 warn() { echo -e "\033[33m[WARN]\033[0m $*"; }
-fail() { echo -e "\033[31m[FAIL]\033[0m $*"; }
 
 echo "=== setup.sh — environment setup ==="
 
 # ── OS detection ──────────────────────────────────────────────────────────────
 OS_TYPE="unknown"
 case "$(uname -s 2>/dev/null)" in
-  Darwin)             OS_TYPE="macos" ;;
-  Linux)              OS_TYPE="linux" ;;
+  Darwin)               OS_TYPE="macos" ;;
+  Linux)                OS_TYPE="linux" ;;
   MINGW*|MSYS*|CYGWIN*) OS_TYPE="windows-bash" ;;
   *)
     if [ -n "${OS:-}" ] && [ "$OS" = "Windows_NT" ]; then
@@ -36,13 +46,64 @@ case "$(uname -s 2>/dev/null)" in
 esac
 info "Detected OS: $OS_TYPE"
 
-# ── Python binary (python3 on macOS/Linux, python on Windows Git Bash) ───────
+# ── Helper: require a command or warn and skip ────────────────────────────────
+require() {
+  local cmd="$1" hint="$2"
+  if ! command -v "$cmd" &>/dev/null; then
+    warn "$cmd not found — $hint"
+    return 1
+  fi
+  return 0
+}
+
+# ── Python binary resolution ──────────────────────────────────────────────────
 PY_BIN=""
 if command -v python3 &>/dev/null; then
   PY_BIN="python3"
 elif command -v python &>/dev/null; then
-  PY_BIN="python"
+  # Guard against 'python' aliased to Python 2
+  if python --version 2>&1 | grep -q "^Python 3"; then
+    PY_BIN="python"
+  fi
 fi
+
+# ── Python venv helpers ───────────────────────────────────────────────────────
+activate_venv() {
+  if [ -f ".venv/bin/activate" ]; then
+    # shellcheck disable=SC1091
+    source .venv/bin/activate
+  elif [ -f ".venv/Scripts/activate" ]; then
+    # shellcheck disable=SC1091
+    source .venv/Scripts/activate
+  else
+    warn "Could not find venv activate script — continuing without activation"
+  fi
+}
+
+venv_activate_hint() {
+  if [ "$OS_TYPE" = "macos" ] || [ "$OS_TYPE" = "linux" ]; then
+    info "  Activate venv: source .venv/bin/activate"
+  else
+    info "  Activate venv (Git Bash): source .venv/Scripts/activate"
+    info "  Activate venv (PowerShell): .venv\\Scripts\\Activate.ps1"
+  fi
+}
+
+ensure_venv() {
+  if [ -z "$PY_BIN" ]; then
+    warn "Python 3 not found — skipping venv creation (install from https://python.org)"
+    return 1
+  fi
+  if [ ! -d ".venv" ]; then
+    info "Creating Python virtual environment (.venv)…"
+    "$PY_BIN" -m venv .venv
+    pass ".venv created"
+  else
+    info ".venv already exists — reusing"
+  fi
+  activate_venv
+  return 0
+}
 
 # ── 1. .env.sample → .env ─────────────────────────────────────────────────────
 if [ -f ".env.sample" ]; then
@@ -57,65 +118,89 @@ fi
 # ── 2. Dependency install (stack auto-detection) ──────────────────────────────
 if [ "$SKIP_INSTALL" = false ]; then
 
-  # Node.js
+  # ── Node.js ────────────────────────────────────────────────────────────────
   if [ -f "package.json" ]; then
-    if ! command -v npm &>/dev/null; then
-      warn "Node.js / npm not found — skipping npm install (install from https://nodejs.org)"
-    else
+    if require npm "install Node.js from https://nodejs.org"; then
       info "Node.js project detected — running npm install"
       npm install
       pass "npm install complete"
     fi
   fi
 
-  # Python (requirements.txt)
+  # ── Python (requirements.txt) ─────────────────────────────────────────────
   if [ -f "requirements.txt" ]; then
-    if [ -z "$PY_BIN" ]; then
-      warn "Python not found — skipping venv + pip install (install from https://python.org)"
-    else
-      info "Python project detected — creating .venv and installing dependencies"
-      "$PY_BIN" -m venv .venv
-
-      # Activate: macOS/Linux use bin/, Windows Git Bash uses Scripts/
-      if [ -f ".venv/bin/activate" ]; then
-        # shellcheck disable=SC1091
-        source .venv/bin/activate
-      elif [ -f ".venv/Scripts/activate" ]; then
-        # shellcheck disable=SC1091
-        source .venv/Scripts/activate
-      fi
-
+    info "Python project detected (requirements.txt)"
+    if ensure_venv; then
       pip install -r requirements.txt
-      pass "pip install complete (.venv created)"
-
-      # macOS: remind user to activate venv in their shell
-      if [ "$OS_TYPE" = "macos" ] || [ "$OS_TYPE" = "linux" ]; then
-        info "Activate venv in your shell: source .venv/bin/activate"
-      else
-        info "Activate venv in Git Bash: source .venv/Scripts/activate"
-      fi
+      pass "pip install -r requirements.txt complete"
+      venv_activate_hint
     fi
   fi
 
-  # Python (pyproject.toml, no requirements.txt)
+  # ── Python (pyproject.toml, no requirements.txt) ──────────────────────────
   if [ -f "pyproject.toml" ] && [ ! -f "requirements.txt" ]; then
-    if [ -z "$PY_BIN" ]; then
-      warn "Python not found — skipping pip install -e . (install from https://python.org)"
-    else
-      info "pyproject.toml detected — running pip install -e ."
+    info "Python project detected (pyproject.toml)"
+    if ensure_venv; then
       pip install -e .
       pass "pip install -e . complete"
+      venv_activate_hint
     fi
   fi
 
-  # Ruby
+  # ── Ruby ──────────────────────────────────────────────────────────────────
   if [ -f "Gemfile" ]; then
-    if ! command -v bundle &>/dev/null; then
-      warn "Bundler not found — skipping bundle install (run: gem install bundler)"
-    else
+    if require bundle "run: gem install bundler"; then
       info "Ruby project detected — running bundle install"
       bundle install
       pass "bundle install complete"
+    fi
+  fi
+
+  # ── .NET ──────────────────────────────────────────────────────────────────
+  DOTNET_PROJ=$(find . -maxdepth 3 \( -name "*.csproj" -o -name "*.sln" -o -name "*.fsproj" \) -not -path "./.git/*" 2>/dev/null | head -1)
+  if [ -n "$DOTNET_PROJ" ]; then
+    if require dotnet "install .NET SDK from https://dotnet.microsoft.com/download"; then
+      info ".NET project detected ($DOTNET_PROJ) — running dotnet restore"
+      dotnet restore
+      pass "dotnet restore complete"
+    fi
+  fi
+
+  # ── Java / Maven ──────────────────────────────────────────────────────────
+  if [ -f "pom.xml" ]; then
+    if require mvn "install Maven from https://maven.apache.org or use 'sdk install maven' (SDKMAN)"; then
+      info "Maven project detected — running mvn dependency:resolve -q"
+      mvn dependency:resolve -q
+      pass "mvn dependency:resolve complete"
+    fi
+  fi
+
+  # ── Java / Gradle ─────────────────────────────────────────────────────────
+  if [ -f "build.gradle" ] || [ -f "build.gradle.kts" ]; then
+    GRADLE_CMD="./gradlew"
+    [ ! -f "./gradlew" ] && GRADLE_CMD="gradle"
+    if require "$GRADLE_CMD" "install Gradle from https://gradle.org or use 'sdk install gradle' (SDKMAN)"; then
+      info "Gradle project detected — running $GRADLE_CMD dependencies (quiet)"
+      "$GRADLE_CMD" dependencies -q 2>/dev/null || "$GRADLE_CMD" dependencies
+      pass "Gradle dependencies resolved"
+    fi
+  fi
+
+  # ── C/C++ (CMake) ─────────────────────────────────────────────────────────
+  if [ -f "CMakeLists.txt" ]; then
+    if require cmake "install CMake from https://cmake.org"; then
+      info "CMake project detected — configuring build (cmake -B build)"
+      cmake -B build -S . 2>&1 | tail -5
+      pass "CMake configure complete — build artifacts in build/"
+      info "  To build: cmake --build build"
+    fi
+  fi
+
+  # ── C/C++ (plain Makefile, no CMake) ─────────────────────────────────────
+  if [ -f "Makefile" ] && [ ! -f "CMakeLists.txt" ]; then
+    if require make "install build tools (Linux: build-essential, macOS: xcode-select --install)"; then
+      info "Makefile detected — 'make' is available but NOT run automatically"
+      info "  Run manually: make"
     fi
   fi
 


### PR DESCRIPTION
## Summary
Extends `setup.sh`/`setup.ps1` with mandatory Python venv and 4 new stacks:

| Stack | Detection | Action |
|-------|-----------|--------|
| **Python** | `requirements.txt` / `pyproject.toml` | Always creates `.venv` first (mandatory), then pip install; Python 3-only guard |
| **.NET** | `*.csproj` / `*.sln` / `*.fsproj` (depth 3) | `dotnet restore` |
| **Java Maven** | `pom.xml` | `mvn dependency:resolve -q` |
| **Java Gradle** | `build.gradle` / `build.gradle.kts` | `./gradlew` or `gradle dependencies` |
| **C/C++ CMake** | `CMakeLists.txt` | `cmake -B build` (configure only) |
| **C/C++ Makefile** | `Makefile` (no CMake) | Info only — not auto-run |

All stacks check toolchain availability first and print install URL if missing.

## Test plan
- [x] `bash scripts/new-project.sh "test"` → audit 11 PASS → setup → initial commit → cd banner → exit 0
- [x] `bash scripts/audit.sh` passes at workspace root

🤖 Generated with [Claude Code](https://claude.com/claude-code)