### PR TITLE
fix: track memory/ logs in git (remove memory/*.md from .gitignore)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -51,3 +51,5 @@ __pycache__/
 !templates/
 !.editorconfig
 !SECURITY.md
+!AGENTS.md
+!memory/

--- a/memory/2026-05-23.md
+++ b/memory/2026-05-23.md
@@ -1,0 +1,19 @@
+## Session ??fix: align markdown files with CONSTITUTION.md standards
+## Session ??chore: update Gemini CLI tool mappings in template
+## Session ??docs: add multi-agent kickoff and security-first scaffold
+## Session — feat: backport security governance and auto-dating hooks
+
+- **Security Governance**: Backported and registered the `security-monitor` agent across `AGENTS.md` and `docs/context.md` in all sub-projects.
+- **Branch Standardization**: Standardized legacy branch names (e.g. `quickdl`) to `main`.
+- **Obsolete Instruction Removal**: Removed obsolete manual PM kickoff instruction text from `README`s.
+- **Pre-commit Automation**: Added Auto-bumper hook to automatically update the `Last Updated:` date in Markdown documents.
+- **CHANGELOG Auto-dating**: Added Perl script to hooks and `dev-sync` to automatically inject `**[YYYY-MM-DD]**` date stamps into CHANGELOG entries, and backfilled existing history.
+## Session ??fix: initialize memory tracking on project creation
+## Session ??docs: clarify tracking management guidelines (CHANGELOG vs. Memory)
+## Session ??feat: dev-sync upgrades for memory and changelog tracking
+
+**Modified Files**:
+-  M scripts/dev-sync.ps1
+-  M scripts/dev-sync.sh
+-  M templates/scripts/dev-sync.ps1
+-  M templates/scripts/dev-sync.sh

--- a/memory/MEMORY.md
+++ b/memory/MEMORY.md
@@ -1,0 +1,11 @@
+﻿# Memory Index
+
+| Date | Summary |
+|------|---------|
+| [2026-05-23](2026-05-23.md) | fix: align markdown files with CONSTITUTION.md standards |
+| [2026-05-23](2026-05-23.md) | chore: update Gemini CLI tool mappings in template |
+| [2026-05-23](2026-05-23.md) | docs: add multi-agent kickoff and security-first scaffold |
+| [2026-05-23](2026-05-23.md) | feat: backport security governance and auto-dating hooks |
+| [2026-05-23](2026-05-23.md) | fix: initialize memory tracking on project creation |
+| [2026-05-23](2026-05-23.md) | docs: clarify tracking management guidelines (CHANGELOG vs. Memory) |
+| [2026-05-23](2026-05-23.md) | feat: dev-sync upgrades for memory and changelog tracking |


### PR DESCRIPTION
Remove `memory/*.md` from `.gitignore` so that memory logs are tracked in GitHub, enabling AI context sharing across sessions.