### PR TITLE
refactor: migrate local relative paths to absolute GitHub URLs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-# Changelog
+﻿# Changelog
 
 All notable changes to this workspace configuration are documented in this file.
 
@@ -15,25 +15,25 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - **[2026-05-23]**: `README.md` / `README_ko.md`: Remove obsolete manual "Multi-Agent Kickoff" instruction text (automated in the background via post-checkout hook).
 
 
-### Added — Go/Rust/Elixir stack support + unknown-stack security agent
+### Added ??Go/Rust/Elixir stack support + unknown-stack security agent
 - **[2026-05-23]**: `templates/scripts/setup.sh` + `setup.ps1`: Go (`go mod download` + `go-licenses`), Rust (`cargo fetch` + `cargo-license`), Elixir (`mix deps.get`) stacks added; unknown-stack detection block prints a security banner pointing users to `agents/stack-setup.md` and blocks accidental installs
-- **[2026-05-23]**: `templates/agents/stack-setup.md` (NEW): 6-phase security-conscious agent for unrecognized stacks — Stack ID → Web Research → Mandatory Security Review (🟢/🟡/🔴 risk levels, HIGH requires `CONFIRM HIGH RISK`) → Present Plan → Execute via sub-agent → Persist to setup.sh/ps1
-- **[2026-05-23]**: `templates/AGENTS.md`: `stack-setup` added to Agent Roster (🔴 Security/Setup group) and Subagent Roster dispatch table
+- **[2026-05-23]**: `templates/agents/stack-setup.md` (NEW): 6-phase security-conscious agent for unrecognized stacks ??Stack ID ??Web Research ??Mandatory Security Review (?윟/?윞/?뵶 risk levels, HIGH requires `CONFIRM HIGH RISK`) ??Present Plan ??Execute via sub-agent ??Persist to setup.sh/ps1
+- **[2026-05-23]**: `templates/AGENTS.md`: `stack-setup` added to Agent Roster (?뵶 Security/Setup group) and Subagent Roster dispatch table
 
-### Added — Multi-stack setup automation with mandatory Python venv and cross-platform support
-- **[2026-05-23]**: `templates/scripts/setup.sh` + `setup.ps1`: Python venv now uses `uv venv` + `uv pip install` when uv is available, falling back to `python -m venv` + `pip`; `py_install`/`Py-Install` helper abstracts manager; multi-stack OS-aware setup with OSI license audit — Node.js (npm + `license-checker`), Python (uv/venv + `pip-licenses`), Ruby, .NET, Maven, Gradle, CMake/Makefile; `--skip-license-check` flag
-- **[2026-05-23]**: `CONSTITUTION.md` §8.5: Open-Source Package Policy — prefer OSI-approved licenses, document non-OSS exceptions
-- **[2026-05-23]**: `templates/docs/context.md`: Coding Guidelines §5 Open-Source Package Policy added
+### Added ??Multi-stack setup automation with mandatory Python venv and cross-platform support
+- **[2026-05-23]**: `templates/scripts/setup.sh` + `setup.ps1`: Python venv now uses `uv venv` + `uv pip install` when uv is available, falling back to `python -m venv` + `pip`; `py_install`/`Py-Install` helper abstracts manager; multi-stack OS-aware setup with OSI license audit ??Node.js (npm + `license-checker`), Python (uv/venv + `pip-licenses`), Ruby, .NET, Maven, Gradle, CMake/Makefile; `--skip-license-check` flag
+- **[2026-05-23]**: `CONSTITUTION.md` 짠8.5: Open-Source Package Policy ??prefer OSI-approved licenses, document non-OSS exceptions
+- **[2026-05-23]**: `templates/docs/context.md`: Coding Guidelines 짠5 Open-Source Package Policy added
 - **[2026-05-23]**: `scripts/new-project.sh` + `new-project.ps1`: step 9 prints directory-change banner with exact `cd <path>` command
 
 
-### Changed — Antigravity 2.0 / Gemini CLI session start config (workspace + templates + 4 sub-projects)
+### Changed ??Antigravity 2.0 / Gemini CLI session start config (workspace + templates + 4 sub-projects)
 
 **`GEMINI.md` (workspace root)**
 - **[2026-05-23]**: Tool mapping expanded with full operational guidance (`StartLine`, `EndLine`, `IsArtifact`, `MatchPerLine`, `NEVER use cd`)
-- **[2026-05-23]**: ⚠️ Multi-replace offset safeguard added (bottom-to-top chunk ordering rule)
-- **[2026-05-23]**: ⚠️ Grep 50-match cap safeguard added (partitioning remediation)
-- **[2026-05-23]**: Planning Mode artifact specifications added (`implementation_plan.md`, `task.md`, `walkthrough.md` — brain/ paths + ArtifactType metadata)
+- **[2026-05-23]**: ?좑툘 Multi-replace offset safeguard added (bottom-to-top chunk ordering rule)
+- **[2026-05-23]**: ?좑툘 Grep 50-match cap safeguard added (partitioning remediation)
+- **[2026-05-23]**: Planning Mode artifact specifications added (`implementation_plan.md`, `task.md`, `walkthrough.md` ??brain/ paths + ArtifactType metadata)
 - **[2026-05-23]**: Subagent orchestration added (`define_subagent`, `invoke_subagent` JSON examples, `send_message`, Reactive Wakeup)
 
 **`CLAUDE.md` (workspace root)**
@@ -43,65 +43,65 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - **[2026-05-23]**: Fully applied identical Antigravity 2.0 settings (safeguards, Planning Mode artifacts, Subagent orchestration)
 - **[2026-05-23]**: Removed duplicate `### Session Start` section at bottom of file (identical to `## Context Loading` at top)
 
-### Changed — `scripts/audit.sh` + `scripts/audit.ps1` (workspace root) + `templates/scripts/audit.sh` + `templates/scripts/audit.ps1`
-- **[2026-05-23]**: Moved CHANGELOG.md `[Unreleased]` section check outside `docs/context.md` condition block — enforced equally for workspace root and new projects
-- **[2026-05-23]**: scripts/audit.ps1 (workspace root): synced to 8 checks with .sh — added missing checks for AGENTS.md, agents/, .env.sample, scripts parity
+### Changed ??`scripts/audit.sh` + `scripts/audit.ps1` (workspace root) + `templates/scripts/audit.sh` + `templates/scripts/audit.ps1`
+- **[2026-05-23]**: Moved CHANGELOG.md `[Unreleased]` section check outside `docs/context.md` condition block ??enforced equally for workspace root and new projects
+- **[2026-05-23]**: scripts/audit.ps1 (workspace root): synced to 8 checks with .sh ??added missing checks for AGENTS.md, agents/, .env.sample, scripts parity
 
 ### Fixed
 - **[2026-05-23]**: MD file consistency: unified Session Start Checklist across CLAUDE.md, GEMINI.md, and README.md (including templates/)
 - **[2026-05-23]**: MD file consistency: updated subagent Phase 4 execution loop and `/sync` pipeline descriptions in `templates/` and root configurations
 
 ### Added
-- **[2026-05-23]**: `scripts/sync-md.sh` and `scripts/sync-md.ps1` — missing files required by `dev-sync.sh` (workspace pipeline was broken without them)
+- **[2026-05-23]**: `scripts/sync-md.sh` and `scripts/sync-md.ps1` ??missing files required by `dev-sync.sh` (workspace pipeline was broken without them)
 
-### Fixed + Added — Global best practices audit (13 items)
+### Fixed + Added ??Global best practices audit (13 items)
 
-**P1 — Bugs / Inconsistencies:**
-- **[2026-05-23]**: `CONSTITUTION.md §5`: added `purple` to color palette (was missing after designer.md update)
-- **[2026-05-23]**: `CONSTITUTION.md §5`: fixed JSON Input Contract — removed `//` comments (invalid JSON syntax)
-- **[2026-05-23]**: `CONSTITUTION.md §1`: added `.github/` (workflows/, CODEOWNERS, pull_request_template.md) and `SECURITY.md` to standard folder structure
-- **[2026-05-23]**: `CONSTITUTION.md §3`: added `perf:`, `ci:`, `style:`, `revert:` to Conventional Commits table (Conventional Commits v1.0 compliance)
-- **[2026-05-23]**: `CONSTITUTION.md § Workspace`: unified Session Start checklist order (1→CONSTITUTION, 2→context.md, 3→AGENTS.md, 4→MEMORY.md, 5→skills) — was inconsistent with CLAUDE.md
+**P1 ??Bugs / Inconsistencies:**
+- **[2026-05-23]**: `CONSTITUTION.md 짠5`: added `purple` to color palette (was missing after designer.md update)
+- **[2026-05-23]**: `CONSTITUTION.md 짠5`: fixed JSON Input Contract ??removed `//` comments (invalid JSON syntax)
+- **[2026-05-23]**: `CONSTITUTION.md 짠1`: added `.github/` (workflows/, CODEOWNERS, pull_request_template.md) and `SECURITY.md` to standard folder structure
+- **[2026-05-23]**: `CONSTITUTION.md 짠3`: added `perf:`, `ci:`, `style:`, `revert:` to Conventional Commits table (Conventional Commits v1.0 compliance)
+- **[2026-05-23]**: `CONSTITUTION.md 짠 Workspace`: unified Session Start checklist order (1?묬ONSTITUTION, 2?뭖ontext.md, 3?묨GENTS.md, 4?묺EMORY.md, 5?뭩kills) ??was inconsistent with CLAUDE.md
 - **[2026-05-23]**: `scripts/dev-sync.sh` + `dev-sync.ps1` (workspace): use `.github/pull_request_template.md` for PR body when present; fall back to `--fill`
 - **[2026-05-23]**: `scripts/dev-sync.sh` (workspace): applied same perl escape fix and branch guard as templates
 
-**P2 — Feature gaps:**
-- **[2026-05-23]**: `CONSTITUTION.md §2`: added memory archiving policy (50-row threshold, 30-day retention, `memory/archive/` for older logs, `docs/history.md` for ADR summaries)
+**P2 ??Feature gaps:**
+- **[2026-05-23]**: `CONSTITUTION.md 짠2`: added memory archiving policy (50-row threshold, 30-day retention, `memory/archive/` for older logs, `docs/history.md` for ADR summaries)
 - **[2026-05-23]**: `templates/docs/context.md`: added `## Git / PR Workflow` section (present in all real projects but was missing from the template)
-- **[2026-05-23]**: `.editorconfig` + `templates/.editorconfig`: new — charset/indent/EOL/trailing-whitespace rules for all editors (VS Code, JetBrains, Vim, etc.)
+- **[2026-05-23]**: `.editorconfig` + `templates/.editorconfig`: new ??charset/indent/EOL/trailing-whitespace rules for all editors (VS Code, JetBrains, Vim, etc.)
 
-**P3 — Best practices:**
-- **[2026-05-23]**: `templates/.github/CODEOWNERS`: new — automatic PR reviewer assignment template
-- **[2026-05-23]**: `templates/.github/dependabot.yml`: new — dependency auto-update config template (pip/npm/github-actions stubs)
-- **[2026-05-23]**: `templates/.github/workflows/ci.yml`: new — GitHub Actions CI stub (audit gate + Python/Node test job stubs)
-- **[2026-05-23]**: `SECURITY.md` + `templates/SECURITY.md`: new — security vulnerability reporting policy (GitHub Advisory + response SLA)
+**P3 ??Best practices:**
+- **[2026-05-23]**: `templates/.github/CODEOWNERS`: new ??automatic PR reviewer assignment template
+- **[2026-05-23]**: `templates/.github/dependabot.yml`: new ??dependency auto-update config template (pip/npm/github-actions stubs)
+- **[2026-05-23]**: `templates/.github/workflows/ci.yml`: new ??GitHub Actions CI stub (audit gate + Python/Node test job stubs)
+- **[2026-05-23]**: `SECURITY.md` + `templates/SECURITY.md`: new ??security vulnerability reporting policy (GitHub Advisory + response SLA)
 - **[2026-05-23]**: `README.md`: updated Conventional Commits list to include new prefixes
 
-### Fixed — Template system (14-item improvement pass)
+### Fixed ??Template system (14-item improvement pass)
 
-**P1 — Bugs:**
-- **[2026-05-23]**: `templates/scripts/dev-sync.sh`: perl changelog auto-insert now passes `$MSG` as a Perl variable (`BEGIN{$m=shift}`) — prevents breakage when commit message contains `/`, `&`, or `\`
-- **[2026-05-23]**: `templates/scripts/dev-sync.ps1`: removed `-NoNewline` from `Set-Content` call — was silently stripping trailing newline from `CHANGELOG.md`
-- **[2026-05-23]**: `templates/scripts/sync-md.sh` + `sync-md.ps1`: added deduplication guard — same-day entries no longer appended twice to `MEMORY.md`
+**P1 ??Bugs:**
+- **[2026-05-23]**: `templates/scripts/dev-sync.sh`: perl changelog auto-insert now passes `$MSG` as a Perl variable (`BEGIN{$m=shift}`) ??prevents breakage when commit message contains `/`, `&`, or `\`
+- **[2026-05-23]**: `templates/scripts/dev-sync.ps1`: removed `-NoNewline` from `Set-Content` call ??was silently stripping trailing newline from `CHANGELOG.md`
+- **[2026-05-23]**: `templates/scripts/sync-md.sh` + `sync-md.ps1`: added deduplication guard ??same-day entries no longer appended twice to `MEMORY.md`
 
-**P2 — Feature gaps:**
-- **[2026-05-23]**: `templates/scripts/audit.sh` + `audit.ps1`: strengthened from 4 → 8 checks (added: AGENTS.md existence, agents/ non-empty, .env.sample existence, scripts .sh/.ps1 parity)
+**P2 ??Feature gaps:**
+- **[2026-05-23]**: `templates/scripts/audit.sh` + `audit.ps1`: strengthened from 4 ??8 checks (added: AGENTS.md existence, agents/ non-empty, .env.sample existence, scripts .sh/.ps1 parity)
 - **[2026-05-23]**: `scripts/new-project.sh` + `new-project.ps1`: post-scaffold audit runs automatically; added initial commit guidance; `.ps1` files now included in `git update-index --chmod=+x`
 - **[2026-05-23]**: `templates/README.md`: added `## Contributing` and `## License` placeholder sections; added CLAUDE.md + GEMINI.md to Documentation links
 - **[2026-05-23]**: `templates/docs/context.md`: converted Tech Stack from bullet list to table (better AI parseability; consistent with project examples)
 - **[2026-05-23]**: `templates/GEMINI.md`: Session Start section now has actual `@`-syntax loading instructions (was comment-only)
 
-**P3 — Quality / best practices:**
-- **[2026-05-23]**: `templates/.github/pull_request_template.md`: new file — PR body template for `gh pr create --fill`
-- **[2026-05-23]**: `templates/scripts/dev-sync.sh` + `dev-sync.ps1`: added branch guard — if already on a PR branch, commits in place instead of creating a new branch
+**P3 ??Quality / best practices:**
+- **[2026-05-23]**: `templates/.github/pull_request_template.md`: new file ??PR body template for `gh pr create --fill`
+- **[2026-05-23]**: `templates/scripts/dev-sync.sh` + `dev-sync.ps1`: added branch guard ??if already on a PR branch, commits in place instead of creating a new branch
 - **[2026-05-23]**: `templates/memory/MEMORY.md`: added explanatory header distinguishing index (MEMORY.md) from daily logs (YYYY-MM-DD.md)
-- **[2026-05-23]**: `templates/agents/designer.md`: changed `color: magenta` → `color: purple` (was conflicting with analyst-example.md)
-- **[2026-05-23]**: `scripts/audit.sh` (workspace): synced with template — now runs all 8 checks
+- **[2026-05-23]**: `templates/agents/designer.md`: changed `color: magenta` ??`color: purple` (was conflicting with analyst-example.md)
+- **[2026-05-23]**: `scripts/audit.sh` (workspace): synced with template ??now runs all 8 checks
 
-### Fixed — MD file comparison (workspace + templates)
-- **[2026-05-23]**: `templates/agents/architect.md`: Unicode corruption on line 60 — `Context ?? Decision` → `Context → Decision` (arrow was mangled to replacement characters)
-- **[2026-05-23]**: `templates/agents/pm.md`: Phase 6 Finalization — added Co-Authored-By commit signature requirement
-- **[2026-05-23]**: `templates/agents/code-writer.md`: added rule 5 — update `CHANGELOG.md [Unreleased]` after every change
+### Fixed ??MD file comparison (workspace + templates)
+- **[2026-05-23]**: `templates/agents/architect.md`: Unicode corruption on line 60 ??`Context ?? Decision` ??`Context ??Decision` (arrow was mangled to replacement characters)
+- **[2026-05-23]**: `templates/agents/pm.md`: Phase 6 Finalization ??added Co-Authored-By commit signature requirement
+- **[2026-05-23]**: `templates/agents/code-writer.md`: added rule 5 ??update `CHANGELOG.md [Unreleased]` after every change
 - **[2026-05-23]**: `templates/CLAUDE.md`: added `### Custom Command Error Recovery` section (error handling for `/sync` failures, hook bypass prohibition)
 - **[2026-05-23]**: `templates/GEMINI.md`: added `/new-project` and `/post-write` rows to command emulation table
 - **[2026-05-23]**: `templates/CHANGELOG.md`: added `---` separator and Semantic Versioning link (parity with workspace format)
@@ -112,41 +112,41 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - **[2026-05-23]**: Improve `templates/AGENTS.md` with AI disclaimer, dispatch protocol, phase workflow, role boundary matrix, skills table, and expanded maintenance rule
 
 ### Fixed
-- **[2026-05-23]**: `CONSTITUTION.md §7` — Windows `.\scripts\new-project.ps1` command had a line-break bug rendering it as `.\scripts` + `ew-project.ps1`
-- **[2026-05-23]**: `scripts/audit.sh` — remove unused `PASS=0` / `FAIL=1` dead code variables
-- **[2026-05-23]**: `CONSTITUTION.md §1` — add workspace-root exception note to AGENTS.md rule
+- **[2026-05-23]**: `CONSTITUTION.md 짠7` ??Windows `.\scripts\new-project.ps1` command had a line-break bug rendering it as `.\scripts` + `ew-project.ps1`
+- **[2026-05-23]**: `scripts/audit.sh` ??remove unused `PASS=0` / `FAIL=1` dead code variables
+- **[2026-05-23]**: `CONSTITUTION.md 짠1` ??add workspace-root exception note to AGENTS.md rule
 - **[2026-05-23]**: Improve `templates/CLAUDE.md` with doc intent, CLI vs Desktop table, behavioral rules section, git hooks install, Co-Authored-By, and settings.json clarification
 - **[2026-05-23]**: Improve `templates/GEMINI.md` with doc intent, tool name mapping table, git commit policy, command emulation guide, and `.claude/` coexistence rules
 
-### Fixed — Missing slash commands / Skill registrations
-- **[2026-05-23]**: Added `.claude/commands/memlog.md` (workspace + templates) — registered `/memlog` Skill
-- **[2026-05-23]**: Added `.claude/commands/new-task.md` (workspace + templates) — registered `/new-task` Skill
-- **[2026-05-23]**: Added `.claude/commands/new-project.md` (workspace only) — registered `/new-project` Skill
-- **[2026-05-23]**: CLAUDE.md §2: reflected exact filenames in command table and added explanation of Skill registration principle
+### Fixed ??Missing slash commands / Skill registrations
+- **[2026-05-23]**: Added `.claude/commands/memlog.md` (workspace + templates) ??registered `/memlog` Skill
+- **[2026-05-23]**: Added `.claude/commands/new-task.md` (workspace + templates) ??registered `/new-task` Skill
+- **[2026-05-23]**: Added `.claude/commands/new-project.md` (workspace only) ??registered `/new-project` Skill
+- **[2026-05-23]**: CLAUDE.md 짠2: reflected exact filenames in command table and added explanation of Skill registration principle
 - **[2026-05-23]**: templates/CLAUDE.md: added Slash Commands section (specifying command->Skill auto-registration principle)
 - **[2026-05-23]**: templates/docs/context.md: added `/memlog` to Development Workflow, added Slash Commands table
 
-### Changed — License
-- **[2026-05-23]**: MIT → AGPL-3.0
+### Changed ??License
+- **[2026-05-23]**: MIT ??AGPL-3.0
 
-### Fixed — Scaffold guideline consistency (4th review — final)
-- **[2026-05-23]**: CONSTITUTION.md §5: specified Designer parallel dispatch in Phase 3 Governance Workflow
+### Fixed ??Scaffold guideline consistency (4th review ??final)
+- **[2026-05-23]**: CONSTITUTION.md 짠5: specified Designer parallel dispatch in Phase 3 Governance Workflow
 
-### Fixed — Scaffold guideline consistency (3rd 5-round review)
+### Fixed ??Scaffold guideline consistency (3rd 5-round review)
 - **[2026-05-23]**: templates/agents/pm.md: specified designer parallel dispatch in Governance Workflow Phase 3
-- **[2026-05-23]**: CONSTITUTION.md §Workspace: corrected Session Start checklist order (swapped 3<->4 — MEMORY.md first, then skills)
-- **[2026-05-23]**: CONSTITUTION.md §3: synced /sync pipeline order with actual dev-sync.sh (memlog->MEMORY.md->CHANGELOG->audit->branch->commit->push->PR)
+- **[2026-05-23]**: CONSTITUTION.md 짠Workspace: corrected Session Start checklist order (swapped 3<->4 ??MEMORY.md first, then skills)
+- **[2026-05-23]**: CONSTITUTION.md 짠3: synced /sync pipeline order with actual dev-sync.sh (memlog->MEMORY.md->CHANGELOG->audit->branch->commit->push->PR)
 
-### Fixed — Scaffold guideline consistency (2nd 5-round review)
+### Fixed ??Scaffold guideline consistency (2nd 5-round review)
 - **[2026-05-23]**: scripts/new-project.ps1: moved git update-index after git init (removed dead code)
 - **[2026-05-23]**: templates/CLAUDE.md: corrected Hooks Override comment (clarified inactive hook state), improved Step 0 expression, specified `model: inherit` default
 - **[2026-05-23]**: templates/GEMINI.md: already modified (previous round)
 - **[2026-05-23]**: templates/docs/context.md: fixed CONSTITUTION.md link path (`../` -> `../../`)
 - **[2026-05-23]**: templates/AGENTS.md: fixed `_examples` relative path (`../../templates/` -> `../templates/`)
-- **[2026-05-23]**: CONSTITUTION.md §7: "pm.md + 3 others" -> "+ 4 others", corrected `.claude/settings.json` description
-- **[2026-05-23]**: GEMINI.md §3: added `@AGENTS.md` to Context Loading (workspace root)
+- **[2026-05-23]**: CONSTITUTION.md 짠7: "pm.md + 3 others" -> "+ 4 others", corrected `.claude/settings.json` description
+- **[2026-05-23]**: GEMINI.md 짠3: added `@AGENTS.md` to Context Loading (workspace root)
 
-### Fixed — Scaffold guideline consistency (5-round review)
+### Fixed ??Scaffold guideline consistency (5-round review)
 - **[2026-05-23]**: templates/agents/pm.md: added missing `designer.md` to Agent Roster
 - **[2026-05-23]**: templates/CLAUDE.md: detailed Session Start section (4-step checklist)
 - **[2026-05-23]**: templates/GEMINI.md: added `@AGENTS.md` to Context Loading
@@ -156,129 +156,129 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - **[2026-05-23]**: scripts/new-project.sh: escaped Perl replacement special characters (`\Q...\E`), added test-runner command guide to Next steps
 - **[2026-05-23]**: scripts/new-project.ps1: removed duplicate `.sample` filter, added `chmod +x` parity for WSL (git update-index), added test-runner command guide to Next steps
 
-### Fixed — Project consistency (README, CLAUDE.md, CONSTITUTION.md)
-- **[2026-05-23]**: CLAUDE.md §1: clearly indicated that PostToolUse hook is inactive (`.claude/settings.json` is `{}`)
+### Fixed ??Project consistency (README, CLAUDE.md, CONSTITUTION.md)
+- **[2026-05-23]**: CLAUDE.md 짠1: clearly indicated that PostToolUse hook is inactive (`.claude/settings.json` is `{}`)
 - **[2026-05-23]**: README.md: updated 4-role -> 5-role agent model (added Designer), added `templates/` to Repository Structure, included Designer in Two Philosophies, updated Multi-Agent Workflow
-- **[2026-05-23]**: CONSTITUTION.md §7: updated Post-scaffold checklist agent count 4 -> 5, fixed `.\scriptsudit.ps1` typo (`.\scripts\audit.ps1`)
+- **[2026-05-23]**: CONSTITUTION.md 짠7: updated Post-scaffold checklist agent count 4 -> 5, fixed `.\scriptsudit.ps1` typo (`.\scripts\audit.ps1`)
 - **[2026-05-23]**: scripts/dev-sync.ps1: added missing file to workspace root (Script Parity rule compliance)
 
-### Changed — workspace `.githooks/pre-commit` + `.claude/settings.json` + `.claude/commands/`
+### Changed ??workspace `.githooks/pre-commit` + `.claude/settings.json` + `.claude/commands/`
 - **[2026-05-23]**: Applied same changes as templates/ to the workspace root itself
 - **[2026-05-23]**: `.githooks/pre-commit`: conditional audit (memory/ exempt)
 - **[2026-05-23]**: .claude/settings.json: removed PostToolUse hook
 - **[2026-05-23]**: .claude/commands/changelog.md + sync.md: newly added
 - **[2026-05-23]**: `scripts/dev-sync.sh`: Added newly (memlog -> sync-md -> changelog -> audit -> commit)
 
-### Changed — `templates/.githooks/pre-commit`
+### Changed ??`templates/.githooks/pre-commit`
 - **[2026-05-23]**: Smart conditional audit: skips `audit.sh` when only `memory/` files are staged (session logs, daily entries)
-- **[2026-05-23]**: Runs audit only when structural files outside `memory/` are staged — prevents spurious failures on log-only commits
+- **[2026-05-23]**: Runs audit only when structural files outside `memory/` are staged ??prevents spurious failures on log-only commits
 
-### Changed — `templates/.claude/settings.json`
-- **[2026-05-23]**: Removed PostToolUse hook — audit no longer fires on every Write/Edit
+### Changed ??`templates/.claude/settings.json`
+- **[2026-05-23]**: Removed PostToolUse hook ??audit no longer fires on every Write/Edit
 - **[2026-05-23]**: Audit is now enforced exclusively via pre-commit hook and `dev-sync.sh` pipeline
 
-### Changed — `templates/scripts/dev-sync.sh` + `dev-sync.ps1`
-- **[2026-05-23]**: Reordered pipeline: `memlog → sync-md → changelog → audit → commit → PR`
-  (was: `audit → memlog → sync-md → commit`)
+### Changed ??`templates/scripts/dev-sync.sh` + `dev-sync.ps1`
+- **[2026-05-23]**: Reordered pipeline: `memlog ??sync-md ??changelog ??audit ??commit ??PR`
+  (was: `audit ??memlog ??sync-md ??commit`)
 - **[2026-05-23]**: Added auto-changelog step: if `[Unreleased]` section has no entries, inserts the commit message automatically
-- **[2026-05-23]**: Audit now runs after memory and changelog are updated — logically correct order
+- **[2026-05-23]**: Audit now runs after memory and changelog are updated ??logically correct order
 
-### Added — `templates/.claude/commands/changelog.md`
+### Added ??`templates/.claude/commands/changelog.md`
 - **[2026-05-23]**: `/changelog "description"` command: adds a typed entry (`### Added/Changed/Fixed/Removed`) to `CHANGELOG.md [Unreleased]`
 
-### Added — `templates/.claude/commands/sync.md`
+### Added ??`templates/.claude/commands/sync.md`
 - **[2026-05-23]**: `/sync "feat: ..."` command: wraps `bash scripts/dev-sync.sh` with pipeline description
 
-### Added — `templates/agents/designer.md` (new)
-- **[2026-05-23]**: UI/UX design agent for Phase 3 — Design group
+### Added ??`templates/agents/designer.md` (new)
+- **[2026-05-23]**: UI/UX design agent for Phase 3 ??Design group
 - **[2026-05-23]**: Produces wireframes (text-based), component specs, design tokens, and accessibility checklists
 - **[2026-05-23]**: Output format: Design Specification with Screen Overview, Component List, Interaction Spec, Design Tokens, Accessibility Notes
 - **[2026-05-23]**: Added to `templates/AGENTS.md` and `templates/docs/context.md` agent tables
-- **[2026-05-23]**: Added to CONSTITUTION.md §5 Role groups table
+- **[2026-05-23]**: Added to CONSTITUTION.md 짠5 Role groups table
 
-### Added — `templates/` folder (new)
-- **[2026-05-23]**: Created `templates/` directory mirroring the exact structure of a new project — the folder itself is the authoritative scaffold reference
+### Added ??`templates/` folder (new)
+- **[2026-05-23]**: Created `templates/` directory mirroring the exact structure of a new project ??the folder itself is the authoritative scaffold reference
 - **[2026-05-23]**: All project files: `docs/context.md`, `AGENTS.md`, `CLAUDE.md`, `GEMINI.md`, `README.md`, `CHANGELOG.md`, `.env.sample`, `.gitignore`
 - **[2026-05-23]**: Config files: `.claude/settings.json`, `.gemini/settings.json`, `.githooks/pre-commit`, `.githooks/pre-push`
 - **[2026-05-23]**: Agent definitions: `agents/pm.md`, `agents/architect.md`, `agents/code-writer.md`, `agents/test-runner.md`
 - **[2026-05-23]**: Scripts (cross-platform): `scripts/audit.sh`, `audit.ps1`, `dev-sync.sh`, `dev-sync.ps1`, `sync-md.sh`, `sync-md.ps1`
 - **[2026-05-23]**: Structural stubs: `memory/MEMORY.md`, `docs/adr/.gitkeep`, `skills/.gitkeep`
 - **[2026-05-23]**: `_examples/` subfolder (reference-only, excluded from new projects):
-  - **[2026-05-23]**: `adr/0001-example-decision.md` — filled-in ADR example
-  - **[2026-05-23]**: `agents/analyst-example.md` — domain analyst agent template
-  - **[2026-05-23]**: `memory/2026-01-15-example.md` — daily session log example
-  - **[2026-05-23]**: `skills/example-skill/SKILL.md` — reusable skill template
+  - **[2026-05-23]**: `adr/0001-example-decision.md` ??filled-in ADR example
+  - **[2026-05-23]**: `agents/analyst-example.md` ??domain analyst agent template
+  - **[2026-05-23]**: `memory/2026-01-15-example.md` ??daily session log example
+  - **[2026-05-23]**: `skills/example-skill/SKILL.md` ??reusable skill template
 
-### Changed — `scripts/new-project.sh` + `new-project.ps1` (rewrite)
+### Changed ??`scripts/new-project.sh` + `new-project.ps1` (rewrite)
 - **[2026-05-23]**: Replaced ~270-line heredoc approach with `cp -r templates/. <project>/` + `perl -pi` placeholder substitution
-- **[2026-05-23]**: Script now has 6 logical steps: copy → remove `_examples/` → remove `.gitkeep` → substitute `[Project Name]` → chmod → git init
+- **[2026-05-23]**: Script now has 6 logical steps: copy ??remove `_examples/` ??remove `.gitkeep` ??substitute `[Project Name]` ??chmod ??git init
 - **[2026-05-23]**: Emits `_examples/` path in output so users know where to find extension templates
 
-### Changed — CONSTITUTION.md §7 (simplified)
-- **[2026-05-23]**: Reduced from ~1,000 lines to ~70 lines — all template content moved to `templates/`
-- **[2026-05-23]**: §7 now contains: scaffolding commands, generated-files table, and a concise post-scaffold checklist
+### Changed ??CONSTITUTION.md 짠7 (simplified)
+- **[2026-05-23]**: Reduced from ~1,000 lines to ~70 lines ??all template content moved to `templates/`
+- **[2026-05-23]**: 짠7 now contains: scaffolding commands, generated-files table, and a concise post-scaffold checklist
 - **[2026-05-23]**: Post-scaffold checklist reduced to essential placeholder checks only
 
-### Changed — `.gitignore` (workspace)
+### Changed ??`.gitignore` (workspace)
 - **[2026-05-23]**: Added `!templates/` negation so the new folder is tracked by git
 
-### Added — CONSTITUTION.md §7 (scaffold template completeness review)
-- **[2026-05-23]**: `scripts/audit.sh` + `audit.ps1` scaffold templates added to §7 (previously only copied from workspace, never documented)
+### Added ??CONSTITUTION.md 짠7 (scaffold template completeness review)
+- **[2026-05-23]**: `scripts/audit.sh` + `audit.ps1` scaffold templates added to 짠7 (previously only copied from workspace, never documented)
 - **[2026-05-23]**: `scripts/dev-sync.ps1` scaffold template added alongside existing `dev-sync.sh` template (Windows parity)
 - **[2026-05-23]**: `scripts/sync-md.ps1` scaffold template added alongside existing `sync-md.sh` template (Windows parity)
-- **[2026-05-23]**: `.gemini/settings.json` scaffold template added (`{}`) — referenced in checklist but never templated
+- **[2026-05-23]**: `.gemini/settings.json` scaffold template added (`{}`) ??referenced in checklist but never templated
 - **[2026-05-23]**: **Extension templates** subsection added (created on demand, not at project init):
-  - **[2026-05-23]**: `docs/adr/NNNN-slug.md` — Architecture Decision Record (3-section: Context → Decision → Consequences)
-  - **[2026-05-23]**: `agents/<name>-analyst.md` — Analysis agent (read-only investigator; dispatched by PM in Phase 1–2)
-  - **[2026-05-23]**: `memory/YYYY-MM-DD.md` — Daily session log format
+  - **[2026-05-23]**: `docs/adr/NNNN-slug.md` ??Architecture Decision Record (3-section: Context ??Decision ??Consequences)
+  - **[2026-05-23]**: `agents/<name>-analyst.md` ??Analysis agent (read-only investigator; dispatched by PM in Phase 1??)
+  - **[2026-05-23]**: `memory/YYYY-MM-DD.md` ??Daily session log format
 
-### Fixed — CONSTITUTION.md §7 (path bugs)
-- **[2026-05-23]**: `CLAUDE.md` scaffold: `../../CLAUDE.md` → `../CLAUDE.md` (project-root file is one level above workspace, not two)
-- **[2026-05-23]**: `GEMINI.md` scaffold: `../../GEMINI.md` → `../GEMINI.md`; `@../../CONSTITUTION.md` → `@../CONSTITUTION.md`
+### Fixed ??CONSTITUTION.md 짠7 (path bugs)
+- **[2026-05-23]**: `CLAUDE.md` scaffold: `https://raw.githubusercontent.com/5throck/ai-workspace-standards/main/CLAUDE.md` ??`https://raw.githubusercontent.com/5throck/ai-workspace-standards/main/CLAUDE.md` (project-root file is one level above workspace, not two)
+- **[2026-05-23]**: `GEMINI.md` scaffold: `https://raw.githubusercontent.com/5throck/ai-workspace-standards/main/GEMINI.md` ??`https://raw.githubusercontent.com/5throck/ai-workspace-standards/main/GEMINI.md`; `@../https://raw.githubusercontent.com/5throck/ai-workspace-standards/main/CONSTITUTION.md` ??`@https://raw.githubusercontent.com/5throck/ai-workspace-standards/main/CONSTITUTION.md`
 - **[2026-05-23]**: Path notes for both templates corrected; clarified that `../../` is correct only for files inside subdirectories (`docs/`, `agents/`, etc.)
 - **[2026-05-23]**: Post-scaffold checklist: path check items updated to show correct `../` expectation with anti-pattern warning
 
-### Fixed — `scripts/audit.sh` + `audit.ps1`
-- **[2026-05-23]**: CONSTITUTION.md check: now looks at both `./CONSTITUTION.md` and `../CONSTITUTION.md` — previously always failed when run from a project directory (CONSTITUTION.md lives at workspace root, one level up)
+### Fixed ??`scripts/audit.sh` + `audit.ps1`
+- **[2026-05-23]**: CONSTITUTION.md check: now looks at both `./CONSTITUTION.md` and `https://raw.githubusercontent.com/5throck/ai-workspace-standards/main/CONSTITUTION.md` ??previously always failed when run from a project directory (CONSTITUTION.md lives at workspace root, one level up)
 
-### Fixed — `scripts/new-project.sh`
-- **[2026-05-23]**: `dev-sync.sh` stub: corrected git workflow order — `git checkout -b "$BRANCH"` now runs before `git add -A && git commit` (previously committed to main before creating the PR branch)
-- **[2026-05-23]**: Generated `CLAUDE.md` / `GEMINI.md`: fixed path references (`../../` → `../`)
-- **[2026-05-23]**: Added `README.md` generation (was missing — checklist required it but script never created it)
+### Fixed ??`scripts/new-project.sh`
+- **[2026-05-23]**: `dev-sync.sh` stub: corrected git workflow order ??`git checkout -b "$BRANCH"` now runs before `git add -A && git commit` (previously committed to main before creating the PR branch)
+- **[2026-05-23]**: Generated `CLAUDE.md` / `GEMINI.md`: fixed path references (`../../` ??`../`)
+- **[2026-05-23]**: Added `README.md` generation (was missing ??checklist required it but script never created it)
 - **[2026-05-23]**: Added `.gemini/settings.json` generation (`{}`)
-- **[2026-05-23]**: `dev-sync.sh` memlog line: changed `echo "Session synced: $MSG"` to `echo "## Session — $MSG"` (matches §7 template)
+- **[2026-05-23]**: `dev-sync.sh` memlog line: changed `echo "Session synced: $MSG"` to `echo "## Session ??$MSG"` (matches 짠7 template)
 
-### Fixed/Added — `scripts/new-project.ps1`
+### Fixed/Added ??`scripts/new-project.ps1`
 - **[2026-05-23]**: Full rewrite for feature parity with `new-project.sh`:
   - **[2026-05-23]**: Now generates all files: `docs/context.md` (full 10-section template), `AGENTS.md`, agent stubs (all 4), `CHANGELOG.md`, `memory/MEMORY.md`, `.env.sample`, `.gitignore`, `CLAUDE.md`, `.claude/settings.json`, `GEMINI.md`, `.gemini/settings.json`, `README.md`, `scripts/dev-sync.ps1`, `scripts/dev-sync.sh`, `scripts/sync-md.ps1`, `scripts/sync-md.sh`, `.githooks/pre-commit`, `.githooks/pre-push`
   - **[2026-05-23]**: Copies `audit.sh` + `audit.ps1` from workspace
   - **[2026-05-23]**: Emits actionable "Next steps" instructions on completion
 
-### Fixed — CONSTITUTION.md §7 (5-round iterative review)
+### Fixed ??CONSTITUTION.md 짠7 (5-round iterative review)
 - **[2026-05-23]**: `README.md` scaffold template: changed outer fence from ` ```markdown ` to `~~~~markdown` to fix nested code block rendering (same fix applied earlier to `docs/context.md` and `GEMINI.md`)
-- **[2026-05-23]**: `scripts/dev-sync.sh` scaffold: fixed git workflow order — `git checkout -b "$BRANCH"` now runs **before** `git add -A && git commit` to prevent commits landing on `main` before the PR branch is created
-- **[2026-05-23]**: `agents/pm.md` scaffold header: added ⚠️ stub-replacement warning (consistent with architect, code-writer, test-runner)
-- **[2026-05-23]**: Post-scaffold checklist: added `agents/pm.md — full template used (not a stub)` check (script stubs all 4 agents, not 3)
-- **[2026-05-23]**: §7 intro: expanded generated-files list to include all 4 agent files (`agents/pm.md`, `agents/architect.md`, `agents/code-writer.md`, `agents/test-runner.md`)
+- **[2026-05-23]**: `scripts/dev-sync.sh` scaffold: fixed git workflow order ??`git checkout -b "$BRANCH"` now runs **before** `git add -A && git commit` to prevent commits landing on `main` before the PR branch is created
+- **[2026-05-23]**: `agents/pm.md` scaffold header: added ?좑툘 stub-replacement warning (consistent with architect, code-writer, test-runner)
+- **[2026-05-23]**: Post-scaffold checklist: added `agents/pm.md ??full template used (not a stub)` check (script stubs all 4 agents, not 3)
+- **[2026-05-23]**: 짠7 intro: expanded generated-files list to include all 4 agent files (`agents/pm.md`, `agents/architect.md`, `agents/code-writer.md`, `agents/test-runner.md`)
 
 ## [2026-05-22]
 
-### Added — CONSTITUTION.md
+### Added ??CONSTITUTION.md
 
-#### §1 Standard Folder Structure
+#### 짠1 Standard Folder Structure
 - Added `.env.sample` and `.gitignore` to the standard folder structure tree
 - Added rule: `AGENTS.md` is always created at project root as the canonical agent roster
 - Added rule: `.env.sample` always committed; `.env` always in `.gitignore`
 
-#### §5 Multi-Agent Architecture
+#### 짠5 Multi-Agent Architecture
 - Split "Execution" group into distinct **Design** and **Execution** groups
-  - **Design**: `architect.md` — architecture decisions, implementation planning, technical spec
-  - **Execution**: `code-writer.md`, `test-runner.md` — code implementation and test verification
+  - **Design**: `architect.md` ??architecture decisions, implementation planning, technical spec
+  - **Execution**: `code-writer.md`, `test-runner.md` ??code implementation and test verification
 
-#### §6 Reusable Skills
+#### 짠6 Reusable Skills
 - Updated Session skill load timing to reference `docs/context.md ## Session Start Skills`
 
-#### §7 New Project Initialization — scaffold templates
+#### 짠7 New Project Initialization ??scaffold templates
 - `docs/context.md` full scaffold template
   - Cross-platform Python venv activation (macOS/Linux + Windows)
   - `## Session Start Skills` section
@@ -286,23 +286,24 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
   - `## Key Files` expanded with AGENTS.md, CHANGELOG.md, and all agent files
   - Path assumption note added to `## Coding Guidelines` link
   - Outer fence changed to `~~~~markdown` to fix nested code block rendering
-- `AGENTS.md` scaffold template (new) — canonical agent index with Group column, dispatch guidance, maintenance rule
-- `agents/pm.md` scaffold template (new) — YAML frontmatter + markdown body, 6-phase workflow, Agent Roster with Group column
-- `agents/architect.md` scaffold template (new) — design-only agent; produces plans/ADRs; structured Implementation Plan output format
-- `agents/code-writer.md` scaffold template (new) — implements approved plans only; per-file change report format
-- `agents/test-runner.md` scaffold template (new) — QA agent; verification sequence; structured QA Report with READY/BLOCKED verdict
-- `CLAUDE.md` project-level scaffold template (new) — Session Start, MCP Servers, Hooks Override, Model Selection Override
-- `.claude/settings.json` scaffold template (new) — PostToolUse hook wiring for `scripts/audit.sh`
-- `GEMINI.md` project-level scaffold template (new) — `@`-syntax context loading, model selection override
+- `AGENTS.md` scaffold template (new) ??canonical agent index with Group column, dispatch guidance, maintenance rule
+- `agents/pm.md` scaffold template (new) ??YAML frontmatter + markdown body, 6-phase workflow, Agent Roster with Group column
+- `agents/architect.md` scaffold template (new) ??design-only agent; produces plans/ADRs; structured Implementation Plan output format
+- `agents/code-writer.md` scaffold template (new) ??implements approved plans only; per-file change report format
+- `agents/test-runner.md` scaffold template (new) ??QA agent; verification sequence; structured QA Report with READY/BLOCKED verdict
+- `CLAUDE.md` project-level scaffold template (new) ??Session Start, MCP Servers, Hooks Override, Model Selection Override
+- `.claude/settings.json` scaffold template (new) ??PostToolUse hook wiring for `scripts/audit.sh`
+- `GEMINI.md` project-level scaffold template (new) ??`@`-syntax context loading, model selection override
 - `CHANGELOG.md` initial scaffold (new)
 - `.env.sample` initial scaffold (new)
 - `memory/MEMORY.md` initial scaffold (new)
 - `.gitignore` initial scaffold covering Python, Node.js, OS artifacts (new)
-- Post-scaffold checklist (new) — 10-item verification with cross-platform commands
+- Post-scaffold checklist (new) ??10-item verification with cross-platform commands
 
-#### §7 Design principle
+#### 짠7 Design principle
 - `docs/context.md` = single source of truth for ALL AI tools; project-level `CLAUDE.md`/`GEMINI.md` = platform-specific overrides only
 
 ---
 
 *Last Updated: 2026-05-23*
+

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -1,8 +1,8 @@
-# GEMINI.md
+﻿# GEMINI.md
 
 This file provides guidance to Gemini (including the Antigravity agentic engine and Gemini CLI) when working in this workspace.
 
-> **Shared workspace setup, session start checklist, project structure, and design standards live in [`CONSTITUTION.md`](CONSTITUTION.md) — read it first.**
+> **Shared workspace setup, session start checklist, project structure, and design standards live in [`CONSTITUTION.md`](CONSTITUTION.md) ??read it first.**
 >
 > For tool-specific behaviors of Claude Code, see [`CLAUDE.md`](CLAUDE.md).
 
@@ -22,12 +22,12 @@ Antigravity utilizes the following specialized, fine-grained toolset for filesys
 | **Search** | `grep_search` | Search codebases via Ripgrep. Keep `MatchPerLine: true` for line-by-line matches. Apply partitioning if matches exceed 50. |
 | **Command Execution** | `run_command` | Execute PowerShell/Bash shell commands. Returns task process IDs. NEVER use `cd` commands. |
 
-#### ⚠️ Surgical Multi-Replace Offset Safeguard
+#### ?좑툘 Surgical Multi-Replace Offset Safeguard
 When calling `multi_replace_file_content` with multiple `ReplacementChunks`, the line numbers of subsequent target blocks will shift if previous edits change the line count.
 - **Rule**: You **MUST** sort and process the `ReplacementChunks` from the **bottom of the file to the top** (descending order of line numbers: largest `StartLine` first).
 - This guarantees that edits made near the end of the file do not alter or corrupt the line numbers of target blocks located higher up in the file.
 
-#### ⚠️ Grep Search 50-Match Cap Safeguard
+#### ?좑툘 Grep Search 50-Match Cap Safeguard
 The `grep_search` tool silently truncates results at exactly **50 matches**.
 - **Rule**: If a codebase-wide search yields 50 results, do **NOT** assume you have all occurrences.
 - **Remediation**: Partition the search. Divide the search by targeting specific subdirectories (e.g., `C:\git\<project>\src`) or apply restrictive file glob filters using the `Includes` parameter (e.g., `["*.py"]` or `["*.ts"]`).
@@ -42,12 +42,12 @@ Enter Planning Mode when:
 
 When entering Planning Mode, Gemini **MUST** leverage the following three precise Markdown artifacts. When creating or updating them, set `IsArtifact: true` and specify accurate metadata:
 
-#### 1. `implementation_plan.md` (Path: `<appDataDir>\brain\<session-id>\implementation_plan.md` on Windows · `<appDataDir>/brain/<session-id>/implementation_plan.md` on macOS/Linux)
+#### 1. `implementation_plan.md` (Path: `<appDataDir>\brain\<session-id>\implementation_plan.md` on Windows 쨌 `<appDataDir>/brain/<session-id>/implementation_plan.md` on macOS/Linux)
 *   **Purpose**: Detailed technical design document presented to the user for feedback and approval.
 *   **Metadata**: `ArtifactType: "implementation_plan"`, `RequestFeedback: true`, and a clear multi-line `Summary`.
 *   **Governance**: Stop and wait for explicit user approval before modifying any application source code.
 
-#### 2. `task.md` (Path: `<appDataDir>\brain\<session-id>\task.md` on Windows · `<appDataDir>/brain/<session-id>/task.md` on macOS/Linux)
+#### 2. `task.md` (Path: `<appDataDir>\brain\<session-id>\task.md` on Windows 쨌 `<appDataDir>/brain/<session-id>/task.md` on macOS/Linux)
 *   **Purpose**: Running TODO list to track development progress dynamically.
 *   **Metadata**: `ArtifactType: "task"`.
 *   **Syntax**:
@@ -55,7 +55,7 @@ When entering Planning Mode, Gemini **MUST** leverage the following three precis
     *   `- [/]` for tasks currently in progress.
     *   `- [x]` for completed tasks.
 
-#### 3. `walkthrough.md` (Path: `<appDataDir>\brain\<session-id>\walkthrough.md` on Windows · `<appDataDir>/brain/<session-id>/walkthrough.md` on macOS/Linux)
+#### 3. `walkthrough.md` (Path: `<appDataDir>\brain\<session-id>\walkthrough.md` on Windows 쨌 `<appDataDir>/brain/<session-id>/walkthrough.md` on macOS/Linux)
 *   **Purpose**: Post-implementation document summarizing changes, automated test logs, and manual validation details.
 *   **Metadata**: `ArtifactType: "walkthrough"`.
 
@@ -63,19 +63,19 @@ When entering Planning Mode, Gemini **MUST** leverage the following three precis
 
 ### 3. Response Language
 
-- All **conversational** replies → **Korean (한국어)** by default.
-- All code, config, commit messages, PR titles, branch names → **English only**.
+- All **conversational** replies ??**Korean (?쒓뎅??** by default.
+- All code, config, commit messages, PR titles, branch names ??**English only**.
 
 ---
 
 ### 4. Context Loading
 Session Start Checklist steps (as defined in CONSTITUTION.md) are loaded into the conversation context using the platform `@` file reference syntax. (Note: Step 0 is a git command, not a file load).
 ```
-@../CONSTITUTION.md          # Step 1 — workspace design standard
-@docs/context.md             # Step 2 — project knowledge
-@AGENTS.md                   # Step 3 — canonical agent roster
-@memory/MEMORY.md            # Step 4 — recent changes (skip if file does not exist)
-@skills/                     # Step 5 — load skills listed in docs/context.md
+@https://raw.githubusercontent.com/5throck/ai-workspace-standards/main/CONSTITUTION.md          # Step 1 ??workspace design standard
+@docs/context.md             # Step 2 ??project knowledge
+@AGENTS.md                   # Step 3 ??canonical agent roster
+@memory/MEMORY.md            # Step 4 ??recent changes (skip if file does not exist)
+@skills/                     # Step 5 ??load skills listed in docs/context.md
 ```
 
 For internationalization (i18n) work, also load the baseline translation reference:
@@ -123,11 +123,11 @@ The platform supports **Reactive Wakeup**: you do not need to poll or query task
 2.  **test-runner** verifies against acceptance criteria and runs tests.
 3.  **Quality gate (audit script)** validates compliance.
 
-> Loop and correct if review errors are flagged — maximum **3 iterations** before escalating to the user.
+> Loop and correct if review errors are flagged ??maximum **3 iterations** before escalating to the user.
 
 **Model Selection Overrides** (overridden per subagent invocation when appropriate):
-- All standard and complex tasks (Default) ➔ `gemini-2.5-pro`
-- Simple transformations, fast lookups, or file globbing ➔ `gemini-2.5-flash`
+- All standard and complex tasks (Default) ??`gemini-2.5-pro`
+- Simple transformations, fast lookups, or file globbing ??`gemini-2.5-flash`
 
 ---
 
@@ -149,15 +149,16 @@ Gemini does not natively run slash commands. Emulate custom slash commands using
 Many active repositories under the workspace root possess `.claude/` directories rather than `.gemini/`.
 *   **`.gemini/` exists**: Rely on `.gemini/` settings only. Ignore `.claude/` configurations entirely.
 *   **`.claude/` exists, `.gemini/` absent**: Read `.claude/settings.json` and `.claude/commands/` as fallbacks. Emulate custom commands by executing their target scripts.
-*   **Migration**: Offer the user a migration of `.claude/` ➔ `.gemini/` (copying and adapting configurations) when fully transitioning a project away from Claude Code.
+*   **Migration**: Offer the user a migration of `.claude/` ??`.gemini/` (copying and adapting configurations) when fully transitioning a project away from Claude Code.
 
 ---
 
 ## Git & PR Additions (Gemini)
 
-All shared Git/PR rules are in [CONSTITUTION.md §3](CONSTITUTION.md#3-github-pr-workflow). Gemini-specific additions:
+All shared Git/PR rules are in [CONSTITUTION.md 짠3](CONSTITUTION.md#3-github-pr-workflow). Gemini-specific additions:
 
 - **PostToolUse Limitation**: PostToolUse hooks are **disabled** in Gemini/Antigravity sessions. Manually execute `dev-sync` or audit scripts (`scripts/audit.sh` or `scripts/audit.ps1`) after local edits, and run commits at task boundaries.
 - **AI Commit Signatures**: Always append `Co-Authored-By: Gemini <noreply@google.com>` to the end of all AI-generated git commit messages.
 
 *Last Updated: 2026-05-22*
+

--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ git config core.hooksPath .githooks
 # Antigravity will autonomously scaffold the project via a natural language prompt
 # (e.g., "my-project-name 프로젝트를 생성해 줘") ONLY IF the new-project skill is
 # registered in its global plugins (C:\Users\USER\.gemini\config\plugins\workspace-skills).
-# Otherwise, manually execute the script below, or use the /new-project skill folder.
+# Otherwise, manually execute the script below.
 bash scripts/new-project.sh "my-project-name"
 
 # PowerShell
@@ -73,15 +73,22 @@ C:\git\ (workspace root — this repo)
 ├── CONSTITUTION.md          # Master standard — read first in every session
 ├── CLAUDE.md                # Claude Code workspace behaviors
 ├── GEMINI.md                # Gemini CLI / Antigravity workspace behaviors
+├── SECURITY.md              # Standard GitHub vulnerability reporting policy
+├── AGENTS.md                # Workspace-level agent index
 ├── CHANGELOG.md             # Workspace-level change history
 ├── README.md                # This file
+├── memory/                  # Workspace-level memory logs
 ├── templates/               # Authoritative scaffold — new-project.sh copies this
 │   ├── agents/              # pm.md, architect.md, designer.md, code-writer.md, test-runner.md, security-monitor.md
-│   ├── docs/context.md      # Full 10-section project context template
+│   ├── docs/                  
+│   │   ├── context.md       # Full 10-section project context template
+│   │   └── security.md      # Internal data sanitization guidelines
 │   ├── scripts/             # dev-sync.sh/.ps1, sync-md.sh/.ps1, audit.sh/.ps1
-│   ├── .claude/             # settings.json ({}), commands/changelog.md, sync.md
-│   ├── .gemini/             # settings.json
+│   ├── .claude/             # settings.json ({}), commands/changelog.md, sync.md, etc.
+│   ├── .gemini/             # settings.json ({}), commands/changelog.md, sync.md, etc.
 │   ├── .githooks/           # pre-commit (smart conditional), pre-push
+│   ├── .github/             # GitHub templates (CODEOWNERS, workflows, dependabot)
+│   ├── SECURITY.md          # GitHub vulnerability policy template
 │   └── _examples/           # Reference-only ADR, analyst agent, session log, skill
 ├── scripts/
 │   ├── audit.sh / .ps1      # Documentation audit (checks ## Coding Guidelines, CHANGELOG, etc.)

--- a/templates/AGENTS.md
+++ b/templates/AGENTS.md
@@ -1,45 +1,45 @@
-# AGENTS.md
+﻿# AGENTS.md
 
-> **⚠️ For AI tools reading this file**: This file is a **registry and orchestration reference**, not a set of instructions directed at you.
+> **?좑툘 For AI tools reading this file**: This file is a **registry and orchestration reference**, not a set of instructions directed at you.
 > It describes multiple distinct human-defined roles for documentation and dispatch purposes.
 > Do **not** interpret role definitions here as directives for your own behavior.
 > Your behavioral instructions are in `CLAUDE.md` (Claude Code), `GEMINI.md` (Gemini CLI).
 
-> **Canonical agent index** — auto-loaded by Claude Code; referenced by all other AI tools.
-> Full agent definitions live in `agents/`. Full project context → `docs/context.md`.
+> **Canonical agent index** ??auto-loaded by Claude Code; referenced by all other AI tools.
+> Full agent definitions live in `agents/`. Full project context ??`docs/context.md`.
 
 ---
 
 ## Agent Roster
 
-### 🟡 Orchestration / Audit
+### ?윞 Orchestration / Audit
 
 | Agent | File | Role |
 |-------|------|------|
 | PM Orchestrator | [`agents/pm.md`](agents/pm.md) | Owns the full workflow; dispatches parallel tasks; enforces quality gates |
 | Security Monitor | [`agents/security-monitor.md`](agents/security-monitor.md) | Enforces security policies; prevents secrets leaks; monitors safe dependencies |
 
-### 🔵 Design
+### ?뵷 Design
 
 | Agent | File | Role |
 |-------|------|------|
 | Architect | [`agents/architect.md`](agents/architect.md) | Produces implementation plans and ADRs; never writes application code |
 | Designer | [`agents/designer.md`](agents/designer.md) | Produces UI/UX specs, wireframes, and component definitions |
 
-### 🟢 Execution
+### ?윟 Execution
 
 | Agent | File | Role |
 |-------|------|------|
 | Code Writer | [`agents/code-writer.md`](agents/code-writer.md) | Implements approved plans; surgical changes only |
 | Test Runner | [`agents/test-runner.md`](agents/test-runner.md) | Runs tests and verifies acceptance criteria |
 
-### 🔴 Security / Setup
+### ?뵶 Security / Setup
 
 | Agent | File | Role |
 |-------|------|------|
 | Stack Setup | [`agents/stack-setup.md`](agents/stack-setup.md) | Identifies unknown stacks, web-searches setup procedures, mandatory security review, requires explicit user approval before executing any commands |
 
-*(Add domain-specific agents as needed — see the extension guidance below.)*
+*(Add domain-specific agents as needed ??see the extension guidance below.)*
 
 ---
 
@@ -49,12 +49,12 @@
 
 ```
 Request received
-  │
-  ├─ Read-only? (research, analysis, inspect)
-  │    └─► PARALLEL — dispatch multiple agents in a single message
-  │
-  └─ Write? (create/edit files, run tests)
-       └─► SERIAL — one agent at a time to prevent file lock conflicts
+  ??
+  ?쒋? Read-only? (research, analysis, inspect)
+  ??   ?붴???PARALLEL ??dispatch multiple agents in a single message
+  ??
+  ?붴? Write? (create/edit files, run tests)
+       ?붴???SERIAL ??one agent at a time to prevent file lock conflicts
 ```
 
 > **Why serial writes?** Concurrent writes to the same files cause merge conflicts and lock contention.
@@ -62,26 +62,26 @@ Request received
 
 ### Dispatch Rules
 
-1. **Single message, multiple `Agent()` calls** — all parallel agents must be dispatched in one turn.
-2. **Merge before proceeding** — PM waits for ALL parallel agents to return before the next serial step.
-3. **Phase 4 execution loop** — each implementation task goes through:
+1. **Single message, multiple `Agent()` calls** ??all parallel agents must be dispatched in one turn.
+2. **Merge before proceeding** ??PM waits for ALL parallel agents to return before the next serial step.
+3. **Phase 4 execution loop** ??each implementation task goes through:
    - **code-writer** implements the changes
    - **test-runner** verifies against acceptance criteria and runs tests
    - **Quality gate (audit script)** validates compliance
-   - Loop and correct if issues found — maximum **3 iterations** before escalating to the user.
-4. **Error handling** — if any parallel agent fails, PM resolves the failure before proceeding. Do not skip.
-5. **Max fix iterations** — 3 per review cycle before escalating to the user.
+   - Loop and correct if issues found ??maximum **3 iterations** before escalating to the user.
+4. **Error handling** ??if any parallel agent fails, PM resolves the failure before proceeding. Do not skip.
+5. **Max fix iterations** ??3 per review cycle before escalating to the user.
 
 ### Subagent Roster
 
 | Agent | File | Parallelizable | Write Allowed? |
 |-------|------|:--------------:|:--------------:|
-| Security Monitor | `agents/security-monitor.md`| ✅ Triage phase | ❌ No |
-| Architect | `agents/architect.md` | ✅ Design phase | ❌ No |
-| Designer | `agents/designer.md` | ✅ Design phase | ❌ No |
-| Code Writer | `agents/code-writer.md` | ❌ Serial | ✅ Source files |
-| Test Runner | `agents/test-runner.md` | ❌ After writes | ✅ Test files only |
-| Stack Setup | `agents/stack-setup.md` | ✅ Research phase | ✅ setup.sh/ps1 only (after approval) |
+| Security Monitor | `agents/security-monitor.md`| ??Triage phase | ??No |
+| Architect | `agents/architect.md` | ??Design phase | ??No |
+| Designer | `agents/designer.md` | ??Design phase | ??No |
+| Code Writer | `agents/code-writer.md` | ??Serial | ??Source files |
+| Test Runner | `agents/test-runner.md` | ??After writes | ??Test files only |
+| Stack Setup | `agents/stack-setup.md` | ??Research phase | ??setup.sh/ps1 only (after approval) |
 
 *(Extend this table as you add Analysis or specialized agents to the project.)*
 
@@ -90,32 +90,32 @@ Request received
 ## Harness Engineering Workflow
 
 ```
-Phase 0 — Team Assembly & Skill Orchestration (Kickoff)
+Phase 0 ??Team Assembly & Skill Orchestration (Kickoff)
   PM assesses project requirements
   PM dynamically creates new agents/skills and resolves R&R overlap
   PM updates AGENTS.md and docs/context.md
 
-Phase 1 — Triage & Analysis
+Phase 1 ??Triage & Analysis
   PM classifies the request
   Dispatch read-only agents in parallel (analysis, research)
-  PM synthesizes findings → acceptance criteria
+  PM synthesizes findings ??acceptance criteria
 
-Phase 2 — Design
+Phase 2 ??Design
   Architect produces implementation plan + ADR
-  Designer produces UI/UX spec (if task has UI surface) — parallel with Architect
-  PM obtains explicit user approval ← GATE
+  Designer produces UI/UX spec (if task has UI surface) ??parallel with Architect
+  PM obtains explicit user approval ??GATE
 
-Phase 3 — Implementation (serial)
+Phase 3 ??Implementation (serial)
   Code Writer implements per approved plan
   Test Runner verifies after each change
 
-Phase 4 — QA Gate (all must pass)
+Phase 4 ??QA Gate (all must pass)
   bash scripts/audit.sh     exit 0
   [project test command]    all tests pass
 
-Phase 5 — Finalization
+Phase 5 ??Finalization
   PM logs decisions to memory/YYYY-MM-DD.md
-  PM runs /sync "type: description" → PR opened
+  PM runs /sync "type: description" ??PR opened
 ```
 
 ---
@@ -141,9 +141,9 @@ Use this to resolve ambiguity when multiple agents could handle a request.
 
 | Skill | File | Trigger condition |
 |-------|------|-------------------|
-| *(none yet — add entries as skills are created in `skills/`)* | | |
+| *(none yet ??add entries as skills are created in `skills/`)* | | |
 
-*(When a skill is created, add a row here and in `docs/context.md § Skills`.)*
+*(When a skill is created, add a row here and in `docs/context.md 짠 Skills`.)*
 
 ---
 
@@ -154,7 +154,7 @@ All agents, regardless of their role, must adhere to the following:
 - **Communication Style**: Keep explanations concise and use markdown formatting. Always explain "why", not just "what".
 - **Conflicting Instructions**: If a user request violates project rules (e.g., bypassing tests), warn the user and request explicit confirmation before proceeding.
 - **Coding Standards**: Follow SOLID principles. Write unit tests when creating functional code. No speculative abstractions.
-- **Language**: All code, config, commit messages, and branch names → **English only**.
+- **Language**: All code, config, commit messages, and branch names ??**English only**.
 
 ---
 
@@ -174,10 +174,10 @@ Add domain-specific agents when the project requires specialized expertise beyon
 1. Create `agents/<name>.md` with the agent's role, constraints, and write-access rules.
 2. Add a row to the Agent Roster table above.
 3. Add a row to the Subagent Roster dispatch table (Parallelizable / Write Allowed).
-4. Update `docs/context.md § Agents` to match.
-5. If the agent uses a skill, add it to the Skills table here and in `docs/context.md § Session Start Skills`.
+4. Update `docs/context.md 짠 Agents` to match.
+5. If the agent uses a skill, add it to the Skills table here and in `docs/context.md 짠 Session Start Skills`.
 
-> Reference: [`abap_vibe_coding/AGENTS.md`](../abap_vibe_coding/AGENTS.md) (ERP domain example) and [`Pricing-Mgmt-Simulation/AGENTS.md`](../Pricing-Mgmt-Simulation/AGENTS.md) (financial BI example).
+> Reference: [`abap_vibe_coding/AGENTS.md`](https://github.com/5throck/abap_vibe_coding/blob/main/AGENTS.md) (ERP domain example) and [`Pricing-Mgmt-Simulation/AGENTS.md`](https://github.com/5throck/Pricing-Mgmt-Simulation/blob/main/AGENTS.md) (financial BI example).
 
 ---
 
@@ -187,4 +187,5 @@ When a new `agents/<name>.md` is created, **the developer or AI agent responsibl
 1. Add a row to the Agent Roster table above.
 2. Add a row to the Subagent Roster dispatch table (with Parallelizable / Write Allowed columns).
 3. Update the `## Agents` table in `docs/context.md` to match.
-4. If the agent uses a skill, add a row to the Skills table above and in `docs/context.md § Skills`.
+4. If the agent uses a skill, add a row to the Skills table above and in `docs/context.md 짠 Skills`.
+

--- a/templates/CLAUDE.md
+++ b/templates/CLAUDE.md
@@ -1,7 +1,7 @@
-# CLAUDE.md
+﻿# CLAUDE.md
 
-> **All project context, coding guidelines, and dev workflow → [`docs/context.md`](docs/context.md)**
-> Workspace-level Claude Code behaviors → [`../CLAUDE.md`](../CLAUDE.md)
+> **All project context, coding guidelines, and dev workflow ??[`docs/context.md`](docs/context.md)**
+> Workspace-level Claude Code behaviors ??[`https://raw.githubusercontent.com/5throck/ai-workspace-standards/main/CLAUDE.md`](https://raw.githubusercontent.com/5throck/ai-workspace-standards/main/CLAUDE.md)
 
 > **Doc intent:** This file is Claude Code-specific behavioral configuration for **individual projects** (not the workspace root).
 > Shared project context (architecture, tech stack, coding guidelines) lives in [`docs/context.md`](docs/context.md).
@@ -17,8 +17,8 @@ At the start of every Claude Code session, run this checklist:
 
 ```
 0. git config core.hooksPath .githooks   # activate hooks (run once per clone; verify it stuck)
-1. Read ../CONSTITUTION.md               # workspace design standard
-2. Read docs/context.md                  # project knowledge — coding guidelines, agents, workflow
+1. Read https://raw.githubusercontent.com/5throck/ai-workspace-standards/main/CONSTITUTION.md               # workspace design standard
+2. Read docs/context.md                  # project knowledge ??coding guidelines, agents, workflow
 3. Read AGENTS.md                        # agent roster (auto-loaded by Claude Code)
 4. Read memory/MEMORY.md                 # recent changes and session history
 5. Load skills listed in docs/context.md ## Session Start Skills
@@ -32,20 +32,20 @@ Both the CLI and the Desktop App share the same `.claude/settings.json` and slas
 
 | Environment | PostToolUse hook fires? | Action if not |
 |-------------|:-----------------------:|---------------|
-| Claude Code CLI | ✅ Automatic | — |
-| Claude Code Desktop App | ❌ Never | Run `bash scripts/audit.sh` manually before committing |
+| Claude Code CLI | ??Automatic | ??|
+| Claude Code Desktop App | ??Never | Run `bash scripts/audit.sh` manually before committing |
 
 > **Recommended split:**
-> - **CLI** — automated workflows, hook-driven audit, multi-agent orchestration.
-> - **Desktop App** — PR monitoring, visual diff review, parallel sessions.
+> - **CLI** ??automated workflows, hook-driven audit, multi-agent orchestration.
+> - **Desktop App** ??PR monitoring, visual diff review, parallel sessions.
 
 ---
 
 ### Claude Code Settings
 
-- `.claude/settings.json` — shared team config (committed to repo)
-- `.claude/settings.local.json` — personal write permissions + git/gh access (gitignored)
-- `.claude/commands/` — slash commands auto-registered as Skills
+- `.claude/settings.json` ??shared team config (committed to repo)
+- `.claude/settings.local.json` ??personal write permissions + git/gh access (gitignored)
+- `.claude/commands/` ??slash commands auto-registered as Skills
 
 Both files are loaded automatically by Claude Code.
 
@@ -58,7 +58,7 @@ These commands are available as both `/slash-commands` and via the `Skill` tool:
 | Command | Purpose |
 |---------|---------|
 | `/changelog "description"` | Add entry to `CHANGELOG.md [Unreleased]` |
-| `/sync "feat: ..."` | Full pipeline — memlog → sync-md → changelog → audit → commit → PR |
+| `/sync "feat: ..."` | Full pipeline ??memlog ??sync-md ??changelog ??audit ??commit ??PR |
 | `/memlog "summary"` | Append session entry to `memory/YYYY-MM-DD.md` only |
 | `/new-task "task name"` | Create task tracking block in today's memory log |
 
@@ -70,7 +70,7 @@ These commands are available as both `/slash-commands` and via the `Skill` tool:
 ### Hooks
 
 ```json
-// .claude/settings.json — enable PostToolUse audit after every Write/Edit:
+// .claude/settings.json ??enable PostToolUse audit after every Write/Edit:
 {
   "hooks": {
     "PostToolUse": [
@@ -107,8 +107,8 @@ git config core.hooksPath .githooks
 ### Behavioral Rules
 
 #### Response Language
-- All **conversational** replies → **Korean (한국어)** by default.
-- All code, config, commit messages, PR titles, branch names → **English only**.
+- All **conversational** replies ??**Korean (?쒓뎅??** by default.
+- All code, config, commit messages, PR titles, branch names ??**English only**.
 
 #### Plan Mode
 Enter plan mode (`EnterPlanMode`) when:
@@ -127,7 +127,7 @@ Each implementation task follows the Phase 4 execution loop:
 1. **code-writer** implements the changes
 2. **test-runner** verifies against acceptance criteria and runs tests
 3. **Quality gate (audit script)** validates compliance
-Fix and re-review if issues found — maximum **3 iterations** before escalating to the user.
+Fix and re-review if issues found ??maximum **3 iterations** before escalating to the user.
 
 ---
 
@@ -136,14 +136,14 @@ Fix and re-review if issues found — maximum **3 iterations** before escalating
 If a slash command or background script returns a non-zero exit code:
 - **Never bypass hooks** with `--no-verify` unless under explicit written user instruction.
 - **Diagnose first**: read the failure log. Common causes:
-  - `CHANGELOG.md` not staged → run `/changelog` and stage the file, then retry.
-  - Direct push to `main` blocked by pre-push hook → use `/sync` to create a PR branch automatically.
+  - `CHANGELOG.md` not staged ??run `/changelog` and stage the file, then retry.
+  - Direct push to `main` blocked by pre-push hook ??use `/sync` to create a PR branch automatically.
 
 ---
 
 ### Git
 
-Follow conventions in [`docs/context.md § Git Conventions`](docs/context.md).
+Follow conventions in [`docs/context.md 짠 Git Conventions`](docs/context.md).
 Always append to AI-generated commit messages:
 
 ```
@@ -154,10 +154,10 @@ Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>
 
 ### MCP Servers
 
-Document project-specific `.mcp.json` entries here. General MCP guidance: workspace [`../CLAUDE.md §3`](../CLAUDE.md).
+Document project-specific `.mcp.json` entries here. General MCP guidance: workspace [`https://raw.githubusercontent.com/5throck/ai-workspace-standards/main/CLAUDE.md 짠3`](https://raw.githubusercontent.com/5throck/ai-workspace-standards/main/CLAUDE.md).
 
 ```json
-// .mcp.json — example structure (add to project root; gitignored env vars go in .mcp.local.json)
+// .mcp.json ??example structure (add to project root; gitignored env vars go in .mcp.local.json)
 // {
 //   "mcpServers": {
 //     "<server-name>": {
@@ -171,14 +171,15 @@ Document project-specific `.mcp.json` entries here. General MCP guidance: worksp
 // }
 ```
 
-> Use relative paths for `command` — Claude Code resolves them against the project root.
+> Use relative paths for `command` ??Claude Code resolves them against the project root.
 
 ---
 
 ### Model Selection Override
-<!-- agents/*.md use `model: inherit` — inheriting from workspace ../CLAUDE.md defaults: -->
+<!-- agents/*.md use `model: inherit` ??inheriting from workspace https://raw.githubusercontent.com/5throck/ai-workspace-standards/main/CLAUDE.md defaults: -->
 <!--   - Default (inherit)    : claude-sonnet-4-6                          -->
 <!--   - Heavy reasoning      : claude-opus-4-7                            -->
 <!--   - Fast lookups         : claude-haiku-4-5-20251001                  -->
 <!-- Uncomment below to override workspace defaults for this project only. -->
 <!-- model: claude-opus-4-7                                                -->
+

--- a/templates/GEMINI.md
+++ b/templates/GEMINI.md
@@ -1,7 +1,7 @@
-# GEMINI.md
+﻿# GEMINI.md
 
-> **All project context, coding guidelines, and dev workflow → [`docs/context.md`](docs/context.md)**
-> Workspace-level Gemini behaviors → [`../GEMINI.md`](../GEMINI.md)
+> **All project context, coding guidelines, and dev workflow ??[`docs/context.md`](docs/context.md)**
+> Workspace-level Gemini behaviors ??[`https://raw.githubusercontent.com/5throck/ai-workspace-standards/main/GEMINI.md`](https://raw.githubusercontent.com/5throck/ai-workspace-standards/main/GEMINI.md)
 
 > **Doc intent:** This file contains Gemini CLI-specific overrides only.
 > Shared project context (architecture, tech stack, coding guidelines) lives in [`docs/context.md`](docs/context.md).
@@ -11,7 +11,7 @@
 
 Load project files at session start using the `@` syntax:
 ```
-@../CONSTITUTION.md      # workspace design standard
+@https://raw.githubusercontent.com/5throck/ai-workspace-standards/main/CONSTITUTION.md      # workspace design standard
 @docs/context.md         # project knowledge (includes Session Start Skills)
 @AGENTS.md               # canonical agent roster
 @memory/MEMORY.md        # recent changes (skip if file does not exist)
@@ -19,8 +19,8 @@ Load project files at session start using the `@` syntax:
 ```
 
 <!-- Add project-specific files below as needed, e.g.:               -->
-<!-- @locales/en.json    — baseline locale for i18n work              -->
-<!-- @docs/BIZ_LOGIC.md  — domain formulas / business rules           -->
+<!-- @locales/en.json    ??baseline locale for i18n work              -->
+<!-- @docs/BIZ_LOGIC.md  ??domain formulas / business rules           -->
 
 ---
 
@@ -40,11 +40,11 @@ Gemini CLI uses different tool names from Claude Code:
 | **Command Execution** | `run_command` | Execute PowerShell/Bash shell commands. Returns task process IDs. NEVER use `cd` commands. |
 | **Agent** | `invoke_subagent` | Pass agent role from `agents/<name>.md` |
 
-#### ⚠️ Surgical Multi-Replace Offset Safeguard
+#### ?좑툘 Surgical Multi-Replace Offset Safeguard
 When calling `multi_replace_file_content` with multiple `ReplacementChunks`, the line numbers of subsequent target blocks will shift if previous edits change the line count.
 - **Rule**: Sort and process `ReplacementChunks` from the **bottom of the file to the top** (descending order of line numbers: largest `StartLine` first).
 
-#### ⚠️ Grep Search 50-Match Cap Safeguard
+#### ?좑툘 Grep Search 50-Match Cap Safeguard
 The `grep_search` tool silently truncates results at exactly **50 matches**.
 - **Rule**: If a search yields 50 results, do **NOT** assume you have all occurrences.
 - **Remediation**: Partition the search by targeting specific subdirectories or applying restrictive file glob filters via the `Includes` parameter.
@@ -75,7 +75,7 @@ When entering Planning Mode, leverage these three Markdown artifacts (set `IsArt
 *Path: `<appDataDir>\brain\<session-id>\task.md`*
 - **Purpose**: Running TODO list to track development progress dynamically.
 - **Metadata**: `ArtifactType: "task"`.
-- **Syntax**: `- [ ]` uncompleted · `- [/]` in progress · `- [x]` completed.
+- **Syntax**: `- [ ]` uncompleted 쨌 `- [/]` in progress 쨌 `- [x]` completed.
 
 #### 3. `walkthrough.md`
 *Path: `<appDataDir>\brain\<session-id>\walkthrough.md`*
@@ -112,11 +112,11 @@ For parallel execution, quality reviews, or sandboxed research tasks, utilize th
 
 #### Communication (`send_message`)
 Interact with spawned agents via their unique `conversationID`.
-**Reactive Wakeup**: Do not poll in a loop — simply yield execution and the platform wakes you automatically when an agent replies or a background task completes.
+**Reactive Wakeup**: Do not poll in a loop ??simply yield execution and the platform wakes you automatically when an agent replies or a background task completes.
 
 ### Response Language
-- All **conversational** replies → **Korean (한국어)** by default.
-- All code, config, commit messages, PR titles, branch names → **English only**.
+- All **conversational** replies ??**Korean (?쒓뎅??** by default.
+- All code, config, commit messages, PR titles, branch names ??**English only**.
 
 ### Optimal Interaction Guidelines
 - **Context Management**: Leverage your massive context window by cross-referencing multiple files simultaneously (e.g., when debugging, review log files along with related code).
@@ -153,11 +153,11 @@ Instead, emulate them by reading the `.md` file and executing the described scri
 | Equivalent to | Run instead |
 |---------------|------------|
 | `/sync "feat: ..."` | `bash scripts/dev-sync.sh "feat: ..."` |
-| `/memlog "summary"` | Manually append `## Session — summary` to `memory/YYYY-MM-DD.md` |
+| `/memlog "summary"` | Manually append `## Session ??summary` to `memory/YYYY-MM-DD.md` |
 | `/changelog "..."` | Manually add entry to `CHANGELOG.md [Unreleased]` |
 | `/new-task "name"` | Manually append task block to `memory/YYYY-MM-DD.md` |
-| `/new-project "name"` | `bash scripts/new-project.sh "<name>"` (macOS/Linux) · `.\scripts\new-project.ps1 "<name>"` (Windows) |
-| `/post-write` | `bash scripts/audit.sh` (macOS/Linux) · `.\scripts\audit.ps1` (Windows) |
+| `/new-project "name"` | `bash scripts/new-project.sh "<name>"` (macOS/Linux) 쨌 `.\scripts\new-project.ps1 "<name>"` (Windows) |
+| `/post-write` | `bash scripts/audit.sh` (macOS/Linux) 쨌 `.\scripts\audit.ps1` (Windows) |
 
 ---
 
@@ -167,7 +167,7 @@ This project uses `.claude/` for Claude Code configuration. Gemini follows these
 
 - **Absolute Precedence**: `.gemini/` always takes precedence over `.claude/` if both exist.
 - **Fallback**: If no `.gemini/` directory exists, Gemini may read `.claude/settings.json` and `.claude/commands/` as a fallback source of truth.
-- **Command Emulation**: Slash commands defined as `.claude/commands/<name>.md` can be emulated — read the file to understand the underlying script and run it directly via `shell`.
+- **Command Emulation**: Slash commands defined as `.claude/commands/<name>.md` can be emulated ??read the file to understand the underlying script and run it directly via `shell`.
 - **Agent Roles**: Gemini can instantiate roles defined in `agents/*.md` using `define_subagent` and `invoke_subagent`.
 - **Migration**: If the project transitions away from Claude Code, proactively offer to migrate `.claude/` configuration to `.gemini/` rather than leaving legacy files orphaned.
 
@@ -177,3 +177,4 @@ This project uses `.claude/` for Claude Code configuration. Gemini follows these
 <!-- Uncomment to override workspace defaults for this project only.          -->
 <!-- - Default      : gemini-2.5-pro                                          -->
 <!-- - Fast lookups : gemini-2.5-flash                                        -->
+

--- a/templates/README.md
+++ b/templates/README.md
@@ -1,4 +1,4 @@
-# {{PROJECT_NAME}}
+﻿# {{PROJECT_NAME}}
 
 {{PROJECT_DESCRIPTION}}
 
@@ -29,17 +29,18 @@ cp .env.sample .env   # fill in values
 
 ## Documentation
 
-- **Project context & architecture** → [`docs/context.md`](docs/context.md)
-- **Agent index** → [`AGENTS.md`](AGENTS.md)
-- **Change history** → [`CHANGELOG.md`](CHANGELOG.md)
-- **Workspace standards** → [`../CONSTITUTION.md`](../CONSTITUTION.md)
-- **Claude Code config** → [`CLAUDE.md`](CLAUDE.md)
-- **Gemini CLI config** → [`GEMINI.md`](GEMINI.md)
+- **Project context & architecture** ??[`docs/context.md`](docs/context.md)
+- **Agent index** ??[`AGENTS.md`](AGENTS.md)
+- **Change history** ??[`CHANGELOG.md`](CHANGELOG.md)
+- **Workspace standards** ??[`https://raw.githubusercontent.com/5throck/ai-workspace-standards/main/CONSTITUTION.md`](https://raw.githubusercontent.com/5throck/ai-workspace-standards/main/CONSTITUTION.md)
+- **Claude Code config** ??[`CLAUDE.md`](CLAUDE.md)
+- **Gemini CLI config** ??[`GEMINI.md`](GEMINI.md)
 
 ## Contributing
 
-[Describe how to contribute — or delete this section if the project is private/internal.]
+[Describe how to contribute ??or delete this section if the project is private/internal.]
 
 ## License
 
-[License name] — see [LICENSE](LICENSE)
+[License name] ??see [LICENSE](LICENSE)
+

--- a/templates/README_ko.md
+++ b/templates/README_ko.md
@@ -1,45 +1,46 @@
-# {{PROJECT_NAME}}
+﻿# {{PROJECT_NAME}}
 
 {{PROJECT_DESCRIPTION}}
 
-## 프로젝트 특징 (Characteristics)
+## ?꾨줈?앺듃 ?뱀쭠 (Characteristics)
 
 {{PROJECT_CHARACTERISTICS}}
 
-## 프로젝트 사용법
+## ?꾨줈?앺듃 ?ъ슜踰?
 
-1. **설정 검토**: `AGENTS.md`, `CLAUDE.md`, `GEMINI.md`를 열고 새 프로젝트의 구체적인 역할과 목표에 맞게 수정합니다.
-2. **스크립트 수정**: `scripts/` 디렉토리 내의 파일들(예: `dev-sync.ps1`, `audit.ps1`)을 검토하고, 프로젝트의 요구사항에 맞추어 주석이나 하드코딩된 예시 텍스트를 수정합니다.
-3. **메모리 초기화**: 새 프로젝트에 맞는 `memory/MEMORY.md` 인덱스를 시작합니다.
+1. **?ㅼ젙 寃??*: `AGENTS.md`, `CLAUDE.md`, `GEMINI.md`瑜??닿퀬 ???꾨줈?앺듃??援ъ껜?곸씤 ??븷怨?紐⑺몴??留욊쾶 ?섏젙?⑸땲??
+2. **?ㅽ겕由쏀듃 ?섏젙**: `scripts/` ?붾젆?좊━ ?댁쓽 ?뚯씪???? `dev-sync.ps1`, `audit.ps1`)??寃?좏븯怨? ?꾨줈?앺듃???붽뎄?ы빆??留욎텛??二쇱꽍?대굹 ?섎뱶肄붾뵫???덉떆 ?띿뒪?몃? ?섏젙?⑸땲??
+3. **硫붾え由?珥덇린??*: ???꾨줈?앺듃??留욌뒗 `memory/MEMORY.md` ?몃뜳?ㅻ? ?쒖옉?⑸땲??
 
-## 빠른 시작
+## 鍮좊Ⅸ ?쒖옉
 
 ```bash
-# 1. 훅(hooks) 활성화
+# 1. ??hooks) ?쒖꽦??
 git config core.hooksPath .githooks
 
-# 2. 환경 설정
-cp .env.sample .env   # 환경 변수 값 입력
+# 2. ?섍꼍 ?ㅼ젙
+cp .env.sample .env   # ?섍꼍 蹂??媛??낅젰
 
-# 3. 의존성 설치
+# 3. ?섏〈???ㅼ튂
 # Python:  python -m venv .venv && source .venv/bin/activate && pip install -r requirements.txt
 # Node.js: npm install
 
 ```
 
-## 핵심 문서
+## ?듭떖 臾몄꽌
 
-- **프로젝트 컨텍스트 & 아키텍처** → [`docs/context.md`](docs/context.md)
-- **에이전트 인덱스** → [`AGENTS.md`](AGENTS.md)
-- **변경 이력** → [`CHANGELOG.md`](CHANGELOG.md)
-- **워크스페이스 표준** → [`../CONSTITUTION.md`](../CONSTITUTION.md)
-- **Claude Code 설정** → [`CLAUDE.md`](CLAUDE.md)
-- **Gemini CLI 설정** → [`GEMINI.md`](GEMINI.md)
+- **?꾨줈?앺듃 而⑦뀓?ㅽ듃 & ?꾪궎?띿쿂** ??[`docs/context.md`](docs/context.md)
+- **?먯씠?꾪듃 ?몃뜳??* ??[`AGENTS.md`](AGENTS.md)
+- **蹂寃??대젰** ??[`CHANGELOG.md`](CHANGELOG.md)
+- **?뚰겕?ㅽ럹?댁뒪 ?쒖?** ??[`https://raw.githubusercontent.com/5throck/ai-workspace-standards/main/CONSTITUTION.md`](https://raw.githubusercontent.com/5throck/ai-workspace-standards/main/CONSTITUTION.md)
+- **Claude Code ?ㅼ젙** ??[`CLAUDE.md`](CLAUDE.md)
+- **Gemini CLI ?ㅼ젙** ??[`GEMINI.md`](GEMINI.md)
 
-## 기여하기
+## 湲곗뿬?섍린
 
-[기여 방법을 설명하세요 — 프라이빗/내부 프로젝트인 경우 이 섹션을 삭제하세요.]
+[湲곗뿬 諛⑸쾿???ㅻ챸?섏꽭?????꾨씪?대퉿/?대? ?꾨줈?앺듃??寃쎌슦 ???뱀뀡????젣?섏꽭??]
 
-## 라이선스
+## ?쇱씠?좎뒪
 
-[라이선스 이름] — [LICENSE](LICENSE) 파일 참조
+[?쇱씠?좎뒪 ?대쫫] ??[LICENSE](LICENSE) ?뚯씪 李몄“
+

--- a/templates/agents/architect.md
+++ b/templates/agents/architect.md
@@ -1,9 +1,9 @@
----
+﻿---
 name: architect
 model: inherit
 color: blue
 description: >
-  Design agent — produces implementation plans and technical specs. Use when: planning a new
+  Design agent ??produces implementation plans and technical specs. Use when: planning a new
   feature, evaluating architectural trade-offs, or generating an ADR before implementation starts.
 examples:
   - user: "Design the data model for user authentication"
@@ -12,13 +12,13 @@ examples:
 
 ## Role
 
-You are the architect for **[Project Name]**. You own Phase 3 — Design. You produce clear, reviewable implementation plans before any code is written. You never write application code directly — your output is always a plan or technical specification for the code-writer to execute.
+You are the architect for **[Project Name]**. You own Phase 3 ??Design. You produce clear, reviewable implementation plans before any code is written. You never write application code directly ??your output is always a plan or technical specification for the code-writer to execute.
 
 ## Responsibilities
 
 - Analyze requirements and acceptance criteria from the Analysis phase.
 - Design the implementation: data models, API surface, module boundaries, file changes.
-- Identify and document trade-offs explicitly — never pick silently.
+- Identify and document trade-offs explicitly ??never pick silently.
 - Produce an ADR (`docs/adr/NNNN-slug.md`) for significant architectural decisions.
 - Present the plan to the PM; do **not** proceed to implementation without explicit user approval.
 
@@ -54,8 +54,9 @@ One paragraph describing what will be built and why this approach was chosen.
 
 ## Constraints
 
-- Never write application source code — produce plans only.
+- Never write application source code ??produce plans only.
 - Surface all ambiguities before finalizing the plan.
 - Flag any change that touches more than 3 files as high-risk and require explicit user confirmation.
-- All ADRs must follow the 3-section format: Context → Decision → Consequences.
-- ADR template: see `../../templates/_examples/adr/0001-example-decision.md` in the workspace root (not copied into the project — reference only).
+- All ADRs must follow the 3-section format: Context ??Decision ??Consequences.
+- ADR template: see `https://raw.githubusercontent.com/5throck/ai-workspace-standards/main/templates/_examples/adr/0001-example-decision.md` in the workspace root (not copied into the project ??reference only).
+

--- a/templates/agents/pm.md
+++ b/templates/agents/pm.md
@@ -1,9 +1,9 @@
----
+﻿---
 name: pm
 model: inherit
 color: yellow
 description: >
-  PM orchestrator — owns the full workflow. Use when: starting any multi-step task,
+  PM orchestrator ??owns the full workflow. Use when: starting any multi-step task,
   coordinating parallel agents, reviewing a feature request, or running the QA gate.
 examples:
   - user: "Add a new API endpoint for user registration"
@@ -12,22 +12,22 @@ examples:
 
 ## Role
 
-You are the PM orchestrator for **[Project Name]**. You own the end-to-end workflow from triage to PR creation. You never implement code directly — you classify requests, dispatch specialist agents, synthesize findings, and enforce quality gates.
+You are the PM orchestrator for **[Project Name]**. You own the end-to-end workflow from triage to PR creation. You never implement code directly ??you classify requests, dispatch specialist agents, synthesize findings, and enforce quality gates.
 
 ## Governance Workflow
 
-Follow the 6-phase PM workflow defined in [CONSTITUTION.md §5](../../CONSTITUTION.md#5-multi-agent-architecture), with a preliminary step for dynamic team assembly:
+Follow the 6-phase PM workflow defined in [CONSTITUTION.md 짠5](../https://raw.githubusercontent.com/5throck/ai-workspace-standards/main/CONSTITUTION.md#5-multi-agent-architecture), with a preliminary step for dynamic team assembly:
 
-0. **Team Assembly & Skill Orchestration** — During project kickoff, analyze project requirements and assess if the default agent roster or existing skills are sufficient. 
+0. **Team Assembly & Skill Orchestration** ??During project kickoff, analyze project requirements and assess if the default agent roster or existing skills are sufficient. 
    - If specialized agents are needed, generate `agents/<name>.md`. Update existing agents' files to prevent role overlap.
    - If specialized workflows are needed, generate `skills/<name>/SKILL.md` directly (using proper YAML frontmatter) or instruct agents to use `workflow-skill-creator` later for complex tasks.
    - Update `AGENTS.md` and `docs/context.md` (Session Start Skills) with any new agents or skills.
-1. **Triage** — Classify the request; dispatch read-only agents in parallel (single message).
-2. **Analysis** — Synthesize findings into requirements + acceptance criteria.
-3. **Design** — Dispatch architect (implementation plan + ADR) and, if the task has UI/UX surface, designer (wireframes + component spec) in parallel; obtain explicit user approval before proceeding.
-4. **Implementation** — Dispatch code-writer (serial); test-runner verifies after each change.
-5. **QA** — Verify all acceptance criteria; run audit script + tests.
-6. **Finalization** — Run memlog → sync; open PR; hand off to user. All AI-generated commits must include `Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>`.
+1. **Triage** ??Classify the request; dispatch read-only agents in parallel (single message).
+2. **Analysis** ??Synthesize findings into requirements + acceptance criteria.
+3. **Design** ??Dispatch architect (implementation plan + ADR) and, if the task has UI/UX surface, designer (wireframes + component spec) in parallel; obtain explicit user approval before proceeding.
+4. **Implementation** ??Dispatch code-writer (serial); test-runner verifies after each change.
+5. **QA** ??Verify all acceptance criteria; run audit script + tests.
+6. **Finalization** ??Run memlog ??sync; open PR; hand off to user. All AI-generated commits must include `Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>`.
 
 ## Agent Roster
 
@@ -47,3 +47,4 @@ Add rows as specialist agents are created. Start with PM only; expand when the p
 - Maximum **3 fix iterations** per review cycle before escalating to the user.
 - Never bypass audit hooks (`--no-verify` is forbidden).
 - All Git artifacts (commit messages, PR titles, branch names) must be in English.
+

--- a/templates/docs/context.md
+++ b/templates/docs/context.md
@@ -1,4 +1,4 @@
-# [Project Name]
+﻿# [Project Name]
 
 ## Project Overview
 [One-sentence description of what this project does and who it's for.]
@@ -17,24 +17,24 @@
 ## Architecture
 ```
 [project root]/
-├── src/                  # [main source — e.g., app logic, API handlers]
-│   ├── [folder]          # [description]
-│   └── [folder]          # [description]
-├── docs/                 # project context, ADRs
-├── agents/               # AI agent definitions
-├── scripts/              # audit, dev-sync, sync-md
-├── memory/               # session logs
-└── [any other top-level dirs]
+?쒋?? src/                  # [main source ??e.g., app logic, API handlers]
+??  ?쒋?? [folder]          # [description]
+??  ?붴?? [folder]          # [description]
+?쒋?? docs/                 # project context, ADRs
+?쒋?? agents/               # AI agent definitions
+?쒋?? scripts/              # audit, dev-sync, sync-md
+?쒋?? memory/               # session logs
+?붴?? [any other top-level dirs]
 ```
 
 ## Environment Setup
-- Copy `.env.sample` → `.env` and fill in all required values.
+- Copy `.env.sample` ??`.env` and fill in all required values.
 - **Python**:
   - macOS/Linux: `python -m venv .venv && source .venv/bin/activate && pip install -r requirements.txt`
   - Windows:     `python -m venv .venv && .venv\Scripts\activate && pip install -r requirements.txt`
 - **Node.js**: `npm install`
 - Required env keys (see `.env.sample`):
-  - `[KEY_NAME]` — [description] *(replace with actual keys, or write "N/A — no env vars required")*
+  - `[KEY_NAME]` ??[description] *(replace with actual keys, or write "N/A ??no env vars required")*
 
 ## Agents
 <!-- See AGENTS.md at the project root for the full agent index (canonical source). -->
@@ -42,25 +42,25 @@
 <!-- NOTE: This list may be dynamically expanded by the PM during the Kickoff Phase.-->
 | Group | Agent file | Role |
 |-------|------------|------|
-| Orchestration | `agents/pm.md` | PM orchestrator — owns the workflow, dispatches parallel tasks |
-| Orchestration | `agents/security-monitor.md` | Security monitor — enforces policies, prevents secrets leaks |
-| Design | `agents/architect.md` | Architect — produces implementation plans and ADRs |
-| Design | `agents/designer.md` | Designer — produces UI/UX specs, wireframes, and component definitions |
-| Execution | `agents/code-writer.md` | Code writer — implements approved plans |
-| Execution | `agents/test-runner.md` | Test runner — verifies acceptance criteria and runs QA gate |
+| Orchestration | `agents/pm.md` | PM orchestrator ??owns the workflow, dispatches parallel tasks |
+| Orchestration | `agents/security-monitor.md` | Security monitor ??enforces policies, prevents secrets leaks |
+| Design | `agents/architect.md` | Architect ??produces implementation plans and ADRs |
+| Design | `agents/designer.md` | Designer ??produces UI/UX specs, wireframes, and component definitions |
+| Execution | `agents/code-writer.md` | Code writer ??implements approved plans |
+| Execution | `agents/test-runner.md` | Test runner ??verifies acceptance criteria and runs QA gate |
 
 ## Skills
 | Skill path | Trigger condition |
 |------------|-------------------|
-| *(none yet — add entries as skills are created in `skills/`)* | |
+| *(none yet ??add entries as skills are created in `skills/`)* | |
 
 ## Session Start Skills
 <!-- Skills listed here are loaded at the start of EVERY session by ALL AI tools. -->
 <!-- NOTE: This list may be dynamically expanded by the PM during the Kickoff Phase.-->
-<!-- Format: `skills/<name>/SKILL.md` — reason / trigger                          -->
-<!-- Example: `skills/auth-flow/SKILL.md` — always load when auth-related tasks   -->
+<!-- Format: `skills/<name>/SKILL.md` ??reason / trigger                          -->
+<!-- Example: `skills/auth-flow/SKILL.md` ??always load when auth-related tasks   -->
 <!-- Add a skill: create skills/<name>/SKILL.md, then add a line below.           -->
-<!-- See ../../templates/_examples/skills/example-skill/SKILL.md for the template.-->
+<!-- See https://raw.githubusercontent.com/5throck/ai-workspace-standards/main/templates/_examples/skills/example-skill/SKILL.md for the template.-->
 - *(none yet)*
 
 ## Development Workflow
@@ -70,13 +70,13 @@ bash scripts/audit.sh            # Windows: .\scripts\audit.ps1
 
 # Log a session entry (without syncing)
 # Claude Code:  /memlog "summary"
-# Bash:         echo "## Session — summary" >> memory/$(date +%Y-%m-%d).md
+# Bash:         echo "## Session ??summary" >> memory/$(date +%Y-%m-%d).md
 
 # Add a changelog entry (optional, before sync)
 # Claude Code:  /changelog "added|changed|fixed|removed <description>"
 # Gemini CLI:   append to CHANGELOG.md under [Unreleased]
 
-# Full sync: memlog → sync-md → changelog → audit → commit → PR
+# Full sync: memlog ??sync-md ??changelog ??audit ??commit ??PR
 bash scripts/dev-sync.sh "feat: description"   # Windows: .\scripts\dev-sync.ps1 "feat: ..."
 # Claude Code:  /sync "feat: description"
 ```
@@ -102,33 +102,33 @@ Each `.claude/commands/<name>.md` file is auto-registered as a Skill in Claude C
 
 ```
 /sync "feat: description"
-  ↓
+  ??
   1. memory/YYYY-MM-DD.md append (memlog)
   2. memory/MEMORY.md index update (sync-md)
   3. CHANGELOG.md [Unreleased] auto-add
-  4. audit.sh                    ← must exit 0
+  4. audit.sh                    ??must exit 0
   5. git checkout -b pr/<date>-<slug>
   6. git commit + push
-  7. gh pr create → GitHub PR
+  7. gh pr create ??GitHub PR
 ```
 
 > Run `/changelog "description"` before `/sync` to pre-populate the changelog entry.
-> **Rule: All changes reach `main` via PR only — never direct push.**
+> **Rule: All changes reach `main` via PR only ??never direct push.**
 
 ---
 
 ## Key Files
 | File | Purpose |
 |------|---------|
-| `docs/context.md` | This file — single source of truth for all AI tools |
-| `AGENTS.md` | Canonical agent index — auto-loaded by Claude Code |
-| `agents/pm.md` | PM orchestrator — workflow owner |
-| `agents/security-monitor.md` | Security agent — enforces policies and scans for secrets |
-| `agents/architect.md` | Design agent — implementation plans and ADRs |
-| `agents/designer.md` | Design agent — UI/UX specs and component definitions |
-| `agents/code-writer.md` | Implementation agent — writes code from approved plans |
-| `agents/test-runner.md` | QA agent — runs tests and verifies acceptance criteria |
-| `scripts/dev-sync.sh` | Full sync pipeline (memlog → sync-md → changelog → audit → commit → PR) |
+| `docs/context.md` | This file ??single source of truth for all AI tools |
+| `AGENTS.md` | Canonical agent index ??auto-loaded by Claude Code |
+| `agents/pm.md` | PM orchestrator ??workflow owner |
+| `agents/security-monitor.md` | Security agent ??enforces policies and scans for secrets |
+| `agents/architect.md` | Design agent ??implementation plans and ADRs |
+| `agents/designer.md` | Design agent ??UI/UX specs and component definitions |
+| `agents/code-writer.md` | Implementation agent ??writes code from approved plans |
+| `agents/test-runner.md` | QA agent ??runs tests and verifies acceptance criteria |
+| `scripts/dev-sync.sh` | Full sync pipeline (memlog ??sync-md ??changelog ??audit ??commit ??PR) |
 | `scripts/audit.sh` | Documentation audit script |
 | `scripts/sync-md.sh` | Updates `memory/MEMORY.md` index with today's session entry |
 | `memory/MEMORY.md` | Session log index |
@@ -138,11 +138,11 @@ Each `.claude/commands/<name>.md` file is auto-registered as a Skill in Claude C
 ## Coding Guidelines
 
 > These rules apply to every AI tool working in this project.
-> Full rationale: [CONSTITUTION.md §8](../../CONSTITUTION.md#8-coding-behavior-guidelines)
-> *(This file lives in `docs/` — `../` = project root, `../../` = workspace root where `CONSTITUTION.md` lives.)*
+> Full rationale: [CONSTITUTION.md 짠8](../https://raw.githubusercontent.com/5throck/ai-workspace-standards/main/CONSTITUTION.md#8-coding-behavior-guidelines)
+> *(This file lives in `docs/` ??`../` = project root, `../../` = workspace root where `CONSTITUTION.md` lives.)*
 
 ### 1. Think Before Coding
-- State assumptions explicitly before implementing. If uncertain, ask — don't guess silently.
+- State assumptions explicitly before implementing. If uncertain, ask ??don't guess silently.
 - If multiple interpretations exist, present them; don't pick one silently.
 - If something is unclear, stop and name what's confusing.
 - **Secrets**: Never hardcode passwords, API tokens, or keys. Always use env vars / `.env.sample`.
@@ -159,8 +159,8 @@ Each `.claude/commands/<name>.md` file is auto-registered as a Skill in Claude C
 
 ### 4. Goal-Driven Execution
 - Convert every task into a verifiable goal before starting:
-  - "Add validation" → "Write tests for invalid inputs, then make them pass"
-  - "Fix the bug" → "Write a reproducer test, then fix it"
+  - "Add validation" ??"Write tests for invalid inputs, then make them pass"
+  - "Fix the bug" ??"Write a reproducer test, then fix it"
 - For multi-step tasks, state a brief numbered plan with a verify step for each.
 
 ### 5. Open-Source Package Policy
@@ -168,8 +168,9 @@ Each `.claude/commands/<name>.md` file is auto-registered as a Skill in Claude C
 - **Avoid** GPL-3.0, AGPL-3.0, SSPL, BSL, or proprietary licenses unless explicitly justified.
 - Run `bash scripts/setup.sh --skip-commit` after adding dependencies to trigger the license audit.
 - Document any intentional non-OSS dependency in this file under a `## Non-OSS Dependencies` section.
-- Full policy: [CONSTITUTION.md §8.5](../../CONSTITUTION.md#5-open-source-package-policy)
+- Full policy: [CONSTITUTION.md 짠8.5](../https://raw.githubusercontent.com/5throck/ai-workspace-standards/main/CONSTITUTION.md#5-open-source-package-policy)
 
 ### 6. Response Language
-- All **conversational** replies to the user → **Korean (한국어)** by default.
-- All code, config, commit messages, PR titles, branch names, **CHANGELOG.md**, and **memory/ logs** → **English only**.
+- All **conversational** replies to the user ??**Korean (?쒓뎅??** by default.
+- All code, config, commit messages, PR titles, branch names, **CHANGELOG.md**, and **memory/ logs** ??**English only**.
+


### PR DESCRIPTION
Migrated hardcoded local relative paths (e.g. `../CONSTITUTION.md`) to absolute GitHub URLs to allow projects to be checked out and developed independently of the workspace root path.