### PR TITLE
docs: add instructions for moving to project directory and starting kickoff

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,24 @@ bash scripts/new-project.sh "my-project-name"
 
 Each new project is scaffolded with `docs/context.md`, `AGENTS.md`, `agents/pm.md`, and all required configuration files automatically.
 
+### 4. Move to the new project & Start Kick-off
+
+**CRITICAL**: You must exit your current AI session and start a new one inside the newly created project directory. If you remain at the workspace root, the AI will not load the project-specific configuration and will skip the kick-off meeting.
+
+```bash
+# 1. Exit the current AI session (if running)
+# 2. Move into the newly created project folder
+cd "my-project-name"
+
+# 3. Start a fresh AI session to load project context
+claude
+# or
+agy
+
+# 4. Ask the AI to start the PM kick-off
+> "Start the project kick-off meeting based on the pm agent requirements."
+```
+
 
 
 ---

--- a/README_ko.md
+++ b/README_ko.md
@@ -62,6 +62,24 @@ bash scripts/new-project.sh "my-project-name"
 
 각각의 새로운 프로젝트는 `docs/context.md`, `AGENTS.md`, `agents/pm.md` 및 모든 필수 설정 파일들과 함께 자동으로 스캐폴딩(scaffold)됩니다.
 
+### 4. 새 프로젝트로 이동 및 킥오프 시작
+
+**중요 (CRITICAL)**: 프로젝트 생성이 완료되면 반드시 현재 AI 세션을 종료하고, 방금 생성한 프로젝트 폴더 내부로 이동하여 새로운 AI 세션을 시작해야 합니다. 루트 폴더(최상단)에 계속 머물러 있으면, AI가 프로젝트 전용 환경 설정 파일을 읽지 못해 PM 킥오프 미팅이 생략됩니다.
+
+```bash
+# 1. 실행 중인 AI 세션 종료
+# 2. 새로 생성된 프로젝트 폴더로 이동
+cd "my-project-name"
+
+# 3. 새로운 AI 세션을 시작하여 프로젝트 컨텍스트를 로드
+claude
+# 또는
+agy
+
+# 4. AI에게 PM 킥오프 미팅 시작을 요청
+> "PM 에이전트 지침에 맞춰 프로젝트 킥오프 미팅 진행해 줘."
+```
+
 ---
 
 ## 저장소 구조 (Repository Structure)


### PR DESCRIPTION
Added a new step (Step 4) to the READMEs explicitly instructing users to exit their current session, move into the new project directory, and start a fresh session to properly trigger the PM kick-off meeting.