### PR TITLE
fix: suppress git add warnings during project scaffolding

### DIFF
--- a/templates/scripts/setup.ps1
+++ b/templates/scripts/setup.ps1
@@ -371,7 +371,7 @@ if (Test-Path $IndexPath) {
 if (-not $SkipCommit) {
     $gitDir = git rev-parse --git-dir 2>$null
     if ($LASTEXITCODE -eq 0) {
-        git add -A
+        git add -A 2>$null
         $msg = "chore: initial scaffold`n`nCo-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>"
         git commit -m $msg 2>$null
         if ($LASTEXITCODE -eq 0) { Pass "Initial commit created" } else { Warn "Nothing to commit (already committed?)" }

--- a/templates/scripts/setup.sh
+++ b/templates/scripts/setup.sh
@@ -430,7 +430,7 @@ fi
 # ── 4. Initial commit ─────────────────────────────────────────────────────────
 if [ "$SKIP_COMMIT" = false ]; then
   if git rev-parse --git-dir > /dev/null 2>&1; then
-    git add -A
+    git add -A 2>/dev/null
     if git commit -m "chore: initial scaffold
 
 Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>" 2>/dev/null; then


### PR DESCRIPTION
Suppressed stderr on \git add -A\ in \setup.ps1\ and \setup.sh\ to prevent the wall of 'LF will be replaced by CRLF' warnings from cluttering the terminal output when scaffolding a new project.