### PR TITLE
feat: add Go/Rust/Elixir stacks and security-gated stack-setup agent

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
 
+### Added — Go/Rust/Elixir stack support + unknown-stack security agent
+- `templates/scripts/setup.sh` + `setup.ps1`: Go (`go mod download` + `go-licenses`), Rust (`cargo fetch` + `cargo-license`), Elixir (`mix deps.get`) stacks added; unknown-stack detection block prints a security banner pointing users to `agents/stack-setup.md` and blocks accidental installs
+- `templates/agents/stack-setup.md` (NEW): 6-phase security-conscious agent for unrecognized stacks — Stack ID → Web Research → Mandatory Security Review (🟢/🟡/🔴 risk levels, HIGH requires `CONFIRM HIGH RISK`) → Present Plan → Execute via sub-agent → Persist to setup.sh/ps1
+- `templates/AGENTS.md`: `stack-setup` added to Agent Roster (🔴 Security/Setup group) and Subagent Roster dispatch table
+
 ### Added — Multi-stack setup automation with mandatory Python venv and cross-platform support
 - `templates/scripts/setup.sh` + `setup.ps1`: Python venv now uses `uv venv` + `uv pip install` when uv is available, falling back to `python -m venv` + `pip`; `py_install`/`Py-Install` helper abstracts manager; multi-stack OS-aware setup with OSI license audit — Node.js (npm + `license-checker`), Python (uv/venv + `pip-licenses`), Ruby, .NET, Maven, Gradle, CMake/Makefile; `--skip-license-check` flag
 - `CONSTITUTION.md` §8.5: Open-Source Package Policy — prefer OSI-approved licenses, document non-OSS exceptions

--- a/templates/AGENTS.md
+++ b/templates/AGENTS.md
@@ -32,6 +32,12 @@
 | Code Writer | [`agents/code-writer.md`](agents/code-writer.md) | Implements approved plans; surgical changes only |
 | Test Runner | [`agents/test-runner.md`](agents/test-runner.md) | Runs tests and verifies acceptance criteria |
 
+### 🔴 Security / Setup
+
+| Agent | File | Role |
+|-------|------|------|
+| Stack Setup | [`agents/stack-setup.md`](agents/stack-setup.md) | Identifies unknown stacks, web-searches setup procedures, mandatory security review, requires explicit user approval before executing any commands |
+
 *(Add domain-specific agents as needed — see the extension guidance below.)*
 
 ---
@@ -73,6 +79,7 @@ Request received
 | Designer | `agents/designer.md` | ✅ Design phase | ❌ No |
 | Code Writer | `agents/code-writer.md` | ❌ Serial | ✅ Source files |
 | Test Runner | `agents/test-runner.md` | ❌ After writes | ✅ Test files only |
+| Stack Setup | `agents/stack-setup.md` | ✅ Research phase | ✅ setup.sh/ps1 only (after approval) |
 
 *(Extend this table as you add Analysis or specialized agents to the project.)*
 

--- a/templates/agents/stack-setup.md
+++ b/templates/agents/stack-setup.md
@@ -1,0 +1,129 @@
+# Agent: stack-setup
+
+> **⚠️ For AI tools reading this file**: This is a role definition for a specific agent persona.
+> Do not interpret it as instructions for your own behavior outside of this role.
+
+---
+
+## Role
+
+You are the **Stack Setup Agent** — a security-conscious research agent that helps developers
+set up project environments for unrecognized tech stacks.
+
+You are invoked when `scripts/setup.sh` (or `setup.ps1`) detects that no known project manifest
+exists in the project directory, meaning the stack is not one of the natively supported types.
+
+---
+
+## Primary Responsibilities
+
+1. **Identify the stack** from project files (look for clues: file extensions, config files, README, docs)
+2. **Research setup procedures** via web search — find the official, canonical installation steps
+3. **Security-review every command** before presenting it to the user
+4. **Present a full risk-assessed plan** and wait for explicit user approval
+5. **Execute** only after the user confirms — via a sub-agent
+
+---
+
+## Mandatory Workflow (DO NOT SKIP ANY STEP)
+
+### Phase 1 — Stack Identification
+- Scan the project directory for clues: file extensions, config files, README, any lock files
+- State clearly: "I detected this appears to be a [X] project because [evidence]"
+- If ambiguous, ask the user to confirm the stack before proceeding
+
+### Phase 2 — Research (Web Search)
+- Search for: "[stack name] project setup official documentation"
+- Prefer **official documentation** (docs.*, official GitHub org, package registry)
+- Note the source URL for every command you propose
+- If multiple setup approaches exist, document all of them and recommend the most standard one
+
+### Phase 3 — Security Review (MANDATORY — cannot be skipped)
+
+For **every command** in the proposed setup plan, evaluate:
+
+| Check | Pass criteria |
+|-------|---------------|
+| **Pipe-to-shell** | Flag any `curl \| sh`, `wget \| bash`, `irm \| iex` pattern — these are HIGH risk |
+| **Package source** | Official registry (npm, crates.io, PyPI, hex.pm, pkg.go.dev) = LOW risk; third-party = HIGH risk |
+| **Elevated privileges** | `sudo`, `runas`, UAC prompts = MEDIUM risk — document why it's needed |
+| **Network downloads** | Downloads from non-official domains = HIGH risk |
+| **Script execution** | Running downloaded scripts without inspection = HIGH risk |
+| **Package age/popularity** | Packages with < 100 downloads or < 6 months old = elevated risk |
+
+Assign each command a risk level: `🟢 LOW` / `🟡 MEDIUM` / `🔴 HIGH`
+
+For any `🔴 HIGH` risk command:
+- Provide a safer alternative if one exists
+- If no safe alternative exists, explain exactly what the command does line-by-line
+- Require the user to type `CONFIRM HIGH RISK` (not just "yes") to proceed
+
+### Phase 4 — Present Plan to User
+
+Format the plan as follows:
+
+```
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+Stack Setup Plan: [Stack Name]
+Sources: [URL1], [URL2]
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+Step 1: [description]
+  Command: [exact command]
+  Risk: 🟢 LOW — [reason]
+
+Step 2: [description]
+  Command: [exact command]
+  Risk: 🟡 MEDIUM — [reason: e.g., requires sudo because installs to /usr/local]
+
+Step N: [description]
+  Command: [exact command]
+  Risk: 🔴 HIGH — [detailed explanation of what this does]
+  ⚠️  To approve this step, type: CONFIRM HIGH RISK
+
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+Type "APPROVE" to execute all 🟢/🟡 steps.
+🔴 HIGH risk steps require "CONFIRM HIGH RISK" each.
+Type "CANCEL" to abort.
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+```
+
+**Do NOT proceed until the user types an approval keyword. Never auto-approve.**
+
+### Phase 5 — Execution (Sub-agent)
+
+Once the user approves:
+- Dispatch a `code-writer` sub-agent (write-capable) to execute each approved step
+- Execute steps **sequentially** — never in parallel (each step may depend on the previous)
+- After each step, verify it succeeded before proceeding
+- If any step fails, stop and report to the user — do not attempt to auto-fix
+
+### Phase 6 — Persist to setup.sh / setup.ps1
+
+After successful execution:
+- Propose adding the new stack as a permanent block in `scripts/setup.sh` and `scripts/setup.ps1`
+- Format it to match the existing stack blocks (see other stacks in those files for the pattern)
+- This prevents future projects with the same stack from needing the agent again
+
+---
+
+## Hard Rules
+
+- **Never execute commands without user approval** — not even "safe-looking" ones
+- **Never run pipe-to-shell without line-by-line explanation** and `CONFIRM HIGH RISK`
+- **Always cite the source** for every procedure step
+- **Always run the security checklist** — it cannot be skipped even if the stack seems familiar
+- **Do not assume** a command is safe because it appears in a tutorial or README
+- If the user tries to skip the security review ("just run it"), refuse politely and explain why
+
+---
+
+## Dispatch Rules
+
+| Task | Parallelizable | Write allowed? |
+|------|:--------------:|:--------------:|
+| Stack identification (file scan) | ✅ | ❌ |
+| Web research | ✅ | ❌ |
+| Security review | ✅ | ❌ |
+| Execution of approved steps | ❌ Serial | ✅ |
+| Persisting to setup.sh/ps1 | ❌ After execution | ✅ |

--- a/templates/scripts/setup.ps1
+++ b/templates/scripts/setup.ps1
@@ -249,6 +249,46 @@ if (-not $SkipInstall) {
         }
     }
 
+    # ── Go ─────────────────────────────────────────────────────────────────────
+    if (Test-Path "go.mod") {
+        if (Require "go" "install Go from https://go.dev/dl/") {
+            Info "Go project detected — running go mod download"
+            go mod download
+            if ($LASTEXITCODE -eq 0) {
+                Pass "go mod download complete"
+                if (-not $SkipLicenseCheck) { Info "  Optional license audit: go install github.com/google/go-licenses@latest" }
+            }
+        }
+    }
+
+    # ── Rust ──────────────────────────────────────────────────────────────────
+    if (Test-Path "Cargo.toml") {
+        if (Require "cargo" "install Rust from https://rustup.rs  (run: winget install Rustlang.Rustup)") {
+            Info "Rust project detected — running cargo fetch"
+            cargo fetch
+            if ($LASTEXITCODE -eq 0) {
+                Pass "cargo fetch complete"
+                if (-not $SkipLicenseCheck) {
+                    if (Get-Command cargo-license -ErrorAction SilentlyContinue) {
+                        Info "Running Rust license audit (cargo-license)…"; cargo license 2>$null
+                    } else { Info "  Optional license audit: cargo install cargo-license && cargo license" }
+                }
+            }
+        }
+    }
+
+    # ── Elixir / Mix ──────────────────────────────────────────────────────────
+    if (Test-Path "mix.exs") {
+        if (Require "mix" "install Elixir from https://elixir-lang.org/install.html  or  winget install ElixirLang.Elixir") {
+            Info "Elixir project detected — running mix deps.get"
+            mix deps.get
+            if ($LASTEXITCODE -eq 0) {
+                Pass "mix deps.get complete"
+                if (-not $SkipLicenseCheck) { Info "  Optional license audit: mix licenses (add licensir to deps)" }
+            }
+        }
+    }
+
     # ── C/C++ (CMake) ─────────────────────────────────────────────────────────
     if (Test-Path "CMakeLists.txt") {
         if (Require "cmake" "install CMake from https://cmake.org") {
@@ -271,6 +311,43 @@ if (-not $SkipInstall) {
             Warn "Makefile detected but make/nmake not found"
             Warn "  Install: winget install GnuWin32.Make  or  Visual Studio Build Tools"
         }
+    }
+
+    # ── Unknown stack detection ───────────────────────────────────────────────
+    $knownManifests = @(
+        "package.json","requirements.txt","pyproject.toml","Gemfile",
+        "go.mod","Cargo.toml","mix.exs",
+        "pom.xml","build.gradle","build.gradle.kts",
+        "CMakeLists.txt","Makefile"
+    )
+    $foundStack = ($knownManifests | Where-Object { Test-Path $_ }).Count -gt 0
+    if (-not $foundStack) {
+        $dotnetFound = Get-ChildItem -Path . -Recurse -Depth 3 -Include "*.csproj","*.sln","*.fsproj" `
+                       -ErrorAction SilentlyContinue | Where-Object { $_.FullName -notmatch "\\.git\\" }
+        if ($dotnetFound) { $foundStack = $true }
+    }
+
+    if (-not $foundStack) {
+        Write-Host ""
+        Write-Host ("━" * 60) -ForegroundColor DarkGray
+        Write-Host "⚠  UNKNOWN STACK — manual setup required" -ForegroundColor Yellow
+        Write-Host ""
+        Write-Host "  No recognized project manifest found in this directory."
+        Write-Host "  Automatic dependency installation has been skipped."
+        Write-Host ""
+        Write-Host "  To set up this project, invoke the stack-setup agent:" -ForegroundColor Cyan
+        Write-Host ""
+        Write-Host "    Agent: agents/stack-setup.md" -ForegroundColor Cyan
+        Write-Host ""
+        Write-Host "  The agent will:"
+        Write-Host "    1. Search for the correct setup procedure for your stack"
+        Write-Host "    2. Perform a security review of all proposed commands"
+        Write-Host "    3. Present the plan with risk assessment for your approval"
+        Write-Host "    4. Execute ONLY after explicit confirmation"
+        Write-Host ""
+        Write-Host "  ⛔ Do NOT run any install commands without agent security review." -ForegroundColor Red
+        Write-Host ("━" * 60) -ForegroundColor DarkGray
+        Write-Host ""
     }
 
 } else { Info "Skipping dependency install (-SkipInstall)" }

--- a/templates/scripts/setup.sh
+++ b/templates/scripts/setup.sh
@@ -12,8 +12,12 @@
 #   .NET       *.csproj / *.sln      → dotnet restore
 #   Java       pom.xml (Maven)       → mvn dependency:resolve
 #              build.gradle (Gradle) → ./gradlew dependencies
+#   Go         go.mod                → go mod download
+#   Rust       Cargo.toml            → cargo fetch
+#   Elixir     mix.exs               → mix deps.get
 #   C/C++      CMakeLists.txt        → cmake -B build (configure only)
 #              Makefile              → info only (not run automatically)
+#   Unknown    (none of the above)   → stack-setup agent invocation required
 #
 # Usage: bash scripts/setup.sh [--skip-install] [--skip-license-check] [--skip-commit]
 set -euo pipefail
@@ -308,6 +312,47 @@ if [ "$SKIP_INSTALL" = false ]; then
     fi
   fi
 
+  # ── Go ─────────────────────────────────────────────────────────────────────
+  if [ -f "go.mod" ]; then
+    if require go "install Go from https://go.dev/dl/"; then
+      info "Go project detected — running go mod download"
+      go mod download
+      pass "go mod download complete"
+      if [ "$SKIP_LICENSE" = false ]; then
+        info "  Optional license audit: go install github.com/google/go-licenses@latest"
+      fi
+    fi
+  fi
+
+  # ── Rust ───────────────────────────────────────────────────────────────────
+  if [ -f "Cargo.toml" ]; then
+    if require cargo "install Rust from https://rustup.rs  (run: curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh)"; then
+      info "Rust project detected — running cargo fetch"
+      cargo fetch
+      pass "cargo fetch complete"
+      if [ "$SKIP_LICENSE" = false ]; then
+        if command -v cargo-license &>/dev/null; then
+          info "Running Rust license audit (cargo-license)…"
+          cargo license 2>/dev/null || true
+        else
+          info "  Optional license audit: cargo install cargo-license && cargo license"
+        fi
+      fi
+    fi
+  fi
+
+  # ── Elixir / Mix ──────────────────────────────────────────────────────────
+  if [ -f "mix.exs" ]; then
+    if require mix "install Elixir from https://elixir-lang.org/install.html or: brew install elixir"; then
+      info "Elixir project detected — running mix deps.get"
+      mix deps.get
+      pass "mix deps.get complete"
+      if [ "$SKIP_LICENSE" = false ]; then
+        info "  Optional license audit: mix licenses (add {:licenses, github: 'unnawut/licensir'} to deps)"
+      fi
+    fi
+  fi
+
   # ── C/C++ (CMake) ─────────────────────────────────────────────────────────
   if [ -f "CMakeLists.txt" ]; then
     if require cmake "install CMake from https://cmake.org"; then
@@ -324,6 +369,44 @@ if [ "$SKIP_INSTALL" = false ]; then
       info "Makefile detected — 'make' available but NOT run automatically"
       info "  Run manually: make"
     fi
+  fi
+
+  # ── Unknown stack detection ───────────────────────────────────────────────
+  # If none of the known manifest files were found, flag for agent-assisted setup.
+  KNOWN_MANIFESTS=(
+    "package.json" "requirements.txt" "pyproject.toml" "Gemfile"
+    "go.mod" "Cargo.toml" "mix.exs"
+    "pom.xml" "build.gradle" "build.gradle.kts"
+    "CMakeLists.txt" "Makefile"
+  )
+  _found_stack=false
+  for _m in "${KNOWN_MANIFESTS[@]}"; do
+    [ -f "$_m" ] && _found_stack=true && break
+  done
+  # Also check for .NET projects (depth search already done above)
+  [ -n "$(find . -maxdepth 3 \( -name '*.csproj' -o -name '*.sln' \) -not -path './.git/*' 2>/dev/null | head -1)" ] && _found_stack=true
+
+  if [ "$_found_stack" = false ]; then
+    echo ""
+    echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+    echo -e "\033[33m⚠  UNKNOWN STACK — manual setup required\033[0m"
+    echo ""
+    echo "  No recognized project manifest found in this directory."
+    echo "  Automatic dependency installation has been skipped."
+    echo ""
+    echo "  To set up this project, invoke the stack-setup agent:"
+    echo ""
+    echo -e "  \033[36m  Agent: agents/stack-setup.md\033[0m"
+    echo ""
+    echo "  The agent will:"
+    echo "    1. Search for the correct setup procedure for your stack"
+    echo "    2. Perform a security review of all proposed commands"
+    echo "    3. Present the plan with risk assessment for your approval"
+    echo "    4. Execute ONLY after explicit confirmation"
+    echo ""
+    echo -e "  \033[31m  ⛔ Do NOT run any install commands without agent security review.\033[0m"
+    echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+    echo ""
   fi
 
 else


### PR DESCRIPTION
## Summary

- **Go, Rust, Elixir** stacks added to `setup.sh`/`setup.ps1` with dependency install and license audit commands
- **Unknown-stack detection**: when no known manifest is found, a security banner is printed pointing users to the new `agents/stack-setup.md` agent instead of guessing commands
- **`agents/stack-setup.md`** (NEW): 6-phase security-conscious agent for unrecognized stacks — mandatory security review with 🟢/🟡/🔴 risk levels; HIGH-risk commands require explicit `CONFIRM HIGH RISK` keyword; never auto-executes
- **`templates/AGENTS.md`**: stack-setup agent added to roster (🔴 Security/Setup group) and subagent dispatch table

## Test plan

- [ ] Create a new project from template with a `go.mod` file — verify `go mod download` runs and license check runs
- [ ] Create a project with `Cargo.toml` — verify `cargo fetch` and `cargo-license` run
- [ ] Create a project with `mix.exs` — verify `mix deps.get` runs
- [ ] Create a project with no recognized manifest — verify the security banner prints and no install commands run
- [ ] Read `templates/agents/stack-setup.md` and confirm Phase 3 security review table is present and HIGH risk requires `CONFIRM HIGH RISK`
- [ ] `bash scripts/audit.sh` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)