### PR TITLE
docs: standardize SECURITY.md and docs/security.md across projects

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,27 +1,30 @@
-# Security Policy
+﻿# Security Policy
 
 ## Supported Versions
 
-This is a workspace configuration repository. Security concerns apply to the
-configuration files, scripts, and scaffold templates it provides.
+| Version | Supported |
+|---------|-----------|
+| Latest  | ??       |
 
 ## Reporting a Vulnerability
 
-If you discover a security issue in this workspace standard (e.g., a script that
-exposes credentials, a hook bypass, or an unsafe default), please report it privately:
+If you discover a security vulnerability in this project, **do not open a public GitHub issue**.
+
+Instead, please report it privately via one of the following channels:
 
 - **GitHub Security Advisory**: [Report a vulnerability](../../security/advisories/new) *(preferred)*
 - **Email**: Contact [@5throck](https://github.com/5throck) directly via GitHub
 
 ### What to include
 
-- Which file or script is affected
-- How the vulnerability could be exploited
-- Any suggested fix
+- A description of the vulnerability and its potential impact
+- Steps to reproduce the issue
+- Any suggested fixes or mitigations
 
 ### Response timeline
 
 - **Acknowledgement**: within 48 hours
-- **Fix release**: within 14 days for critical issues
+- **Initial assessment**: within 7 days
+- **Patch release**: within 30 days for critical issues
 
-We appreciate responsible disclosure.
+We appreciate responsible disclosure and will credit reporters (unless anonymity is requested).

--- a/templates/SECURITY.md
+++ b/templates/SECURITY.md
@@ -1,10 +1,10 @@
-# Security Policy
+﻿# Security Policy
 
 ## Supported Versions
 
 | Version | Supported |
 |---------|-----------|
-| Latest | ✅ |
+| Latest  | ??       |
 
 ## Reporting a Vulnerability
 
@@ -13,7 +13,7 @@ If you discover a security vulnerability in this project, **do not open a public
 Instead, please report it privately via one of the following channels:
 
 - **GitHub Security Advisory**: [Report a vulnerability](../../security/advisories/new) *(preferred)*
-- **Email**: [your-security-email@example.com] *(replace with actual contact)*
+- **Email**: Contact [@5throck](https://github.com/5throck) directly via GitHub
 
 ### What to include
 

--- a/templates/docs/security.md
+++ b/templates/docs/security.md
@@ -1,0 +1,35 @@
+﻿# security.md
+
+Security policy and data sanitization rules for this project.
+
+> For dev context, architecture, and agent instructions, see [context.md](context.md).
+
+---
+
+## Committed Files ??Never Include
+
+Never commit .env, cookies.txt, .mcp.json, or local agent/MCP config files. 
+Note that only sample configurations containing zero secrets (such as .mcp.json.sample and .env.sample) may be tracked and committed.
+
+---
+
+## Sanitize Policy for Tracked Docs, Tests, and Examples
+
+The public repo must not contain concrete identifiers that tie code or docs to a live production system, a real user, or private infrastructure. 
+
+**Never in tracked files:**
+- Real usernames ??use TESTUSER, dmin
+- Real hostnames or IPs ??use dev.example.local, 127.0.0.1, prod.example.com
+- Real passwords, API keys, bearer tokens, or secrets
+- Proprietary customer names or internal namespaces
+
+**Operational scratch goes under gitignored paths (like scratch/)** ??session notes, live database dumps, repros with real identifiers, debugging transcripts. If you need to reference it from a tracked doc, redact first.
+
+---
+
+## Pre-Commit Scan
+
+Before every commit, always review staged files to ensure no sensitive data is leaking.
+The workspace .githooks/pre-commit hook automatically scans for .env files and runs gitleaks if installed.
+
+Rule of thumb: "would a stranger reading this file be able to identify our private servers, customer identities, or bypass our authentication?" If yes, redact and move under gitignored paths.


### PR DESCRIPTION
Standardized GitHub vulnerability reporting policy (SECURITY.md) and internal data sanitization guidelines (docs/security.md) according to workspace standards.