### PR TITLE
feat: uv-first Python venv with pip fallback

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ## [Unreleased]
 
 ### Added — Multi-stack setup automation with mandatory Python venv and cross-platform support
-- `templates/scripts/setup.sh` + `setup.ps1`: multi-stack OS-aware setup with OSI license audit — Node.js (npm + `license-checker`), Python (mandatory `.venv` + pip + `pip-licenses`), Ruby (`bundle` + `licensee`), .NET (`dotnet restore` + `dotnet-project-licenses`), Java Maven/Gradle, C/C++ CMake/Makefile; all stacks toolchain-guarded; `--skip-license-check` flag to bypass audit
+- `templates/scripts/setup.sh` + `setup.ps1`: Python venv now uses `uv venv` + `uv pip install` when uv is available, falling back to `python -m venv` + `pip`; `py_install`/`Py-Install` helper abstracts manager; multi-stack OS-aware setup with OSI license audit — Node.js (npm + `license-checker`), Python (uv/venv + `pip-licenses`), Ruby, .NET, Maven, Gradle, CMake/Makefile; `--skip-license-check` flag
 - `CONSTITUTION.md` §8.5: Open-Source Package Policy — prefer OSI-approved licenses, document non-OSS exceptions
 - `templates/docs/context.md`: Coding Guidelines §5 Open-Source Package Policy added
 - `scripts/new-project.sh` + `new-project.ps1`: step 9 prints directory-change banner with exact `cd <path>` command

--- a/templates/scripts/setup.ps1
+++ b/templates/scripts/setup.ps1
@@ -45,7 +45,9 @@ function Require([string]$Cmd, [string]$Hint) {
     return $true
 }
 
-# ── Python binary resolution ──────────────────────────────────────────────────
+# ── Python toolchain resolution (uv preferred, python -m venv fallback) ───────
+$UvBin = if (Get-Command uv -ErrorAction SilentlyContinue) { "uv" } else { $null }
+
 $PyBin = $null
 foreach ($candidate in @("python3", "python")) {
     if (Get-Command $candidate -ErrorAction SilentlyContinue) {
@@ -63,24 +65,44 @@ function Activate-Venv {
     Warn "Could not find venv Activate.ps1 — continuing without activation"
 }
 
-function Show-VenvHint {
+function Show-VenvHint([string]$Mgr = "pip") {
     if ($IsWin) {
         Info "  Activate venv (PowerShell): .venv\Scripts\Activate.ps1"
         Info "  Activate venv (Git Bash):   source .venv/Scripts/activate"
     } else {
         Info "  Activate venv: source .venv/bin/activate"
     }
+    if ($Mgr -eq "uv") { Info "  Or skip activation: uv run <command>" }
 }
 
+# Ensure-Venv: creates .venv via uv (preferred) or python -m venv (fallback).
+# Returns the manager string: "uv" or "pip".
 function Ensure-Venv {
-    if (-not $PyBin) {
-        Warn "Python 3 not found — skipping venv (install from https://python.org)"; return $false
+    if ($UvBin) {
+        if (-not (Test-Path ".venv")) {
+            Info "Creating Python virtual environment with uv (.venv)…"
+            uv venv .venv; Pass ".venv created (uv)"
+        } else { Info ".venv already exists — reusing (uv)" }
+        Activate-Venv; return "uv"
+    } elseif ($PyBin) {
+        if (-not (Test-Path ".venv")) {
+            Info "uv not found — creating .venv with $PyBin -m venv (fallback)"
+            Info "  Install uv for faster installs: winget install astral-sh.uv  or  pip install uv"
+            & $PyBin -m venv .venv; Pass ".venv created (venv)"
+        } else { Info ".venv already exists — reusing" }
+        Activate-Venv; return "pip"
+    } else {
+        Warn "Neither uv nor Python 3 found — skipping venv"
+        Warn "  Install uv (recommended): winget install astral-sh.uv"
+        Warn "  Or install Python 3: https://python.org"
+        return $null
     }
-    if (-not (Test-Path ".venv")) {
-        Info "Creating Python virtual environment (.venv)…"
-        & $PyBin -m venv .venv; Pass ".venv created"
-    } else { Info ".venv already exists — reusing" }
-    Activate-Venv; return $true
+}
+
+# Py-Install: run 'uv pip install' or 'pip install' depending on manager.
+function Py-Install([string]$Mgr, [string[]]$Args) {
+    if ($Mgr -eq "uv") { uv pip install @Args }
+    else                { pip install @Args }
 }
 
 # ── License audit helpers ─────────────────────────────────────────────────────
@@ -104,7 +126,8 @@ function Audit-PythonLicenses {
     Info "Running Python license audit…"
     if (-not (Get-Command pip-licenses -ErrorAction SilentlyContinue)) {
         Info "pip-licenses not installed — installing for audit…"
-        pip install pip-licenses --quiet 2>$null
+        if ($UvBin) { uv pip install pip-licenses --quiet 2>$null }
+        else         { pip install pip-licenses --quiet 2>$null }
     }
     if (Get-Command pip-licenses -ErrorAction SilentlyContinue) {
         $report = pip-licenses --format=csv 2>$null
@@ -143,18 +166,20 @@ if (-not $SkipInstall) {
     # ── Python (requirements.txt) ─────────────────────────────────────────────
     if (Test-Path "requirements.txt") {
         Info "Python project detected (requirements.txt)"
-        if (Ensure-Venv) {
-            pip install -r requirements.txt
-            if ($LASTEXITCODE -eq 0) { Pass "pip install -r requirements.txt complete"; Audit-PythonLicenses; Show-VenvHint }
+        $mgr = Ensure-Venv
+        if ($mgr) {
+            Py-Install $mgr @("-r", "requirements.txt")
+            if ($LASTEXITCODE -eq 0) { Pass "Dependencies installed (requirements.txt) via $mgr"; Audit-PythonLicenses; Show-VenvHint $mgr }
         }
     }
 
     # ── Python (pyproject.toml, no requirements.txt) ──────────────────────────
     if ((Test-Path "pyproject.toml") -and (-not (Test-Path "requirements.txt"))) {
         Info "Python project detected (pyproject.toml)"
-        if (Ensure-Venv) {
-            pip install -e .
-            if ($LASTEXITCODE -eq 0) { Pass "pip install -e . complete"; Audit-PythonLicenses; Show-VenvHint }
+        $mgr = Ensure-Venv
+        if ($mgr) {
+            Py-Install $mgr @("-e", ".")
+            if ($LASTEXITCODE -eq 0) { Pass "Dependencies installed (pyproject.toml) via $mgr"; Audit-PythonLicenses; Show-VenvHint $mgr }
         }
     }
 

--- a/templates/scripts/setup.sh
+++ b/templates/scripts/setup.sh
@@ -6,8 +6,8 @@
 #
 # Supported stacks:
 #   Node.js    package.json          → npm install  → license-checker audit
-#   Python     requirements.txt /    → .venv (mandatory) + pip install → pip-licenses audit
-#              pyproject.toml
+#   Python     requirements.txt /    → uv venv + uv pip install (fallback: python -m venv + pip)
+#              pyproject.toml           → pip-licenses audit
 #   Ruby       Gemfile               → bundle install
 #   .NET       *.csproj / *.sln      → dotnet restore
 #   Java       pom.xml (Maven)       → mvn dependency:resolve
@@ -63,11 +63,17 @@ require() {
   return 0
 }
 
-# ── Python binary resolution ──────────────────────────────────────────────────
+# ── Python toolchain resolution (uv preferred, python -m venv fallback) ───────
+UV_BIN=""
+if command -v uv &>/dev/null; then
+  UV_BIN="uv"
+fi
+
 PY_BIN=""
 if command -v python3 &>/dev/null; then
   PY_BIN="python3"
 elif command -v python &>/dev/null; then
+  # Guard against 'python' aliased to Python 2
   if python --version 2>&1 | grep -q "^Python 3"; then
     PY_BIN="python"
   fi
@@ -87,28 +93,60 @@ activate_venv() {
 }
 
 venv_activate_hint() {
+  local mgr="${1:-pip}"
   if [ "$OS_TYPE" = "macos" ] || [ "$OS_TYPE" = "linux" ]; then
     info "  Activate venv: source .venv/bin/activate"
   else
     info "  Activate venv (Git Bash): source .venv/Scripts/activate"
     info "  Activate venv (PowerShell): .venv\\Scripts\\Activate.ps1"
   fi
+  if [ "$mgr" = "uv" ]; then
+    info "  Or skip activation entirely: uv run <command>"
+  fi
 }
 
+# ensure_venv: creates .venv via uv (preferred) or python -m venv (fallback).
+# Prints the manager used ("uv" or "pip") to stdout — capture with $(...).
 ensure_venv() {
-  if [ -z "$PY_BIN" ]; then
-    warn "Python 3 not found — skipping venv creation (install from https://python.org)"
+  if [ -n "$UV_BIN" ]; then
+    if [ ! -d ".venv" ]; then
+      info "Creating Python virtual environment with uv (.venv)…"
+      uv venv .venv
+      pass ".venv created (uv)"
+    else
+      info ".venv already exists — reusing (uv)"
+    fi
+    activate_venv
+    echo "uv"
+    return 0
+  elif [ -n "$PY_BIN" ]; then
+    if [ ! -d ".venv" ]; then
+      info "uv not found — creating .venv with $PY_BIN -m venv (fallback)"
+      info "  Install uv for faster installs: curl -LsSf https://astral.sh/uv/install.sh | sh"
+      "$PY_BIN" -m venv .venv
+      pass ".venv created (venv)"
+    else
+      info ".venv already exists — reusing"
+    fi
+    activate_venv
+    echo "pip"
+    return 0
+  else
+    warn "Neither uv nor Python 3 found — skipping venv"
+    warn "  Install uv (recommended): curl -LsSf https://astral.sh/uv/install.sh | sh"
+    warn "  Or install Python 3: https://python.org"
     return 1
   fi
-  if [ ! -d ".venv" ]; then
-    info "Creating Python virtual environment (.venv)…"
-    "$PY_BIN" -m venv .venv
-    pass ".venv created"
+}
+
+# py_install: run 'uv pip install' or 'pip install' depending on manager.
+py_install() {
+  local mgr="$1"; shift
+  if [ "$mgr" = "uv" ]; then
+    uv pip install "$@"
   else
-    info ".venv already exists — reusing"
+    pip install "$@"
   fi
-  activate_venv
-  return 0
 }
 
 # ── License audit helpers ─────────────────────────────────────────────────────
@@ -152,7 +190,9 @@ license_audit_python() {
     fi
   else
     info "pip-licenses not installed — installing for audit…"
-    if pip install pip-licenses --quiet 2>/dev/null; then
+    local install_cmd="pip"
+    [ -n "$UV_BIN" ] && install_cmd="uv pip"
+    if $install_cmd install pip-licenses --quiet 2>/dev/null; then
       license_audit_python  # re-run now that it's installed
     else
       warn "Could not install pip-licenses — skipping Python license audit"
@@ -187,23 +227,23 @@ if [ "$SKIP_INSTALL" = false ]; then
   # ── Python (requirements.txt) ─────────────────────────────────────────────
   if [ -f "requirements.txt" ]; then
     info "Python project detected (requirements.txt)"
-    if ensure_venv; then
-      pip install -r requirements.txt
-      pass "pip install -r requirements.txt complete"
+    mgr=$(ensure_venv) && {
+      py_install "$mgr" -r requirements.txt
+      pass "Dependencies installed (requirements.txt) via $mgr"
       license_audit_python
-      venv_activate_hint
-    fi
+      venv_activate_hint "$mgr"
+    }
   fi
 
   # ── Python (pyproject.toml, no requirements.txt) ──────────────────────────
   if [ -f "pyproject.toml" ] && [ ! -f "requirements.txt" ]; then
     info "Python project detected (pyproject.toml)"
-    if ensure_venv; then
-      pip install -e .
-      pass "pip install -e . complete"
+    mgr=$(ensure_venv) && {
+      py_install "$mgr" -e .
+      pass "Dependencies installed (pyproject.toml) via $mgr"
       license_audit_python
-      venv_activate_hint
-    fi
+      venv_activate_hint "$mgr"
+    }
   fi
 
   # ── Ruby ──────────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary
Python virtual environment management now uses **uv** when available, falling back to standard `python -m venv` + `pip`.

| Condition | venv creation | package install |
|-----------|--------------|-----------------|
| uv installed | `uv venv .venv` | `uv pip install` |
| uv not found | `python -m venv .venv` + install hint | `pip install` |
| neither found | warning + install URLs | skipped |

- `py_install` (sh) / `Py-Install` (ps1) helper abstracts manager so all install calls use the right tool
- `pip-licenses` audit also self-installs via `uv pip install` when uv is present
- Fallback prints install hint: `curl -LsSf https://astral.sh/uv/install.sh | sh` (Linux/macOS), `winget install astral-sh.uv` (Windows)

## Test plan
- [x] `bash scripts/new-project.sh "test"` → audit 11 PASS → setup complete → exit 0
- [x] `bash scripts/audit.sh` at workspace root passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)