### PR TITLE
fix: add -Encoding UTF8 to Add-Content in dev-sync.ps1 to prevent em-dash corruption

### DIFF
--- a/memory/2026-05-23.md
+++ b/memory/2026-05-23.md
@@ -1,6 +1,6 @@
-## Session ??fix: align markdown files with CONSTITUTION.md standards
-## Session ??chore: update Gemini CLI tool mappings in template
-## Session ??docs: add multi-agent kickoff and security-first scaffold
+## Session — fix: align markdown files with CONSTITUTION.md standards
+## Session — chore: update Gemini CLI tool mappings in template
+## Session — docs: add multi-agent kickoff and security-first scaffold
 ## Session — feat: backport security governance and auto-dating hooks
 
 - **Security Governance**: Backported and registered the `security-monitor` agent across `AGENTS.md` and `docs/context.md` in all sub-projects.
@@ -8,9 +8,9 @@
 - **Obsolete Instruction Removal**: Removed obsolete manual PM kickoff instruction text from `README`s.
 - **Pre-commit Automation**: Added Auto-bumper hook to automatically update the `Last Updated:` date in Markdown documents.
 - **CHANGELOG Auto-dating**: Added Perl script to hooks and `dev-sync` to automatically inject `**[YYYY-MM-DD]**` date stamps into CHANGELOG entries, and backfilled existing history.
-## Session ??fix: initialize memory tracking on project creation
-## Session ??docs: clarify tracking management guidelines (CHANGELOG vs. Memory)
-## Session ??feat: dev-sync upgrades for memory and changelog tracking
+## Session — fix: initialize memory tracking on project creation
+## Session — docs: clarify tracking management guidelines (CHANGELOG vs. Memory)
+## Session — feat: dev-sync upgrades for memory and changelog tracking
 
 **Modified Files**:
 -  M scripts/dev-sync.ps1

--- a/scripts/dev-sync.ps1
+++ b/scripts/dev-sync.ps1
@@ -6,11 +6,11 @@ $Date = Get-Date -Format "yyyy-MM-dd"
 
 # ── 1. Write daily session log ─────────────────────────────────────────────────
 New-Item -ItemType Directory -Path "memory" -Force | Out-Null
-Add-Content "memory\$Date.md" "## Session — $Msg"
+Add-Content "memory\$Date.md" "## Session — $Msg" -Encoding UTF8
 $GitStatus = git status --short 2>$null
 if ($GitStatus) {
-    Add-Content "memory\$Date.md" "`n**Modified Files**:"
-    $GitStatus | ForEach-Object { Add-Content "memory\$Date.md" "- $_" }
+    Add-Content "memory\$Date.md" "`n**Modified Files**:" -Encoding UTF8
+    $GitStatus | ForEach-Object { Add-Content "memory\$Date.md" "- $_" -Encoding UTF8 }
 }
 
 # ── 2. Update MEMORY.md index ─────────────────────────────────────────────────

--- a/templates/scripts/dev-sync.ps1
+++ b/templates/scripts/dev-sync.ps1
@@ -6,11 +6,11 @@ $Date = Get-Date -Format "yyyy-MM-dd"
 
 # ── 1. Write daily session log ─────────────────────────────────────────────────
 New-Item -ItemType Directory -Path "memory" -Force | Out-Null
-Add-Content "memory\$Date.md" "## Session — $Msg"
+Add-Content "memory\$Date.md" "## Session — $Msg" -Encoding UTF8
 $GitStatus = git status --short 2>$null
 if ($GitStatus) {
-    Add-Content "memory\$Date.md" "`n**Modified Files**:"
-    $GitStatus | ForEach-Object { Add-Content "memory\$Date.md" "- $_" }
+    Add-Content "memory\$Date.md" "`n**Modified Files**:" -Encoding UTF8
+    $GitStatus | ForEach-Object { Add-Content "memory\$Date.md" "- $_" -Encoding UTF8 }
 }
 
 # ── 2. Update MEMORY.md index ─────────────────────────────────────────────────


### PR DESCRIPTION
PowerShell 5.1's `Add-Content` defaults to UTF-16LE encoding, which replaces the em-dash character (U+2014) with `??`. Fixed by adding `-Encoding UTF8` to all `Add-Content` calls in `dev-sync.ps1` and backfilling the corrupted memory log.