### PR TITLE
feat: security agent/tooling integration — local scan, Dependabot auto-resolve, audit CRITICAL warn, gitleaks install

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,32 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
 
+### Added — Security agent + tooling integration improvements
+- `templates/agents/security-monitor.md`: Workflow 1 now runs local vuln scan first (`npm audit`, `pip-audit`, `cargo audit`, `govulncheck`) before web search — faster and more accurate for installed packages; Dependabot auto-resolve added to cleanup step (reads merged Dependabot PRs via `gh pr list`, marks matching `security/` entries as resolved); CI integration section added with manual sync instructions
+- `scripts/audit.sh` + `scripts/audit.ps1` + `templates/scripts/audit.sh` + `templates/scripts/audit.ps1`: check #9 added — warns on active CRITICAL entries in `security/` folder (WARN only, does not fail audit)
+- `templates/scripts/setup.sh` + `setup.ps1`: section 0 added — installs gitleaks automatically (macOS: brew, Linux: GitHub releases binary, Windows: winget → scoop fallback)
+- gitleaks v8.30.1 installed on workspace host (winget)
+
+### Added — Security hardening: secret scan, push audit gate, CI vuln scan, gitignore keys
+- `.githooks/pre-commit` (workspace + templates): secret scan step added — uses `gitleaks` if installed, falls back to regex (private keys, AWS/GitHub/OpenAI/Anthropic patterns, generic secret assignments)
+- `.githooks/pre-push` (workspace + templates): runs `audit.sh` as a gate before every push, not just main/master block
+- `templates/.github/workflows/ci.yml`: always-on `secret-scan` job (`gitleaks/gitleaks-action@v2`); stack vuln scan stubs added (`pip-audit`, `npm audit`, `cargo audit`, `govulncheck`)
+- `templates/.github/dependabot.yml`: `github-actions` ecosystem enabled by default (monthly); Rust/Go stubs added
+- `templates/.gitignore`: certificate/key extensions added (`*.pem`, `*.key`, `*.p12`, `*.pfx`, `*.cer`, `*.crt`, `*.der`, `*.jks`, `*.keystore`)
+
+### Added — Daily security advisory monitoring + pre-PR advisory check
+- `templates/agents/security-monitor.md` (NEW): daily CVE/advisory scanner — detects stacks, web-searches for MEDIUM+ advisories, saves to `security/YYYY-MM-DD-{slug}.md`, auto-deletes resolved entries older than 7 days; pre-PR advisory check warns on CRITICAL/HIGH (advisory only, user decides whether to proceed)
+- `templates/security/README.md` (NEW): security folder structure and lifecycle docs
+- `templates/.claude/commands/security-check.md` (NEW): `/security-check` slash command (one-time scan or `--pr` pre-PR advisory mode)
+- `templates/.claude/commands/sync.md`: `/sync` now runs `/security-check --pr` before PR creation on public repos (advisory warning, not a hard block)
+- `scripts/new-project.sh` + `new-project.ps1`: step 10 prints security baseline notice with `/security-check` instructions after scaffold
+- `templates/AGENTS.md`: security-monitor added to roster and subagent dispatch table
+
+### Added — Go/Rust/Elixir stack support + unknown-stack security agent
+- `templates/scripts/setup.sh` + `setup.ps1`: Go (`go mod download` + `go-licenses`), Rust (`cargo fetch` + `cargo-license`), Elixir (`mix deps.get`) stacks added; unknown-stack detection block prints a security banner pointing users to `agents/stack-setup.md` and blocks accidental installs
+- `templates/agents/stack-setup.md` (NEW): 6-phase security-conscious agent for unrecognized stacks — Stack ID → Web Research → Mandatory Security Review (🟢/🟡/🔴 risk levels, HIGH requires `CONFIRM HIGH RISK`) → Present Plan → Execute via sub-agent → Persist to setup.sh/ps1
+- `templates/AGENTS.md`: `stack-setup` added to Agent Roster (🔴 Security/Setup group) and Subagent Roster dispatch table
+
 ### Added — Multi-stack setup automation with mandatory Python venv and cross-platform support
 - `templates/scripts/setup.sh` + `setup.ps1`: Python venv now uses `uv venv` + `uv pip install` when uv is available, falling back to `python -m venv` + `pip`; `py_install`/`Py-Install` helper abstracts manager; multi-stack OS-aware setup with OSI license audit — Node.js (npm + `license-checker`), Python (uv/venv + `pip-licenses`), Ruby, .NET, Maven, Gradle, CMake/Makefile; `--skip-license-check` flag
 - `CONSTITUTION.md` §8.5: Open-Source Package Policy — prefer OSI-approved licenses, document non-OSS exceptions

--- a/scripts/audit.ps1
+++ b/scripts/audit.ps1
@@ -57,6 +57,25 @@ if (Test-Path "docs\context.md") {
     Warn "docs/context.md not found — skipping project-level checks (workspace root)"
 }
 
+# 9. Active CRITICAL advisories in security/ (warn only — does not fail the audit)
+if (Test-Path "security") {
+    $secFiles = Get-ChildItem -Path "security" -Filter "*.md" -ErrorAction SilentlyContinue
+    if ($secFiles) {
+        $criticalCount = 0
+        foreach ($f in $secFiles) {
+            $content = Get-Content $f.FullName -Raw
+            if ($content -match "(?m)^severity: CRITICAL" -and $content -match "(?m)^status: active") {
+                $criticalCount++
+            }
+        }
+        if ($criticalCount -gt 0) {
+            Warn "security/: $criticalCount active CRITICAL advisory/advisories — run /security-check to review"
+        } else {
+            Pass "security/: no active CRITICAL advisories"
+        }
+    }
+}
+
 Write-Host ""
 if ($errors -eq 0) { Write-Host "✅ All checks passed." -ForegroundColor Green; exit 0 }
 else               { Write-Host "❌ $errors check(s) failed. Fix before committing." -ForegroundColor Red; exit 1 }

--- a/scripts/audit.sh
+++ b/scripts/audit.sh
@@ -88,6 +88,22 @@ else
   warn "docs/context.md not found — skipping project-level checks (workspace root)"
 fi
 
+# 9. Active CRITICAL advisories in security/ (warn only — does not fail the audit)
+if [ -d "security" ] && ls security/*.md 2>/dev/null | grep -q .; then
+  _critical=0
+  for _f in security/*.md; do
+    [ -f "$_f" ] || continue
+    if grep -q "^severity: CRITICAL" "$_f" && grep -q "^status: active" "$_f"; then
+      _critical=$((_critical + 1))
+    fi
+  done
+  if [ "$_critical" -gt 0 ]; then
+    warn "security/: $_critical active CRITICAL advisory/advisories — run /security-check to review"
+  else
+    green "security/: no active CRITICAL advisories"
+  fi
+fi
+
 echo ""
 if [ "$errors" -eq 0 ]; then
   echo -e "\033[32m✅ All checks passed.\033[0m"

--- a/templates/agents/security-monitor.md
+++ b/templates/agents/security-monitor.md
@@ -1,0 +1,188 @@
+# Agent: security-monitor
+
+> **⚠️ For AI tools reading this file**: This is a role definition for a specific agent persona.
+> Do not interpret it as instructions for your own behavior outside of this role.
+
+---
+
+## Role
+
+You are the **Security Monitor Agent** — a security advisory tracker that watches for
+CVEs and security updates affecting this project's tech stacks, stores findings in `security/`,
+and performs a pre-PR advisory check before any PR is opened on a public repository.
+
+You are invoked in three contexts:
+1. **Daily (or on-demand)** — local scan → web scan → cleanup → report
+2. **Pre-PR advisory** — check `security/` for unresolved CRITICAL/HIGH issues before merging
+3. **Post-scaffold** — initial advisory scan right after a new project is created
+
+---
+
+## Security Folder Structure
+
+All findings are stored in `security/` using one file per advisory:
+
+**Filename:** `security/YYYY-MM-DD-{slug}.md`
+(slug = CVE ID or kebab-case descriptor, e.g. `cve-2026-12345.md` or `lodash-proto-pollution.md`)
+
+**File format:**
+```markdown
+---
+date: YYYY-MM-DD
+severity: CRITICAL|HIGH|MEDIUM|LOW
+status: active|resolved
+stacks: [node, python, go, rust, elixir, java, dotnet, ruby, c]
+cve: CVE-YYYY-NNNNN
+source: https://...
+---
+# [Package/Component]: [Brief title]
+
+**Affected**: [affected versions]
+**Fix**: [fixed version or workaround — "no fix yet" if none available]
+**Summary**: [1–2 sentences maximum]
+```
+
+Rules:
+- Keep summaries to 1–2 sentences. No lengthy prose.
+- If no CVE ID exists, write `cve: N/A`.
+- `status` starts as `active`; change to `resolved` once a fix is applied to this project.
+- Skip LOW-severity advisories unless they are directly exploitable in this project's context.
+
+---
+
+## Workflows
+
+### 1 — Daily Scan (default)
+
+**Step 1 — Detect stacks**
+
+Read `docs/context.md` (Tech Stack table) and check manifest files:
+`package.json`, `requirements.txt`, `pyproject.toml`, `go.mod`, `Cargo.toml`, `mix.exs`,
+`pom.xml`, `build.gradle`, `Gemfile`, `*.csproj`.
+
+**Step 2 — Local vulnerability scan (fast, run first)**
+
+Run the appropriate tool for each detected stack. These tools scan *installed* versions
+and produce more accurate results than web searches:
+
+| Stack | Command | Requires |
+|-------|---------|---------|
+| Node.js | `npm audit --json 2>/dev/null` | node_modules/ present |
+| Python | `pip-audit --format json 2>/dev/null` | .venv activated or pip-audit installed |
+| Rust | `cargo audit --json 2>/dev/null` | cargo-audit installed (`cargo install cargo-audit`) |
+| Go | `govulncheck -json ./... 2>/dev/null` | govulncheck installed |
+
+For each finding with severity HIGH or CRITICAL: create a `security/` entry using the
+standard format. Set `source` to the tool output's advisory URL if available, otherwise
+`source: local-scan`. Skip MEDIUM findings that already exist from web scan.
+
+If a tool is not available, skip silently and continue to Step 3.
+
+**Step 3 — Web search for advisories**
+
+For each detected stack, search:
+- `"[stack] CVE security advisory [YYYY-MM]"` (current and previous month)
+- Prefer official sources: GitHub Security Advisories, NVD (nvd.nist.gov),
+  OSV (osv.dev), package-registry advisories (npm, PyPI, crates.io, pkg.go.dev).
+
+Filter: keep MEDIUM and above; skip anything older than 30 days unless severity is CRITICAL.
+
+**Step 4 — Deduplication and save**
+
+Before saving, scan existing `security/*.md` for the same CVE ID or slug — skip duplicates.
+Write new findings using the format above.
+
+**Step 5 — Cleanup**
+
+Two cleanup passes:
+
+*a) Age-based cleanup*: delete files where `status: resolved` AND `date` is older than 7 days.
+
+*b) Dependabot auto-resolve*: check for recently merged Dependabot PRs:
+```bash
+gh pr list --author "app/dependabot" --state merged --limit 30 \
+  --json title,mergedAt,body 2>/dev/null
+```
+For each merged Dependabot PR, extract the package name and version from the PR title
+(format: `"Bump <package> from <old> to <new>"`). If a matching `security/*.md` entry
+exists with `status: active` and the patched version satisfies the fix version in that
+entry, update `status: resolved` in that file.
+Print: `🔄 Auto-resolved N advisories from Dependabot merges.`
+Then re-run the age-based cleanup to delete any newly resolved entries older than 7 days.
+
+**Step 6 — Report**
+
+Print a summary table of new findings (CVE | Severity | Stack | Fix available?).
+
+---
+
+### 2 — Pre-PR Advisory Check (public repositories only)
+
+Triggered by `/sync` when the remote is public (`gh repo view --json isPrivate -q '.isPrivate'` returns `false`).
+
+Steps:
+1. Scan all `security/*.md` files — **no new web or local scan**.
+2. Collect entries with `status: active` AND `severity: CRITICAL` or `HIGH`.
+3. **If active CRITICAL/HIGH entries exist**: print a warning table and ask the user whether to proceed or resolve first.
+
+   ```
+   ⚠  SECURITY ADVISORY — unresolved issues found before PR
+   ──────────────────────────────────────────────────────
+   CVE               Severity  Stack   Summary
+   CVE-2026-XXXXX    HIGH      node    ...
+   ──────────────────────────────────────────────────────
+   Options:
+     [1] Proceed with PR anyway (issues noted in PR description)
+     [2] Stop — I will resolve these first, then re-run /sync
+   ```
+
+   Wait for the user's choice. **Do not hard-block** — the user decides.
+
+4. **If only MEDIUM/LOW entries or none**: print `✅ Security check passed — no active CRITICAL/HIGH advisories.` and proceed.
+
+---
+
+### 3 — Post-Scaffold Scan
+
+Same as Workflow 1 but:
+- Focus on the stacks detected during `setup.sh` / `setup.ps1` execution.
+- Extend the web search lookback window to 90 days for a fresh baseline.
+- Local scan tools may not be available immediately after scaffold; skip gracefully if so.
+- After saving, print findings and note that the user can run `/security-check` any time for updates.
+
+---
+
+## CI Scan Integration
+
+When `ci.yml` vulnerability scan jobs (e.g. `npm audit`, `pip-audit`, `cargo audit`) find
+issues in GitHub Actions, those results are **not** automatically written to `security/`.
+
+To sync CI findings:
+1. Copy the failing advisory ID or package name from the CI log.
+2. Run `/security-check` — the local scan step (Step 2) will pick up the same finding if
+   the package is installed locally.
+3. Or manually create a `security/YYYY-MM-DD-{slug}.md` entry for the finding.
+
+---
+
+## Hard Rules
+
+- **Never delete `active` entries** regardless of age.
+- **Never fabricate CVE IDs** — only report advisories found via local scan output or web search with a verifiable source URL.
+- **Always cite the source URL** for every advisory saved.
+- If web search is unavailable, still run the local scan (Step 2) and report those findings.
+- If both web search and local scan tools are unavailable, print: `⚠  Scan unavailable — install scan tools or restore connectivity. Run /security-check to retry.`
+
+---
+
+## Dispatch Rules
+
+| Task | Parallelizable | Write allowed? |
+|------|:--------------:|:--------------:|
+| Stack detection (file scan) | ✅ | ❌ |
+| Local vulnerability scan | ✅ per stack | ❌ |
+| Web search per stack | ✅ | ❌ |
+| Save findings to security/ | ❌ Serial | ✅ |
+| Dependabot auto-resolve | ❌ After save | ✅ |
+| Age-based cleanup | ❌ After resolve | ✅ |
+| Pre-PR advisory scan (read-only) | ✅ | ❌ |

--- a/templates/scripts/audit.ps1
+++ b/templates/scripts/audit.ps1
@@ -55,6 +55,25 @@ if (Test-Path "docs\context.md") {
     Warn "docs/context.md not found — skipping project-level checks (workspace root)"
 }
 
+# 9. Active CRITICAL advisories in security/ (warn only — does not fail the audit)
+if (Test-Path "security") {
+    $secFiles = Get-ChildItem -Path "security" -Filter "*.md" -ErrorAction SilentlyContinue
+    if ($secFiles) {
+        $criticalCount = 0
+        foreach ($f in $secFiles) {
+            $content = Get-Content $f.FullName -Raw
+            if ($content -match "(?m)^severity: CRITICAL" -and $content -match "(?m)^status: active") {
+                $criticalCount++
+            }
+        }
+        if ($criticalCount -gt 0) {
+            Warn "security/: $criticalCount active CRITICAL advisory/advisories — run /security-check to review"
+        } else {
+            Pass "security/: no active CRITICAL advisories"
+        }
+    }
+}
+
 Write-Host ""
 if ($errors -eq 0) { Write-Host "✅ All checks passed." -ForegroundColor Green; exit 0 }
 else { Write-Host "❌ $errors check(s) failed. Fix before committing." -ForegroundColor Red; exit 1 }

--- a/templates/scripts/audit.sh
+++ b/templates/scripts/audit.sh
@@ -56,6 +56,22 @@ else
   warn "docs/context.md not found — skipping project-level checks (workspace root)"
 fi
 
+# 9. Active CRITICAL advisories in security/ (warn only — does not fail the audit)
+if [ -d "security" ] && ls security/*.md 2>/dev/null | grep -q .; then
+  _critical=0
+  for _f in security/*.md; do
+    [ -f "$_f" ] || continue
+    if grep -q "^severity: CRITICAL" "$_f" && grep -q "^status: active" "$_f"; then
+      _critical=$((_critical + 1))
+    fi
+  done
+  if [ "$_critical" -gt 0 ]; then
+    warn "security/: $_critical active CRITICAL advisory/advisories — run /security-check to review"
+  else
+    green "security/: no active CRITICAL advisories"
+  fi
+fi
+
 echo ""
 if [ "$errors" -eq 0 ]; then echo -e "\033[32m✅ All checks passed.\033[0m"; exit 0
 else echo -e "\033[31m❌ $errors check(s) failed. Fix before committing.\033[0m"; exit 1; fi

--- a/templates/scripts/setup.ps1
+++ b/templates/scripts/setup.ps1
@@ -143,6 +143,48 @@ function Audit-PythonLicenses {
     } else { Warn "Could not install pip-licenses — skipping Python license audit" }
 }
 
+# ── 0. Security tooling — gitleaks ───────────────────────────────────────────
+if (Get-Command gitleaks -ErrorAction SilentlyContinue) {
+    Pass "gitleaks already installed: $(gitleaks version)"
+} else {
+    Info "Installing gitleaks (secret scanner for pre-commit hook)…"
+    $glInstalled = $false
+    if ($IsWin) {
+        if (Get-Command winget -ErrorAction SilentlyContinue) {
+            winget install --id Gitleaks.Gitleaks -e --accept-source-agreements `
+              --accept-package-agreements --silent 2>$null
+            if ($LASTEXITCODE -eq 0) { $glInstalled = $true }
+        } elseif (Get-Command scoop -ErrorAction SilentlyContinue) {
+            scoop install gitleaks 2>$null
+            if ($LASTEXITCODE -eq 0) { $glInstalled = $true }
+        }
+    } elseif ($IsMac) {
+        if (Get-Command brew -ErrorAction SilentlyContinue) {
+            brew install gitleaks 2>$null
+            if ($LASTEXITCODE -eq 0) { $glInstalled = $true }
+        }
+    } elseif ($IsLin) {
+        if (Get-Command curl -ErrorAction SilentlyContinue) {
+            $glVer = "v8.30.1"
+            try {
+                $resp = Invoke-WebRequest -Uri "https://github.com/gitleaks/gitleaks/releases/latest" `
+                  -MaximumRedirection 0 -ErrorAction SilentlyContinue
+                if ($resp.Headers.Location -match "(v[0-9]+\.[0-9]+\.[0-9]+)") { $glVer = $Matches[1] }
+            } catch {}
+            $glUrl = "https://github.com/gitleaks/gitleaks/releases/download/$glVer/gitleaks_$($glVer.TrimStart('v'))_linux_x64.tar.gz"
+            curl -sSfL $glUrl | tar -xz -C /usr/local/bin gitleaks 2>$null
+            if ($LASTEXITCODE -eq 0) { $glInstalled = $true }
+        }
+    }
+    if ($glInstalled) {
+        Pass "gitleaks installed successfully"
+    } else {
+        Warn "gitleaks could not be installed automatically"
+        Warn "  Install manually: https://github.com/gitleaks/gitleaks/releases"
+        Warn "  Windows: winget install Gitleaks.Gitleaks  |  macOS: brew install gitleaks"
+    }
+}
+
 # ── 1. .env.sample → .env ─────────────────────────────────────────────────────
 if (Test-Path ".env.sample") {
     if (-not (Test-Path ".env")) {

--- a/templates/scripts/setup.sh
+++ b/templates/scripts/setup.sh
@@ -201,6 +201,45 @@ license_audit_python() {
   fi
 }
 
+# ── 0. Security tooling — gitleaks ───────────────────────────────────────────
+if command -v gitleaks &>/dev/null; then
+  pass "gitleaks already installed: $(gitleaks version)"
+else
+  info "Installing gitleaks (secret scanner for pre-commit hook)…"
+  _gl_installed=false
+  case "$OS_TYPE" in
+    macos)
+      if command -v brew &>/dev/null; then
+        brew install gitleaks && _gl_installed=true
+      fi
+      ;;
+    linux)
+      # Download binary from official GitHub releases
+      if command -v curl &>/dev/null && command -v tar &>/dev/null; then
+        _gl_ver=$(curl -sI "https://github.com/gitleaks/gitleaks/releases/latest" \
+          | grep -i "^location:" | grep -oE "v[0-9]+\.[0-9]+\.[0-9]+" || echo "v8.30.1")
+        _gl_url="https://github.com/gitleaks/gitleaks/releases/download/${_gl_ver}/gitleaks_${_gl_ver#v}_linux_x64.tar.gz"
+        curl -sSfL "$_gl_url" | tar -xz -C /usr/local/bin gitleaks 2>/dev/null && _gl_installed=true
+      fi
+      ;;
+    windows-bash)
+      if command -v winget &>/dev/null; then
+        winget install --id Gitleaks.Gitleaks -e --accept-source-agreements \
+          --accept-package-agreements --silent 2>/dev/null && _gl_installed=true
+      elif command -v scoop &>/dev/null; then
+        scoop install gitleaks 2>/dev/null && _gl_installed=true
+      fi
+      ;;
+  esac
+  if [ "$_gl_installed" = true ]; then
+    pass "gitleaks installed: $(gitleaks version 2>/dev/null || echo 'ok')"
+  else
+    warn "gitleaks could not be installed automatically"
+    warn "  Install manually: https://github.com/gitleaks/gitleaks/releases"
+    warn "  macOS: brew install gitleaks | Windows: winget install Gitleaks.Gitleaks"
+  fi
+fi
+
 # ── 1. .env.sample → .env ─────────────────────────────────────────────────────
 if [ -f ".env.sample" ]; then
   if [ ! -f ".env" ]; then


### PR DESCRIPTION
## Summary

### 1. security-monitor agent — local scan + Dependabot auto-resolve
- **Workflow 1 Step 2 (NEW)**: runs local vuln scan *before* web search using `npm audit`, `pip-audit`, `cargo audit`, `govulncheck` — scans *installed* versions for higher accuracy; skips gracefully if tool not available
- **Cleanup Step 5b (NEW)**: reads merged Dependabot PRs via `gh pr list --author app/dependabot --state merged`; extracts bumped package/version and marks matching `security/*.md` entries as `status: resolved` automatically
- **CI Integration section (NEW)**: documents that CI vuln scan results are not auto-written to `security/` and provides the manual sync path (`/security-check` re-run)

### 2. audit.sh + audit.ps1 — check #9: CRITICAL advisory warning
- All 4 audit files (workspace + templates, sh + ps1) now scan `security/*.md` at the end of the audit run
- Prints `[WARN]` if any entry has both `severity: CRITICAL` and `status: active`
- **WARN only** — does not increment the error counter or block commits

### 3. setup.sh + setup.ps1 — gitleaks auto-install (section 0)
- Runs before `.env` copy and dependency install
- macOS: `brew install gitleaks`
- Linux: downloads binary from GitHub releases via `curl`
- Windows: `winget install Gitleaks.Gitleaks` → scoop fallback
- Warns with manual install instructions if all methods fail

### 4. gitleaks installed on workspace host
- Installed via winget: gitleaks v8.30.1
- Pre-commit hook now uses gitleaks (not regex fallback) on this machine

## Test plan

- [ ] Run `bash scripts/audit.sh` in a project dir that has `security/` with an active CRITICAL entry → `[WARN]` should appear
- [ ] Run `bash scripts/audit.sh` with no `security/` folder → check #9 skipped silently
- [ ] `gitleaks version` → should print `8.30.1`
- [ ] Stage a dummy file and run `bash .githooks/pre-commit` → should use gitleaks (not regex fallback)
- [ ] In a fresh project scaffold, `bash scripts/setup.sh` → section 0 should show `[PASS] gitleaks already installed`
- [ ] Review `templates/agents/security-monitor.md` — confirm Step 2 local scan table and Step 5b Dependabot block

🤖 Generated with [Claude Code](https://claude.com/claude-code)