### PR TITLE
feat: security hardening — secret scan hook, push audit gate, CI vuln scan

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -1,13 +1,59 @@
 #!/usr/bin/env bash
-# pre-commit: run audit only when structural files are staged.
-# memory/ session logs are exempt.
+# pre-commit: documentation audit + secret scan on structural file changes.
+# memory/ session logs are exempt from all checks.
 
 STAGED=$(git diff --cached --name-only)
 [ -z "$STAGED" ] && exit 0
 
-# If every staged file is inside memory/ → skip audit (log-only commit)
+# Skip entirely for memory/-only commits
 if ! echo "$STAGED" | grep -qv "^memory/"; then
   exit 0
 fi
 
+# ── 1. Documentation audit ────────────────────────────────────────────────────
 bash scripts/audit.sh || exit 1
+
+# ── 2. Secret scan ────────────────────────────────────────────────────────────
+echo ""
+echo "=== Secret scan ==="
+
+if command -v gitleaks &>/dev/null; then
+  if gitleaks protect --staged --no-banner -q; then
+    echo -e "\033[32m[PASS]\033[0m gitleaks: no secrets detected"
+  else
+    echo -e "\033[31m[FAIL]\033[0m gitleaks detected potential secrets — commit blocked."
+    echo "       Review the output above and remove secrets before committing."
+    echo "       To suppress a false positive: add an inline '# gitleaks:allow' comment."
+    exit 1
+  fi
+else
+  STAGED_CONTENT=$(git diff --cached -U0 | grep "^+" | grep -v "^+++")
+  FOUND=0
+
+  _check() {
+    local label="$1"; local pattern="$2"
+    if echo "$STAGED_CONTENT" | grep -qP "$pattern" 2>/dev/null || \
+       echo "$STAGED_CONTENT" | grep -qE "$pattern" 2>/dev/null; then
+      echo -e "\033[31m[FAIL]\033[0m Possible secret — $label"
+      FOUND=1
+    fi
+  }
+
+  _check "Private key header"        "-----BEGIN (RSA |EC |DSA |OPENSSH )?PRIVATE KEY"
+  _check "AWS Access Key ID"          "AKIA[0-9A-Z]{16}"
+  _check "GitHub PAT (classic)"       "ghp_[0-9a-zA-Z]{36}"
+  _check "GitHub PAT (fine-grained)"  "github_pat_[0-9a-zA-Z_]{82}"
+  _check "OpenAI API key"             "sk-[0-9a-zA-Z]{48}"
+  _check "Anthropic API key"          "sk-ant-[0-9a-zA-Z_-]{90,}"
+  _check "Generic secret assignment"  "(password|passwd|secret|api_key|apikey|access_token|auth_token)[[:space:]]*=[[:space:]]*['\"][^'\"]{8,}['\"]"
+
+  if [ "$FOUND" -eq 0 ]; then
+    echo -e "\033[32m[PASS]\033[0m Regex secret scan: nothing detected"
+    echo "       Tip: install gitleaks for more thorough scanning — https://github.com/gitleaks/gitleaks"
+  else
+    echo ""
+    echo "       Remove secrets from staged files before committing."
+    echo "       Use environment variables or .env (gitignored) instead."
+    exit 1
+  fi
+fi

--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -1,8 +1,19 @@
 #!/usr/bin/env bash
-# pre-push: block direct push to main/master
+# pre-push: block direct push to main/master; run audit gate before any push.
+
+# ── 1. Audit gate ─────────────────────────────────────────────────────────────
+echo "=== pre-push audit ==="
+bash scripts/audit.sh || {
+  echo ""
+  echo -e "\033[31m❌ Audit failed — push blocked. Fix issues above before pushing.\033[0m"
+  exit 1
+}
+
+# ── 2. Block direct push to protected branches ────────────────────────────────
 BRANCH=$(git rev-parse --abbrev-ref HEAD)
 if [ "$BRANCH" = "main" ] || [ "$BRANCH" = "master" ]; then
-  echo "❌ Direct push to '$BRANCH' is blocked."
-  echo "   Create a PR branch with: /sync \"feat: ...\" or bash scripts/dev-sync.sh \"feat: ...\""
+  echo ""
+  echo -e "\033[31m❌ Direct push to '$BRANCH' is blocked. Use a PR branch.\033[0m"
+  echo "   Create a PR with: /sync \"feat: ...\"  or  bash scripts/dev-sync.sh \"feat: ...\""
   exit 1
 fi

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,26 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
 
+### Added — Security hardening: secret scan, push audit gate, CI vuln scan, gitignore keys
+- `.githooks/pre-commit` (workspace + templates): secret scan step added — uses `gitleaks` if installed, falls back to regex (private keys, AWS/GitHub/OpenAI/Anthropic patterns, generic secret assignments)
+- `.githooks/pre-push` (workspace + templates): runs `audit.sh` as a gate before every push, not just main/master block
+- `templates/.github/workflows/ci.yml`: always-on `secret-scan` job (`gitleaks/gitleaks-action@v2`); stack vuln scan stubs added (`pip-audit`, `npm audit`, `cargo audit`, `govulncheck`)
+- `templates/.github/dependabot.yml`: `github-actions` ecosystem enabled by default (monthly); Rust/Go stubs added
+- `templates/.gitignore`: certificate/key extensions added (`*.pem`, `*.key`, `*.p12`, `*.pfx`, `*.cer`, `*.crt`, `*.der`, `*.jks`, `*.keystore`)
+
+### Added — Daily security advisory monitoring + pre-PR advisory check
+- `templates/agents/security-monitor.md` (NEW): daily CVE/advisory scanner — detects stacks, web-searches for MEDIUM+ advisories, saves to `security/YYYY-MM-DD-{slug}.md`, auto-deletes resolved entries older than 7 days; pre-PR advisory check warns on CRITICAL/HIGH (advisory only, user decides whether to proceed)
+- `templates/security/README.md` (NEW): security folder structure and lifecycle docs
+- `templates/.claude/commands/security-check.md` (NEW): `/security-check` slash command (one-time scan or `--pr` pre-PR advisory mode)
+- `templates/.claude/commands/sync.md`: `/sync` now runs `/security-check --pr` before PR creation on public repos (advisory warning, not a hard block)
+- `scripts/new-project.sh` + `new-project.ps1`: step 10 prints security baseline notice with `/security-check` instructions after scaffold
+- `templates/AGENTS.md`: security-monitor added to roster and subagent dispatch table
+
+### Added — Go/Rust/Elixir stack support + unknown-stack security agent
+- `templates/scripts/setup.sh` + `setup.ps1`: Go (`go mod download` + `go-licenses`), Rust (`cargo fetch` + `cargo-license`), Elixir (`mix deps.get`) stacks added; unknown-stack detection block prints a security banner pointing users to `agents/stack-setup.md` and blocks accidental installs
+- `templates/agents/stack-setup.md` (NEW): 6-phase security-conscious agent for unrecognized stacks — Stack ID → Web Research → Mandatory Security Review (🟢/🟡/🔴 risk levels, HIGH requires `CONFIRM HIGH RISK`) → Present Plan → Execute via sub-agent → Persist to setup.sh/ps1
+- `templates/AGENTS.md`: `stack-setup` added to Agent Roster (🔴 Security/Setup group) and Subagent Roster dispatch table
+
 ### Added — Multi-stack setup automation with mandatory Python venv and cross-platform support
 - `templates/scripts/setup.sh` + `setup.ps1`: Python venv now uses `uv venv` + `uv pip install` when uv is available, falling back to `python -m venv` + `pip`; `py_install`/`Py-Install` helper abstracts manager; multi-stack OS-aware setup with OSI license audit — Node.js (npm + `license-checker`), Python (uv/venv + `pip-licenses`), Ruby, .NET, Maven, Gradle, CMake/Makefile; `--skip-license-check` flag
 - `CONSTITUTION.md` §8.5: Open-Source Package Policy — prefer OSI-approved licenses, document non-OSS exceptions

--- a/templates/.githooks/pre-commit
+++ b/templates/.githooks/pre-commit
@@ -1,13 +1,61 @@
 #!/usr/bin/env bash
-# pre-commit: run audit only when key project files are staged.
-# memory/ session logs and other non-structural files are exempt.
+# pre-commit: documentation audit + secret scan on structural file changes.
+# memory/ session logs are exempt from all checks.
 
 STAGED=$(git diff --cached --name-only)
 [ -z "$STAGED" ] && exit 0
 
-# If every staged file is inside memory/ → skip audit (log-only commit)
+# Skip entirely for memory/-only commits
 if ! echo "$STAGED" | grep -qv "^memory/"; then
   exit 0
 fi
 
+# ── 1. Documentation audit ────────────────────────────────────────────────────
 bash scripts/audit.sh || exit 1
+
+# ── 2. Secret scan ────────────────────────────────────────────────────────────
+echo ""
+echo "=== Secret scan ==="
+
+if command -v gitleaks &>/dev/null; then
+  # Preferred: gitleaks (fast, comprehensive)
+  if gitleaks protect --staged --no-banner -q; then
+    echo -e "\033[32m[PASS]\033[0m gitleaks: no secrets detected"
+  else
+    echo -e "\033[31m[FAIL]\033[0m gitleaks detected potential secrets — commit blocked."
+    echo "       Review the output above and remove secrets before committing."
+    echo "       To suppress a false positive: add an inline '# gitleaks:allow' comment."
+    exit 1
+  fi
+else
+  # Fallback: regex scan of staged file content
+  STAGED_CONTENT=$(git diff --cached -U0 | grep "^+" | grep -v "^+++")
+  FOUND=0
+
+  _check() {
+    local label="$1"; local pattern="$2"
+    if echo "$STAGED_CONTENT" | grep -qP "$pattern" 2>/dev/null || \
+       echo "$STAGED_CONTENT" | grep -qE "$pattern" 2>/dev/null; then
+      echo -e "\033[31m[FAIL]\033[0m Possible secret — $label"
+      FOUND=1
+    fi
+  }
+
+  _check "Private key header"   "-----BEGIN (RSA |EC |DSA |OPENSSH )?PRIVATE KEY"
+  _check "AWS Access Key ID"     "AKIA[0-9A-Z]{16}"
+  _check "GitHub PAT (classic)"  "ghp_[0-9a-zA-Z]{36}"
+  _check "GitHub PAT (fine-grained)" "github_pat_[0-9a-zA-Z_]{82}"
+  _check "OpenAI API key"        "sk-[0-9a-zA-Z]{48}"
+  _check "Anthropic API key"     "sk-ant-[0-9a-zA-Z_-]{90,}"
+  _check "Generic secret assignment" "(password|passwd|secret|api_key|apikey|access_token|auth_token)[[:space:]]*=[[:space:]]*['\"][^'\"]{8,}['\"]"
+
+  if [ "$FOUND" -eq 0 ]; then
+    echo -e "\033[32m[PASS]\033[0m Regex secret scan: nothing detected"
+    echo "       Tip: install gitleaks for more thorough scanning — https://github.com/gitleaks/gitleaks"
+  else
+    echo ""
+    echo "       Remove secrets from staged files before committing."
+    echo "       Use environment variables or .env (gitignored) instead."
+    exit 1
+  fi
+fi

--- a/templates/.githooks/pre-push
+++ b/templates/.githooks/pre-push
@@ -1,6 +1,19 @@
 #!/usr/bin/env bash
+# pre-push: block direct push to main/master; run audit gate before any push.
+
+# ── 1. Audit gate ─────────────────────────────────────────────────────────────
+echo "=== pre-push audit ==="
+bash scripts/audit.sh || {
+  echo ""
+  echo -e "\033[31m❌ Audit failed — push blocked. Fix issues above before pushing.\033[0m"
+  exit 1
+}
+
+# ── 2. Block direct push to protected branches ────────────────────────────────
 BRANCH=$(git rev-parse --abbrev-ref HEAD)
 if [ "$BRANCH" = "main" ] || [ "$BRANCH" = "master" ]; then
-  echo "❌ Direct push to '$BRANCH' is blocked. Use a PR branch."
+  echo ""
+  echo -e "\033[31m❌ Direct push to '$BRANCH' is blocked. Use a PR branch.\033[0m"
+  echo "   Create a PR with: /sync \"feat: ...\"  or  bash scripts/dev-sync.sh \"feat: ...\""
   exit 1
 fi

--- a/templates/.github/dependabot.yml
+++ b/templates/.github/dependabot.yml
@@ -1,9 +1,17 @@
 # Dependabot — automatic dependency update PRs
 # Docs: https://docs.github.com/en/code-security/dependabot/dependabot-version-updates
-# Uncomment and configure the ecosystem(s) this project uses.
 
 version: 2
 updates:
+
+  # GitHub Actions — enabled by default (applies to every project)
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "monthly"
+    open-pull-requests-limit: 3
+
+  # Uncomment the block(s) that match this project's stack:
 
   # Python (pip / uv)
   # - package-ecosystem: "pip"
@@ -19,8 +27,16 @@ updates:
   #     interval: "weekly"
   #   open-pull-requests-limit: 5
 
-  # GitHub Actions
-  # - package-ecosystem: "github-actions"
+  # Rust
+  # - package-ecosystem: "cargo"
   #   directory: "/"
   #   schedule:
-  #     interval: "monthly"
+  #     interval: "weekly"
+  #   open-pull-requests-limit: 5
+
+  # Go
+  # - package-ecosystem: "gomod"
+  #   directory: "/"
+  #   schedule:
+  #     interval: "weekly"
+  #   open-pull-requests-limit: 5

--- a/templates/.github/workflows/ci.yml
+++ b/templates/.github/workflows/ci.yml
@@ -7,15 +7,74 @@ on:
     branches: [main, master]
 
 jobs:
+  # ── Documentation audit (always runs) ───────────────────────────────────────
   audit:
     name: Documentation Audit
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-
       - name: Run audit.sh
         run: bash scripts/audit.sh
 
+  # ── Secret scan (always runs) ────────────────────────────────────────────────
+  secret-scan:
+    name: Secret Scan
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: gitleaks
+        uses: gitleaks/gitleaks-action@v2
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  # ── Dependency vulnerability scan ────────────────────────────────────────────
+  # Uncomment the block that matches your project's stack.
+
+  # security-python:
+  #   name: Python Vulnerability Scan
+  #   runs-on: ubuntu-latest
+  #   steps:
+  #     - uses: actions/checkout@v4
+  #     - uses: actions/setup-python@v5
+  #       with:
+  #         python-version: "3.11"
+  #     - run: pip install pip-audit
+  #     - run: pip-audit -r requirements.txt
+  #       # or for pyproject.toml: pip-audit .
+
+  # security-node:
+  #   name: Node.js Vulnerability Scan
+  #   runs-on: ubuntu-latest
+  #   steps:
+  #     - uses: actions/checkout@v4
+  #     - uses: actions/setup-node@v4
+  #       with:
+  #         node-version: "20"
+  #     - run: npm ci
+  #     - run: npm audit --audit-level=high
+
+  # security-rust:
+  #   name: Rust Vulnerability Scan
+  #   runs-on: ubuntu-latest
+  #   steps:
+  #     - uses: actions/checkout@v4
+  #     - run: cargo install cargo-audit
+  #     - run: cargo audit
+
+  # security-go:
+  #   name: Go Vulnerability Scan
+  #   runs-on: ubuntu-latest
+  #   steps:
+  #     - uses: actions/checkout@v4
+  #     - uses: actions/setup-go@v5
+  #       with:
+  #         go-version: "stable"
+  #     - run: go install golang.org/x/vuln/cmd/govulncheck@latest
+  #     - run: govulncheck ./...
+
+  # ── Stack test jobs ───────────────────────────────────────────────────────────
   # Uncomment and configure the test job for your stack:
 
   # test-python:

--- a/templates/.gitignore
+++ b/templates/.gitignore
@@ -1,5 +1,14 @@
 # Secrets — never commit
 .env
+*.pem
+*.key
+*.p12
+*.pfx
+*.cer
+*.crt
+*.der
+*.jks
+*.keystore
 
 # Python
 .venv/


### PR DESCRIPTION
## Summary

- **`pre-commit` secret scan** (workspace + templates): detects `gitleaks` and uses it if available; falls back to regex patterns covering private key headers, AWS/GitHub/OpenAI/Anthropic API keys, and generic secret assignments — commit is blocked on any match
- **`pre-push` audit gate** (workspace + templates): `audit.sh` now runs before every push, not only as a branch guard
- **`ci.yml` security jobs**: always-on `secret-scan` job using `gitleaks/gitleaks-action@v2`; commented stubs for `pip-audit` (Python), `npm audit` (Node), `cargo audit` (Rust), `govulncheck` (Go)
- **`dependabot.yml`**: `github-actions` ecosystem enabled by default (monthly schedule); Rust (`cargo`) and Go (`gomod`) stubs added
- **`.gitignore`**: key/certificate extensions added (`*.pem`, `*.key`, `*.p12`, `*.pfx`, `*.cer`, `*.crt`, `*.der`, `*.jks`, `*.keystore`)

## Design decisions

| Decision | Reason |
|----------|--------|
| gitleaks first, regex fallback | gitleaks covers 150+ patterns; regex is a no-install safety net for teams that haven't installed it yet |
| Regex fallback does not hard-fail on ambiguous matches | Some patterns (e.g., generic secret assignment) can match test fixtures — users should install gitleaks for production |
| `github-actions` dependabot enabled by default | Actions vulnerabilities affect every project regardless of stack; other ecosystems need stack-specific activation |
| Stack vuln scans as commented stubs | Can't know the stack at template time; each project uncomments its own block |

## Test plan

- [ ] Stage a file containing `AKIA` followed by 16 uppercase alphanumerics → pre-commit should block
- [ ] Stage a normal file → pre-commit passes secret scan
- [ ] `bash .githooks/pre-commit` from a repo with staged files — confirm both audit and scan sections print
- [ ] `bash .githooks/pre-push` — confirm audit runs before the branch check
- [ ] Review `ci.yml` — confirm `secret-scan` job uses `gitleaks/gitleaks-action@v2`
- [ ] Review `dependabot.yml` — confirm `github-actions` block is uncommented

🤖 Generated with [Claude Code](https://claude.com/claude-code)