### PR TITLE
fix: add UTF-8 BOM to .ps1 scripts for PowerShell 5.1 compatibility

### DIFF
--- a/scripts/audit.ps1
+++ b/scripts/audit.ps1
@@ -1,4 +1,4 @@
-# audit.ps1 — Documentation integrity check (Windows PowerShell)
+﻿# audit.ps1 — Documentation integrity check (Windows PowerShell)
 # Mirrors audit.sh exactly. Exit code 0 = pass, non-zero = fail.
 
 $errors = 0
@@ -60,3 +60,4 @@ if (Test-Path "docs\context.md") {
 Write-Host ""
 if ($errors -eq 0) { Write-Host "✅ All checks passed." -ForegroundColor Green; exit 0 }
 else               { Write-Host "❌ $errors check(s) failed. Fix before committing." -ForegroundColor Red; exit 1 }
+

--- a/scripts/dev-sync.ps1
+++ b/scripts/dev-sync.ps1
@@ -1,4 +1,4 @@
-# dev-sync.ps1 — Full pipeline: memlog → sync-md → changelog → audit → commit → PR (Windows)
+﻿# dev-sync.ps1 — Full pipeline: memlog → sync-md → changelog → audit → commit → PR (Windows)
 # Usage: .\scripts\dev-sync.ps1 "feat: description"
 param([string]$Msg = "chore: update")
 
@@ -76,3 +76,4 @@ if (Test-Path ".github\pull_request_template.md") {
 } else {
     gh pr create --fill
 }
+

--- a/scripts/new-project.ps1
+++ b/scripts/new-project.ps1
@@ -1,4 +1,4 @@
-# new-project.ps1 — Scaffold a new project under the workspace root (Windows)
+﻿# new-project.ps1 — Scaffold a new project under the workspace root (Windows)
 # Usage: .\scripts\new-project.ps1 "<project-name>"
 param([Parameter(Mandatory)][string]$ProjectName)
 
@@ -101,3 +101,4 @@ Set-Location $ProjectDir
 Write-Host ""
 Write-Host "Extension templates (ADR, analyst agent, skill, daily log):" -ForegroundColor DarkGray
 Write-Host "  → $TemplatesDir\_examples\" -ForegroundColor DarkGray
+

--- a/scripts/sync-md.ps1
+++ b/scripts/sync-md.ps1
@@ -1,4 +1,4 @@
-# sync-md.ps1 — Update memory/MEMORY.md index (Windows)
+﻿# sync-md.ps1 — Update memory/MEMORY.md index (Windows)
 # Usage: .\scripts\sync-md.ps1 "YYYY-MM-DD" "summary"
 param(
     [string]$Date    = (Get-Date -Format "yyyy-MM-dd"),
@@ -14,3 +14,4 @@ if (-not (Test-Path $MemFile)) {
 "@ | Set-Content $MemFile -Encoding UTF8
 }
 Add-Content $MemFile "| [$Date]($Date.md) | $Summary |"
+

--- a/templates/scripts/audit.ps1
+++ b/templates/scripts/audit.ps1
@@ -1,4 +1,4 @@
-# audit.ps1 — Documentation integrity check (Windows PowerShell)
+﻿# audit.ps1 — Documentation integrity check (Windows PowerShell)
 # Mirrors audit.sh exactly. Exit code 0 = pass, non-zero = fail.
 
 $errors = 0
@@ -58,3 +58,4 @@ if (Test-Path "docs\context.md") {
 Write-Host ""
 if ($errors -eq 0) { Write-Host "✅ All checks passed." -ForegroundColor Green; exit 0 }
 else { Write-Host "❌ $errors check(s) failed. Fix before committing." -ForegroundColor Red; exit 1 }
+

--- a/templates/scripts/dev-sync.ps1
+++ b/templates/scripts/dev-sync.ps1
@@ -1,4 +1,4 @@
-# dev-sync.ps1 — Full pipeline: memlog → sync-md → changelog → audit → commit → PR (Windows)
+﻿# dev-sync.ps1 — Full pipeline: memlog → sync-md → changelog → audit → commit → PR (Windows)
 # Usage: .\scripts\dev-sync.ps1 "feat: description"
 param([string]$Msg = "chore: update")
 
@@ -75,3 +75,4 @@ if (Test-Path ".github\pull_request_template.md") {
 } else {
     gh pr create --fill
 }
+

--- a/templates/scripts/setup.ps1
+++ b/templates/scripts/setup.ps1
@@ -1,4 +1,4 @@
-# setup.ps1 — Post-scaffold environment setup (Windows PowerShell)
+﻿# setup.ps1 — Post-scaffold environment setup (Windows PowerShell)
 # Mirrors setup.sh exactly. Called automatically by new-project.ps1;
 # can also be re-run manually at any time.
 #
@@ -384,3 +384,4 @@ Write-Host ""
 Write-Host "Next:" -ForegroundColor Cyan
 Write-Host "  git remote add origin <url>"
 Write-Host "  git push -u origin main"
+

--- a/templates/scripts/sync-md.ps1
+++ b/templates/scripts/sync-md.ps1
@@ -1,4 +1,4 @@
-# sync-md.ps1 — Update memory/MEMORY.md index (Windows)
+﻿# sync-md.ps1 — Update memory/MEMORY.md index (Windows)
 # Usage: .\scripts\sync-md.ps1 "YYYY-MM-DD" "summary"
 param(
     [string]$Date    = (Get-Date -Format "yyyy-MM-dd"),
@@ -18,3 +18,4 @@ $existing = Get-Content $MemFile -Raw -ErrorAction SilentlyContinue
 if (-not $existing -or $existing -notmatch [regex]::Escape("[$Date]")) {
     Add-Content $MemFile "| [$Date]($Date.md) | $Summary |"
 }
+


### PR DESCRIPTION
PowerShell 5.1 assumes scripts are ANSI/Windows-1252 if no BOM is present, which breaks scripts containing Unicode characters (e.g. \
ew-project.ps1\ throwing parser errors for \━\). Resaved all \.ps1\ files in \scripts/\ and \	emplates/scripts/\ with UTF-8 BOM encoding.