### PR TITLE
docs: remove obsolete manual PM kickoff instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,11 +58,7 @@ bash scripts/new-project.sh "my-project-name"
 
 Each new project is scaffolded with `docs/context.md`, `AGENTS.md`, `agents/pm.md`, and all required configuration files automatically.
 
-### 4. Multi-Agent Kickoff (Recommended)
 
-Before writing any code, start a PM-led kickoff meeting to plan the architecture and roles.
-Ask your AI assistant:
-> *"Let's start the PM agent kickoff meeting for this project."*
 
 ---
 

--- a/templates/README.md
+++ b/templates/README.md
@@ -25,9 +25,6 @@ cp .env.sample .env   # fill in values
 # Python:  python -m venv .venv && source .venv/bin/activate && pip install -r requirements.txt
 # Node.js: npm install
 
-# 4. Multi-Agent Kickoff (Recommended)
-# Before writing code, ask the AI to start a PM-led kickoff meeting:
-# "Let's start the PM agent kickoff meeting for this project."
 ```
 
 ## Documentation

--- a/templates/README_ko.md
+++ b/templates/README_ko.md
@@ -25,9 +25,6 @@ cp .env.sample .env   # 환경 변수 값 입력
 # Python:  python -m venv .venv && source .venv/bin/activate && pip install -r requirements.txt
 # Node.js: npm install
 
-# 4. 멀티에이전트 킥오프 회의 (권장)
-# 코드를 작성하기 전에 AI에게 다음 명령을 내려 PM 에이전트 주관의 기획 회의를 시작하세요:
-# "이 프로젝트를 위한 PM 에이전트 킥오프 회의를 시작해 줘."
 ```
 
 ## 핵심 문서


### PR DESCRIPTION
Removes the legacy 'Multi-Agent Kickoff' instructions from READMEs since the PM agent is now automatically invoked in the background via the post-checkout hook.