### PR TITLE
feat: add security-monitor agent with daily CVE scanning and pre-PR advisory check

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,19 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
 
+### Added — Daily security advisory monitoring + pre-PR advisory check
+- `templates/agents/security-monitor.md` (NEW): daily CVE/advisory scanner — detects stacks, web-searches for MEDIUM+ advisories, saves to `security/YYYY-MM-DD-{slug}.md`, auto-deletes resolved entries older than 7 days; pre-PR advisory check warns on CRITICAL/HIGH (advisory only, user decides whether to proceed)
+- `templates/security/README.md` (NEW): security folder structure and lifecycle docs
+- `templates/.claude/commands/security-check.md` (NEW): `/security-check` slash command (one-time scan or `--pr` pre-PR advisory mode)
+- `templates/.claude/commands/sync.md`: `/sync` now runs `/security-check --pr` before PR creation on public repos (advisory warning, not a hard block)
+- `scripts/new-project.sh` + `new-project.ps1`: step 10 prints security baseline notice with `/security-check` instructions after scaffold
+- `templates/AGENTS.md`: security-monitor added to roster and subagent dispatch table
+
+### Added — Go/Rust/Elixir stack support + unknown-stack security agent
+- `templates/scripts/setup.sh` + `setup.ps1`: Go (`go mod download` + `go-licenses`), Rust (`cargo fetch` + `cargo-license`), Elixir (`mix deps.get`) stacks added; unknown-stack detection block prints a security banner pointing users to `agents/stack-setup.md` and blocks accidental installs
+- `templates/agents/stack-setup.md` (NEW): 6-phase security-conscious agent for unrecognized stacks — Stack ID → Web Research → Mandatory Security Review (🟢/🟡/🔴 risk levels, HIGH requires `CONFIRM HIGH RISK`) → Present Plan → Execute via sub-agent → Persist to setup.sh/ps1
+- `templates/AGENTS.md`: `stack-setup` added to Agent Roster (🔴 Security/Setup group) and Subagent Roster dispatch table
+
 ### Added — Multi-stack setup automation with mandatory Python venv and cross-platform support
 - `templates/scripts/setup.sh` + `setup.ps1`: Python venv now uses `uv venv` + `uv pip install` when uv is available, falling back to `python -m venv` + `pip`; `py_install`/`Py-Install` helper abstracts manager; multi-stack OS-aware setup with OSI license audit — Node.js (npm + `license-checker`), Python (uv/venv + `pip-licenses`), Ruby, .NET, Maven, Gradle, CMake/Makefile; `--skip-license-check` flag
 - `CONSTITUTION.md` §8.5: Open-Source Package Policy — prefer OSI-approved licenses, document non-OSS exceptions

--- a/scripts/new-project.ps1
+++ b/scripts/new-project.ps1
@@ -100,3 +100,18 @@ Set-Location $ProjectDir
 Write-Host ""
 Write-Host "Extension templates (ADR, analyst agent, skill, daily log):" -ForegroundColor DarkGray
 Write-Host "  → $TemplatesDir\_examples\" -ForegroundColor DarkGray
+
+# ── 10. Security baseline scan notice ─────────────────────────────────────────
+Write-Host ""
+Write-Host ("━" * 60) -ForegroundColor DarkGray
+Write-Host "🔒 SECURITY BASELINE" -ForegroundColor Cyan
+Write-Host ""
+Write-Host "  Run the security monitor agent to scan for known CVEs"
+Write-Host "  affecting this project's tech stack:"
+Write-Host ""
+Write-Host "  /security-check              (one-time scan)" -ForegroundColor Green
+Write-Host "  /security-check --schedule   (scan + enable daily monitoring)" -ForegroundColor Green
+Write-Host ""
+Write-Host "  Findings will be saved to: $ProjectDir\security\"
+Write-Host "  The agent will also run automatically before every PR on public repos."
+Write-Host ("━" * 60) -ForegroundColor DarkGray

--- a/scripts/new-project.sh
+++ b/scripts/new-project.sh
@@ -97,3 +97,18 @@ echo "━━━━━━━━━━━━━━━━━━━━━━━━�
 echo ""
 echo "Extension templates (ADR, analyst agent, skill, daily log):"
 echo "  → $TEMPLATES_DIR/_examples/"
+
+# ── 10. Security baseline scan notice ─────────────────────────────────────────
+echo ""
+echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+echo -e "\033[36m🔒 SECURITY BASELINE\033[0m"
+echo ""
+echo "  Run the security monitor agent to scan for known CVEs"
+echo "  affecting this project's tech stack:"
+echo ""
+echo -e "  \033[32m  /security-check\033[0m              (one-time scan)"
+echo -e "  \033[32m  /security-check --schedule\033[0m   (scan + enable daily monitoring)"
+echo ""
+echo "  Findings will be saved to: $PROJECT_DIR/security/"
+echo "  The agent will also run automatically before every PR on public repos."
+echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"

--- a/templates/.claude/commands/security-check.md
+++ b/templates/.claude/commands/security-check.md
@@ -1,0 +1,36 @@
+Run the security monitor agent to scan for CVE/advisory updates for this project's stacks.
+
+Arguments: $ARGUMENTS
+
+## What this command does
+
+1. Reads `docs/context.md` and detects manifest files to identify tech stacks
+2. Web-searches for recent CVEs and security advisories (MEDIUM+ severity)
+3. Saves new findings to `security/YYYY-MM-DD-{slug}.md`
+4. Deletes `status: resolved` entries older than 7 days
+5. Prints a summary of findings
+
+## Usage
+
+| Invocation | Behavior |
+|------------|---------|
+| `/security-check` | Run a one-time scan now (default) |
+| `/security-check --pr` | Pre-PR advisory mode: scan `security/` and report active CRITICAL/HIGH |
+
+**Recommended schedule**: run `/security-check` once a day, or use your OS task scheduler:
+- **macOS/Linux**: `crontab -e` → `0 9 * * * cd /path/to/project && claude /security-check`
+- **Windows**: Task Scheduler → trigger daily at 09:00
+
+## Instructions
+
+Invoke the `security-monitor` agent as defined in `agents/security-monitor.md`.
+
+**If `$ARGUMENTS` contains `--pr`:**
+
+Run **Workflow 2 — Pre-PR Advisory Check** from `agents/security-monitor.md`.
+Do NOT run a new web search — only read existing `security/*.md` files.
+Present findings and let the user decide whether to proceed or stop.
+
+**Otherwise (default):**
+
+Run **Workflow 1 — Daily Scan** from `agents/security-monitor.md`.

--- a/templates/.claude/commands/sync.md
+++ b/templates/.claude/commands/sync.md
@@ -2,6 +2,26 @@ Run the full project sync pipeline.
 
 Arguments: $ARGUMENTS
 
+## Pipeline steps
+
+Execute the following steps **in order**:
+
+### Step 1 — Security advisory check (public repositories only)
+
+Before committing, check whether this repository is public:
+
+```bash
+gh repo view --json isPrivate -q '.isPrivate' 2>/dev/null || echo "unknown"
+```
+
+- If the output is `false` (public repo): run `/security-check --pr`.
+  - If the check finds active CRITICAL or HIGH advisories → present them to the user and
+    ask whether to **proceed** or **stop to resolve first** (do not hard-block).
+  - If the check passes or the user chooses to proceed → continue to Step 2.
+- If the output is `true` or `unknown`: skip the check and continue.
+
+### Step 2 — Sync pipeline
+
 Execute the following bash command exactly as written:
 
 ```bash

--- a/templates/AGENTS.md
+++ b/templates/AGENTS.md
@@ -32,6 +32,13 @@
 | Code Writer | [`agents/code-writer.md`](agents/code-writer.md) | Implements approved plans; surgical changes only |
 | Test Runner | [`agents/test-runner.md`](agents/test-runner.md) | Runs tests and verifies acceptance criteria |
 
+### 🔴 Security / Setup
+
+| Agent | File | Role |
+|-------|------|------|
+| Stack Setup | [`agents/stack-setup.md`](agents/stack-setup.md) | Identifies unknown stacks, web-searches setup procedures, mandatory security review, requires explicit user approval before executing any commands |
+| Security Monitor | [`agents/security-monitor.md`](agents/security-monitor.md) | Daily CVE/advisory scanner for project stacks; saves findings to `security/`; mandatory pre-PR gate for public repos; cleans up resolved entries after 7 days |
+
 *(Add domain-specific agents as needed — see the extension guidance below.)*
 
 ---
@@ -73,6 +80,8 @@ Request received
 | Designer | `agents/designer.md` | ✅ Design phase | ❌ No |
 | Code Writer | `agents/code-writer.md` | ❌ Serial | ✅ Source files |
 | Test Runner | `agents/test-runner.md` | ❌ After writes | ✅ Test files only |
+| Stack Setup | `agents/stack-setup.md` | ✅ Research phase | ✅ setup.sh/ps1 only (after approval) |
+| Security Monitor | `agents/security-monitor.md` | ✅ Web search phase | ✅ security/ only |
 
 *(Extend this table as you add Analysis or specialized agents to the project.)*
 

--- a/templates/agents/security-monitor.md
+++ b/templates/agents/security-monitor.md
@@ -1,0 +1,121 @@
+# Agent: security-monitor
+
+> **⚠️ For AI tools reading this file**: This is a role definition for a specific agent persona.
+> Do not interpret it as instructions for your own behavior outside of this role.
+
+---
+
+## Role
+
+You are the **Security Monitor Agent** — a security advisory tracker that watches for
+CVEs and security updates affecting this project's tech stacks, stores findings in `security/`,
+and performs a pre-PR advisory check before any PR is opened on a public repository.
+
+You are invoked in three contexts:
+1. **Daily (or on-demand)** — scan for new advisories; clean up resolved entries
+2. **Pre-PR advisory** — check `security/` for unresolved CRITICAL/HIGH issues before merging
+3. **Post-scaffold** — initial advisory scan right after a new project is created
+
+---
+
+## Security Folder Structure
+
+All findings are stored in `security/` using one file per advisory:
+
+**Filename:** `security/YYYY-MM-DD-{slug}.md`
+(slug = CVE ID or kebab-case descriptor, e.g. `cve-2026-12345.md` or `lodash-proto-pollution.md`)
+
+**File format:**
+```markdown
+---
+date: YYYY-MM-DD
+severity: CRITICAL|HIGH|MEDIUM|LOW
+status: active|resolved
+stacks: [node, python, go, rust, elixir, java, dotnet, ruby, c]
+cve: CVE-YYYY-NNNNN
+source: https://...
+---
+# [Package/Component]: [Brief title]
+
+**Affected**: [affected versions]
+**Fix**: [fixed version or workaround — "no fix yet" if none available]
+**Summary**: [1–2 sentences maximum]
+```
+
+Rules:
+- Keep summaries to 1–2 sentences. No lengthy prose.
+- If no CVE ID exists, write `cve: N/A`.
+- `status` starts as `active`; change to `resolved` once a fix is applied to this project.
+- Skip LOW-severity advisories unless they are directly exploitable in this project's context.
+
+---
+
+## Workflows
+
+### 1 — Daily Scan (default)
+
+1. **Detect stacks**: read `docs/context.md` (Tech Stack table) and check manifest files
+   (`package.json`, `requirements.txt`, `pyproject.toml`, `go.mod`, `Cargo.toml`, `mix.exs`,
+   `pom.xml`, `build.gradle`, `Gemfile`, `*.csproj`).
+2. **Search for advisories** — for each detected stack:
+   - `"[stack] CVE security advisory [YYYY-MM]"` (current and previous month)
+   - Prefer official sources: GitHub Security Advisories, NVD (nvd.nist.gov),
+     OSV (osv.dev), package-registry advisories (npm, PyPI, crates.io, pkg.go.dev).
+3. **Filter**: keep MEDIUM and above; skip anything older than 30 days unless severity is CRITICAL.
+4. **Deduplication**: scan existing `security/*.md` for the same CVE ID or slug — skip duplicates.
+5. **Save**: write new findings using the format above.
+6. **Cleanup**: scan all `security/*.md` — delete files where `status: resolved` AND `date` is older than 7 days.
+   Print: `🗑  Removed N resolved advisories older than 7 days.`
+7. **Report**: print a summary table of new findings (CVE | Severity | Stack | Fix available?).
+
+### 2 — Pre-PR Advisory Check (public repositories only)
+
+Triggered by `/sync` when the remote is public (`gh repo view --json isPrivate -q '.isPrivate'` returns `false`).
+
+Steps:
+1. Scan all `security/*.md` files — no new web search needed.
+2. Collect entries with `status: active` AND `severity: CRITICAL` or `HIGH`.
+3. **If active CRITICAL/HIGH entries exist**: print a warning table and ask the user whether to proceed or resolve first.
+
+   ```
+   ⚠  SECURITY ADVISORY — unresolved issues found before PR
+   ──────────────────────────────────────────────────────
+   CVE               Severity  Stack   Summary
+   CVE-2026-XXXXX    HIGH      node    ...
+   ──────────────────────────────────────────────────────
+   Options:
+     [1] Proceed with PR anyway (issues noted in PR description)
+     [2] Stop — I will resolve these first, then re-run /sync
+   ```
+
+   Wait for the user's choice. **Do not hard-block** — the user decides.
+
+4. **If only MEDIUM/LOW entries or none**: print `✅ Security check passed — no active CRITICAL/HIGH advisories.` and proceed.
+
+### 3 — Post-Scaffold Scan
+
+Same as Workflow 1 but:
+- Focus on the stacks detected during `setup.sh` / `setup.ps1` execution.
+- Extend the lookback window to 90 days for a fresh baseline.
+- After saving, print findings and note that the user can run `/security-check` any time for updates.
+
+---
+
+## Hard Rules
+
+- **Never delete `active` entries** regardless of age.
+- **Never fabricate CVE IDs** — only report advisories found via web search with a verifiable source URL.
+- **Always cite the source URL** for every advisory saved.
+- If web search is unavailable, print: `⚠  Web search unavailable — security scan skipped. Run /security-check when connectivity is restored.`
+
+---
+
+## Dispatch Rules
+
+| Task | Parallelizable | Write allowed? |
+|------|:--------------:|:--------------:|
+| Stack detection (file scan) | ✅ | ❌ |
+| Web search per stack | ✅ | ❌ |
+| Save findings to security/ | ❌ Serial | ✅ |
+| Cleanup of resolved entries | ❌ After save | ✅ |
+| Pre-PR advisory scan (read-only) | ✅ | ❌ |

--- a/templates/security/README.md
+++ b/templates/security/README.md
@@ -1,0 +1,49 @@
+# security/
+
+This folder contains active security advisories for this project's tech stacks,
+managed automatically by the `security-monitor` agent.
+
+## File naming
+
+```
+YYYY-MM-DD-{slug}.md
+```
+
+Where `slug` is the CVE ID (e.g. `cve-2026-12345`) or a kebab-case descriptor
+(e.g. `lodash-prototype-pollution`).
+
+## File format
+
+```markdown
+---
+date: YYYY-MM-DD
+severity: CRITICAL|HIGH|MEDIUM|LOW
+status: active|resolved
+stacks: [node, python, go, ...]
+cve: CVE-YYYY-NNNNN
+source: https://...
+---
+# Package: Brief title
+
+**Affected**: versions  
+**Fix**: fixed version or workaround  
+**Summary**: 1–2 sentences.
+```
+
+## Lifecycle
+
+| State | Meaning | Auto-deleted? |
+|-------|---------|:-------------:|
+| `active` | Not yet patched in this project | ❌ Never |
+| `resolved` | Patched or mitigated | ✅ After 7 days |
+
+## Manual actions
+
+- **Mark as resolved**: change `status: active` → `status: resolved` in the file header.
+  The agent will delete it automatically after 7 days.
+- **Run a manual scan**: `/security-check` in Claude Code.
+- **Run daily (scheduled)**: set up once with `/security-check --schedule`.
+
+## Agent reference
+
+Full behavior: [`agents/security-monitor.md`](../agents/security-monitor.md)


### PR DESCRIPTION
## Summary

- **`agents/security-monitor.md`** (NEW): daily CVE/advisory scanner for project stacks — detects stacks from manifests + `docs/context.md`, web-searches official sources (NVD, OSV, GitHub Security Advisories), saves MEDIUM+ findings to `security/YYYY-MM-DD-{slug}.md`, auto-deletes `status: resolved` entries older than 7 days
- **`security/README.md`** (NEW): advisory file format, lifecycle table, and manual action guide
- **`/security-check` command** (NEW): on-demand scan (`/security-check`) or pre-PR advisory mode (`/security-check --pr`)
- **`/sync` updated**: before PR creation on public repos, runs `/security-check --pr` — presents active CRITICAL/HIGH advisories and **asks the user whether to proceed or stop** (advisory only, no hard block)
- **New project scaffold**: step 10 prints a security baseline notice with `/security-check` instructions
- **`templates/AGENTS.md`**: security-monitor added to roster (🔴 Security/Setup group) and dispatch table

## Design trade-offs

| Decision | Reason |
|----------|---------|
| Advisory warning, not hard block on PR | Avoid blocking trivial commits; user retains final control |
| No auto-scheduling (CronCreate removed) | OS-level schedulers are more reliable; instructions provided in `/security-check` |
| `security/` folder per project, not workspace-wide | Advisories are stack-specific; each project has its own set |
| Workspace-root `/sync` unchanged | Workspace root has no `security/` folder; gate is irrelevant there |

## Test plan

- [ ] Read `templates/agents/security-monitor.md` — confirm 3 workflows, cleanup rule, and "no hard block" advisory behavior
- [ ] Read `templates/.claude/commands/security-check.md` — confirm `--pr` flag behavior and OS schedule instructions
- [ ] Read `templates/.claude/commands/sync.md` — confirm security check is advisory, not blocking
- [ ] Read `templates/security/README.md` — confirm file format and lifecycle table
- [ ] Verify `templates/AGENTS.md` has security-monitor in both roster and dispatch table
- [ ] `bash scripts/audit.sh` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)