### PR TITLE
feat: upgrade dev-sync scripts to use structured memory logs

### DIFF
--- a/scripts/dev-sync.ps1
+++ b/scripts/dev-sync.ps1
@@ -6,12 +6,27 @@ $Date = Get-Date -Format "yyyy-MM-dd"
 
 # ── 1. Write daily session log ─────────────────────────────────────────────────
 New-Item -ItemType Directory -Path "memory" -Force | Out-Null
-Add-Content "memory\$Date.md" "## Session — $Msg" -Encoding UTF8
 $GitStatus = git status --short 2>$null
+$FileList = ""
 if ($GitStatus) {
-    Add-Content "memory\$Date.md" "`n**Modified Files**:" -Encoding UTF8
-    $GitStatus | ForEach-Object { Add-Content "memory\$Date.md" "- $_" -Encoding UTF8 }
+    # Extract just file names, ignoring status codes, and join with commas
+    $FileList = ($GitStatus | ForEach-Object { ($_ -replace '^.{2}\s+', '').Trim() }) -join ", "
 }
+
+# Determine appropriate header: if this file has existing content, add a separator
+$separator = ""
+if (Test-Path "memory\$Date.md") { $separator = "`n---`n`n" }
+
+$template = @"
+$separator## $Msg
+- **Files**: $FileList
+- **Purpose**: 
+- **Decisions**: 
+- **Issues**: None
+"@
+
+Add-Content "memory\$Date.md" $template -Encoding UTF8
+
 
 # ── 2. Update MEMORY.md index ─────────────────────────────────────────────────
 .\scripts\sync-md.ps1 $Date $Msg

--- a/scripts/dev-sync.sh
+++ b/scripts/dev-sync.sh
@@ -8,13 +8,20 @@ DATE=$(date +%Y-%m-%d)
 
 # ── 1. Write daily session log ─────────────────────────────────────────────────
 mkdir -p memory
-echo "## Session — $MSG" >> "memory/$DATE.md"
 GIT_STATUS=$(git status --short 2>/dev/null || true)
+FILE_LIST=""
 if [ -n "$GIT_STATUS" ]; then
-  echo "" >> "memory/$DATE.md"
-  echo "**Modified Files**:" >> "memory/$DATE.md"
-  echo "$GIT_STATUS" | while read -r line; do echo "- $line" >> "memory/$DATE.md"; done
+  # Extract just file names, join with commas
+  FILE_LIST=$(echo "$GIT_STATUS" | sed -E 's/^.{2}[[:space:]]+//' | paste -sd ", " -)
 fi
+
+SEPARATOR=""
+if [ -f "memory/$DATE.md" ]; then
+  SEPARATOR="\n---\n\n"
+fi
+
+printf "${SEPARATOR}## $MSG\n- **Files**: $FILE_LIST\n- **Purpose**: \n- **Decisions**: \n- **Issues**: None\n" >> "memory/$DATE.md"
+
 
 # ── 2. Update MEMORY.md index ─────────────────────────────────────────────────
 bash scripts/sync-md.sh "$DATE" "$MSG"

--- a/templates/scripts/dev-sync.ps1
+++ b/templates/scripts/dev-sync.ps1
@@ -6,12 +6,27 @@ $Date = Get-Date -Format "yyyy-MM-dd"
 
 # ── 1. Write daily session log ─────────────────────────────────────────────────
 New-Item -ItemType Directory -Path "memory" -Force | Out-Null
-Add-Content "memory\$Date.md" "## Session — $Msg" -Encoding UTF8
 $GitStatus = git status --short 2>$null
+$FileList = ""
 if ($GitStatus) {
-    Add-Content "memory\$Date.md" "`n**Modified Files**:" -Encoding UTF8
-    $GitStatus | ForEach-Object { Add-Content "memory\$Date.md" "- $_" -Encoding UTF8 }
+    # Extract just file names, ignoring status codes, and join with commas
+    $FileList = ($GitStatus | ForEach-Object { ($_ -replace '^.{2}\s+', '').Trim() }) -join ", "
 }
+
+# Determine appropriate header: if this file has existing content, add a separator
+$separator = ""
+if (Test-Path "memory\$Date.md") { $separator = "`n---`n`n" }
+
+$template = @"
+$separator## $Msg
+- **Files**: $FileList
+- **Purpose**: 
+- **Decisions**: 
+- **Issues**: None
+"@
+
+Add-Content "memory\$Date.md" $template -Encoding UTF8
+
 
 # ── 2. Update MEMORY.md index ─────────────────────────────────────────────────
 .\scripts\sync-md.ps1 $Date $Msg

--- a/templates/scripts/dev-sync.sh
+++ b/templates/scripts/dev-sync.sh
@@ -8,13 +8,20 @@ DATE=$(date +%Y-%m-%d)
 
 # ── 1. Write daily session log ─────────────────────────────────────────────────
 mkdir -p memory
-echo "## Session — $MSG" >> "memory/$DATE.md"
 GIT_STATUS=$(git status --short 2>/dev/null || true)
+FILE_LIST=""
 if [ -n "$GIT_STATUS" ]; then
-  echo "" >> "memory/$DATE.md"
-  echo "**Modified Files**:" >> "memory/$DATE.md"
-  echo "$GIT_STATUS" | while read -r line; do echo "- $line" >> "memory/$DATE.md"; done
+  # Extract just file names, join with commas
+  FILE_LIST=$(echo "$GIT_STATUS" | sed -E 's/^.{2}[[:space:]]+//' | paste -sd ", " -)
 fi
+
+SEPARATOR=""
+if [ -f "memory/$DATE.md" ]; then
+  SEPARATOR="\n---\n\n"
+fi
+
+printf "${SEPARATOR}## $MSG\n- **Files**: $FILE_LIST\n- **Purpose**: \n- **Decisions**: \n- **Issues**: None\n" >> "memory/$DATE.md"
+
 
 # ── 2. Update MEMORY.md index ─────────────────────────────────────────────────
 bash scripts/sync-md.sh "$DATE" "$MSG"


### PR DESCRIPTION
Upgraded `dev-sync.ps1` and `dev-sync.sh` to output a structured template (Files, Purpose, Decisions, Issues) instead of just appending raw commit messages.