### PR TITLE
security: fix gitleaks flag and propagate security tooling to all sub-projects

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -29,7 +29,7 @@ _GITLEAKS_CONFIG=""
 
 if command -v gitleaks &>/dev/null; then
   # shellcheck disable=SC2086
-  if gitleaks protect --staged --no-banner -q $_GITLEAKS_CONFIG; then
+  if gitleaks protect --staged --no-banner --log-level error $_GITLEAKS_CONFIG; then
     echo -e "\033[32m[PASS]\033[0m gitleaks: no secrets detected"
   else
     echo -e "\033[31m[FAIL]\033[0m gitleaks detected potential secrets — commit blocked."

--- a/templates/.githooks/pre-commit
+++ b/templates/.githooks/pre-commit
@@ -29,7 +29,7 @@ _GITLEAKS_CONFIG=""
 
 if command -v gitleaks &>/dev/null; then
   # shellcheck disable=SC2086
-  if gitleaks protect --staged --no-banner -q $_GITLEAKS_CONFIG; then
+  if gitleaks protect --staged --no-banner --log-level error $_GITLEAKS_CONFIG; then
     echo -e "\033[32m[PASS]\033[0m gitleaks: no secrets detected"
   else
     echo -e "\033[31m[FAIL]\033[0m gitleaks detected potential secrets — commit blocked."

--- a/templates/AGENTS.md
+++ b/templates/AGENTS.md
@@ -81,6 +81,11 @@ Request received
 ## Harness Engineering Workflow
 
 ```
+Phase 0 — Team Assembly & Skill Orchestration (Kickoff)
+  PM assesses project requirements
+  PM dynamically creates new agents/skills and resolves R&R overlap
+  PM updates AGENTS.md and docs/context.md
+
 Phase 1 — Triage & Analysis
   PM classifies the request
   Dispatch read-only agents in parallel (analysis, research)

--- a/templates/agents/pm.md
+++ b/templates/agents/pm.md
@@ -16,8 +16,12 @@ You are the PM orchestrator for **[Project Name]**. You own the end-to-end workf
 
 ## Governance Workflow
 
-Follow the 6-phase PM workflow defined in [CONSTITUTION.md §5](../../CONSTITUTION.md#5-multi-agent-architecture):
+Follow the 6-phase PM workflow defined in [CONSTITUTION.md §5](../../CONSTITUTION.md#5-multi-agent-architecture), with a preliminary step for dynamic team assembly:
 
+0. **Team Assembly & Skill Orchestration** — During project kickoff, analyze project requirements and assess if the default agent roster or existing skills are sufficient. 
+   - If specialized agents are needed, generate `agents/<name>.md`. Update existing agents' files to prevent role overlap.
+   - If specialized workflows are needed, generate `skills/<name>/SKILL.md` directly (using proper YAML frontmatter) or instruct agents to use `workflow-skill-creator` later for complex tasks.
+   - Update `AGENTS.md` and `docs/context.md` (Session Start Skills) with any new agents or skills.
 1. **Triage** — Classify the request; dispatch read-only agents in parallel (single message).
 2. **Analysis** — Synthesize findings into requirements + acceptance criteria.
 3. **Design** — Dispatch architect (implementation plan + ADR) and, if the task has UI/UX surface, designer (wireframes + component spec) in parallel; obtain explicit user approval before proceeding.

--- a/templates/docs/context.md
+++ b/templates/docs/context.md
@@ -39,6 +39,7 @@
 ## Agents
 <!-- See AGENTS.md at the project root for the full agent index (canonical source). -->
 <!-- Duplicate the table here only as a quick-reference summary for non-CC tools.   -->
+<!-- NOTE: This list may be dynamically expanded by the PM during the Kickoff Phase.-->
 | Group | Agent file | Role |
 |-------|------------|------|
 | Orchestration | `agents/pm.md` | PM orchestrator — owns the workflow, dispatches parallel tasks |
@@ -54,6 +55,7 @@
 
 ## Session Start Skills
 <!-- Skills listed here are loaded at the start of EVERY session by ALL AI tools. -->
+<!-- NOTE: This list may be dynamically expanded by the PM during the Kickoff Phase.-->
 <!-- Format: `skills/<name>/SKILL.md` — reason / trigger                          -->
 <!-- Example: `skills/auth-flow/SKILL.md` — always load when auth-related tasks   -->
 <!-- Add a skill: create skills/<name>/SKILL.md, then add a line below.           -->


### PR DESCRIPTION
## Summary

- Fix `gitleaks protect` flag: `-q`/`--quiet` → `--log-level error` (gitleaks v8.30.1 compatibility)
- Apply fix to both `.githooks/pre-commit` and `templates/.githooks/pre-commit`
- Sync template improvements: AGENTS.md Phase 0 step, pm.md, docs/context.md

## Security improvements applied to all 4 sub-projects

Each of `abap_vibe_coding`, `abap_vibe_coding_plugin`, `Pricing-Mgmt-Simulation`, `quickdl` now has:

| File | Change |
|------|--------|
| `.githooks/pre-commit` | 3-phase: .env block + audit.sh + gitleaks/regex scan |
| `.githooks/pre-push` | Audit gate + block direct push to main/master |
| `.gitleaks.toml` | Allowlist config (placeholders, test files, memory/) |
| `scripts/audit.sh` | +check #9: CRITICAL advisory warn (non-blocking) |
| `scripts/audit.ps1` | +check #9: PowerShell equivalent |
| `.gitignore` | +key/cert (`*.pem`, `*.key`, etc.) + log/tmp/db extensions |
| `agents/security-monitor.md` | Security monitor agent (daily scan + pre-PR check) |
| `.claude/commands/security-check.md` | `/security-check` slash command |
| `.claude/commands/sync.md` | Pre-PR security gate for public repos |
| `security/README.md` | Advisory lifecycle documentation |

## Test Plan

- [x] `bash scripts/audit.sh` passes on workspace root
- [x] Pre-commit hook triggers gitleaks with `--log-level error` (no unknown flag error)
- [x] All 4 sub-projects committed successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)