### PR TITLE
docs: rewrite project creation section by OS

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,19 +46,17 @@ git config core.hooksPath .githooks
 ### 3. Create your first project
 
 ```bash
-# Claude Code
-/new-project
-
-# Antigravity (Gemini CLI)
-# Antigravity will autonomously scaffold the project via a natural language prompt
-# (e.g., "create the my-project-name project") ONLY IF the new-project skill is
-# registered in its global plugins (C:\Users\USER\.gemini\config\plugins\workspace-skills).
-# Otherwise, manually execute the script below.
+# macOS / Linux (bash)
 bash scripts/new-project.sh "my-project-name"
 
-# Windows (Command Prompt & PowerShell)
+# Windows — Git Bash
+bash scripts/new-project.sh "my-project-name"
+
+# Windows — Command Prompt or PowerShell
 .\scripts\new-project.cmd "my-project-name"
 ```
+
+> **AI tool shortcut**: In Claude Code, use `/new-project "my-project-name"` instead of running the script directly.
 
 Each new project is scaffolded with `docs/context.md`, `AGENTS.md`, `agents/pm.md`, and all required configuration files automatically.
 


### PR DESCRIPTION
## Summary

- Rewrites the \"Create your first project\" section to be OS-based (macOS/Linux, Windows Git Bash, Windows CMD/PS) rather than AI-tool-based (Claude Code vs Antigravity)
- `/new-project` shortcut moved to a tip note — not the primary path
- Removes Antigravity-specific wording that was confusing and tool-specific

## Before / After

**Before**: Three blocks split by Claude Code / Antigravity / Windows
**After**: Three blocks split by macOS·Linux / Windows Git Bash / Windows CMD·PS, with AI shortcut as a tip

🤖 Generated with [Claude Code](https://claude.com/claude-code)