### PR TITLE
feat: pre-commit auto-logs memory and CHANGELOG on every direct git commit

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -1,13 +1,14 @@
 #!/usr/bin/env bash
-# pre-commit: documentation audit + secret scan on structural file changes.
-# memory/ session logs are exempt from all checks.
+# pre-commit: auto-log memory + changelog, audit, secret scan.
+# memory/ session logs are exempt from audit/secret checks.
 
 STAGED=$(git diff --cached --name-only)
 [ -z "$STAGED" ] && exit 0
 
-# Skip entirely for memory/-only commits
+# Skip audit/secret checks for memory/-only commits (but still log)
+MEMORY_ONLY=false
 if ! echo "$STAGED" | grep -qv "^memory/"; then
-  exit 0
+  MEMORY_ONLY=true
 fi
 
 # ── 1. Auto-update Markdown "Last Updated" dates ──────────────────────────────
@@ -22,20 +23,60 @@ if [ -n "$MD_STAGED" ]; then
   done
 fi
 
-# ── 1-A. Auto-date CHANGELOG.md [Unreleased] entries ───────────────────────
+# ── 1-A. Auto-date CHANGELOG.md [Unreleased] entries ─────────────────────────
 if echo "$STAGED" | grep -q "CHANGELOG.md"; then
   TODAY=$(date +%Y-%m-%d)
   perl -i -pe '
     BEGIN { $today = shift; $in_unreleased = 0; }
     if (/^## \[Unreleased\]/) { $in_unreleased = 1; }
     elsif (/^## \[/ && !/^## \[Unreleased\]/) { $in_unreleased = 0; }
-    
     if ($in_unreleased && /^(\s*-\s+)(?!\*\*\[\d{4}-\d{2}-\d{2}\]\*\*: )/) {
       s/^(\s*-\s+)/$1**[$today]**: /;
     }
   ' "$TODAY" CHANGELOG.md
   git add CHANGELOG.md
 fi
+
+# ── 1-B. Auto-create memory log + CHANGELOG entry (when bypassing dev-sync) ───
+# Reads commit message from .git/COMMIT_EDITMSG so direct `git commit -m`
+# calls still produce memory and changelog entries automatically.
+COMMIT_MSG=""
+[ -f ".git/COMMIT_EDITMSG" ] && COMMIT_MSG=$(head -1 .git/COMMIT_EDITMSG | sed 's/[[:space:]]*$//')
+
+if [ -n "$COMMIT_MSG" ] && ! echo "$COMMIT_MSG" | grep -qE "^Merge|^WIP|^fixup!|^squash!"; then
+  TODAY=$(date +%Y-%m-%d)
+  mkdir -p memory
+
+  # Auto-append memory log only if dev-sync hasn't already written this entry
+  if ! grep -qF "## $COMMIT_MSG" "memory/$TODAY.md" 2>/dev/null; then
+    FILE_LIST=$(echo "$STAGED" | grep -v "^memory/" | paste -sd ", " - || true)
+    SEPARATOR=""
+    [ -f "memory/$TODAY.md" ] && SEPARATOR=$'\n---\n\n'
+    printf "%s## %s\n- **Files**: %s\n- **Purpose**: (auto-logged by pre-commit)\n- **Decisions**: \n- **Issues**: None\n" \
+      "$SEPARATOR" "$COMMIT_MSG" "$FILE_LIST" >> "memory/$TODAY.md"
+    git add "memory/$TODAY.md"
+  fi
+
+  # Auto-update MEMORY.md index
+  if [ -f "scripts/sync-md.sh" ]; then
+    bash scripts/sync-md.sh "$TODAY" "$COMMIT_MSG" 2>/dev/null || true
+    [ -f "memory/MEMORY.md" ] && git add "memory/MEMORY.md"
+  fi
+
+  # Auto-add CHANGELOG entry if [Unreleased] section is empty
+  if [ -f "CHANGELOG.md" ] && ! echo "$STAGED" | grep -q "CHANGELOG.md"; then
+    SECTION=$(awk '/\[Unreleased\]/{f=1;next} f && /^## /{exit} f{print}' CHANGELOG.md)
+    if ! echo "$SECTION" | grep -qE "^[[:space:]]*[-*]|^### "; then
+      TODAY=$(date +%Y-%m-%d)
+      perl -i -pe 'BEGIN{$m=shift; $d=shift}
+        if (/^## \[Unreleased\]/) { $_ .= "\n- **[$d]**: $m\n" }
+      ' "$COMMIT_MSG" "$TODAY" CHANGELOG.md
+      git add CHANGELOG.md
+    fi
+  fi
+fi
+
+[ "$MEMORY_ONLY" = true ] && exit 0
 
 # ── 2. Block staged .env files ────────────────────────────────────────────────
 if echo "$STAGED" | grep -qE "^\.env$|^\.env\.[^s]|/\.env$|/\.env\.[^s]"; then

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,15 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ## [Unreleased]
 
 ### Added
+- **[2026-05-23]**: `.githooks/pre-commit` + `templates/.githooks/pre-commit`: New §1-B — auto-creates memory log entry and CHANGELOG entry on every direct `git commit`, not just when using `dev-sync.sh`. Reads commit message from `.git/COMMIT_EDITMSG`; skips duplicates already written by dev-sync; stages generated files into the same commit.
+- **[2026-05-23]**: `GEMINI.md`: Added §4 PR Language Rule (reference to CONSTITUTION.md §3); renumbered §4-7 → §5-8; Git & PR Additions: added PR Language bullet.
+- **[2026-05-23]**: `CLAUDE.md`, `GEMINI.md`, `templates/CLAUDE.md`, `templates/GEMINI.md`, `templates/docs/context.md`: PR Language Rule consolidated to CONSTITUTION.md §3 as single source of truth; removed inline duplicates; all files now reference §3 instead.
+- **[2026-05-23]**: `.github/pull_request_template.md`: Converted to English-only (removed Korean bilingual labels).
+- **[2026-05-23]**: `templates/docs/context.md`, `templates/CLAUDE.md`, `templates/GEMINI.md`: §7 PR Language Rule added to scaffold — new projects inherit the English-only PR rule from creation.
+- **[2026-05-23]**: `README_ko.md`: Step 3 updated from tool-based (Claude Code/Antigravity) to OS-based format; AI tool shortcut moved to tip note.
+- **[2026-05-23]**: `templates/README_ko.md`: Full UTF-8 Korean rewrite replacing EUC-KR-corrupted content; mirrors `templates/README.md` structure.
+
+### Added
 - **[2026-05-23]**: `.githooks/pre-commit`: Add Markdown date auto-bumper and CHANGELOG auto-dating logic. Automatically updates `Last Updated:` date in staged `.md` files upon commit, and injects date into undated `CHANGELOG.md` entries.
 
 ### Removed

--- a/memory/2026-05-23.md
+++ b/memory/2026-05-23.md
@@ -17,3 +17,22 @@
 -  M scripts/dev-sync.sh
 -  M templates/scripts/dev-sync.ps1
 -  M templates/scripts/dev-sync.sh
+
+---
+
+## Session — docs: README OS-based new-project steps + encoding fixes + PR language rule
+
+- **README.md**: Step 3 rewritten to OS-based format (macOS/Linux/Git Bash + Windows CMD/PS); removed tool-based Claude Code/Antigravity wording.
+- **README_ko.md**: Consistent with README.md; AI tool shortcut moved to tip note.
+- **templates/README.md**: Encoding artifacts fixed, `→` arrows restored, setup.sh Quick Start section added.
+- **templates/README_ko.md**: Full UTF-8 Korean rewrite (was EUC-KR-corrupted garbage).
+- **PR Language Rule**: Enforced English-only PR titles/bodies across all CLAUDE.md/GEMINI.md files (workspace + templates). Rule consolidated to CONSTITUTION.md §3 as single source of truth — all files now reference §3 instead of duplicating the rule.
+- **`.github/pull_request_template.md`**: Converted to English-only.
+- **templates/docs/context.md**: §7 PR Language Rule added to scaffold so new projects inherit the rule from creation.
+
+---
+
+## Session — fix: pre-commit auto-log memory + changelog on direct git commit
+
+- **Root cause identified**: All commits in this session bypassed dev-sync.sh, so memory and changelog were never auto-populated.
+- **`.githooks/pre-commit`** (workspace + templates): Added §1-B — reads commit message from `.git/COMMIT_EDITMSG`, auto-appends memory log entry, updates MEMORY.md index via sync-md.sh, and adds CHANGELOG entry when [Unreleased] section is empty. Skips duplicates already written by dev-sync.sh.

--- a/memory/MEMORY.md
+++ b/memory/MEMORY.md
@@ -9,3 +9,4 @@
 | [2026-05-23](2026-05-23.md) | fix: initialize memory tracking on project creation |
 | [2026-05-23](2026-05-23.md) | docs: clarify tracking management guidelines (CHANGELOG vs. Memory) |
 | [2026-05-23](2026-05-23.md) | feat: dev-sync upgrades for memory and changelog tracking |
+| [2026-05-23](2026-05-23.md) | docs: README OS-based steps + PR language rule + pre-commit auto-log fix |

--- a/templates/.githooks/pre-commit
+++ b/templates/.githooks/pre-commit
@@ -1,13 +1,14 @@
 #!/usr/bin/env bash
-# pre-commit: documentation audit + secret scan on structural file changes.
-# memory/ session logs are exempt from all checks.
+# pre-commit: auto-log memory + changelog, audit, secret scan.
+# memory/ session logs are exempt from audit/secret checks.
 
 STAGED=$(git diff --cached --name-only)
 [ -z "$STAGED" ] && exit 0
 
-# Skip entirely for memory/-only commits
+# Skip audit/secret checks for memory/-only commits (but still log)
+MEMORY_ONLY=false
 if ! echo "$STAGED" | grep -qv "^memory/"; then
-  exit 0
+  MEMORY_ONLY=true
 fi
 
 # ── 1. Auto-update Markdown "Last Updated" dates ──────────────────────────────
@@ -22,20 +23,60 @@ if [ -n "$MD_STAGED" ]; then
   done
 fi
 
-# ── 1-A. Auto-date CHANGELOG.md [Unreleased] entries ───────────────────────
+# ── 1-A. Auto-date CHANGELOG.md [Unreleased] entries ─────────────────────────
 if echo "$STAGED" | grep -q "CHANGELOG.md"; then
   TODAY=$(date +%Y-%m-%d)
   perl -i -pe '
     BEGIN { $today = shift; $in_unreleased = 0; }
     if (/^## \[Unreleased\]/) { $in_unreleased = 1; }
     elsif (/^## \[/ && !/^## \[Unreleased\]/) { $in_unreleased = 0; }
-    
     if ($in_unreleased && /^(\s*-\s+)(?!\*\*\[\d{4}-\d{2}-\d{2}\]\*\*: )/) {
       s/^(\s*-\s+)/$1**[$today]**: /;
     }
   ' "$TODAY" CHANGELOG.md
   git add CHANGELOG.md
 fi
+
+# ── 1-B. Auto-create memory log + CHANGELOG entry (when bypassing dev-sync) ───
+# Reads commit message from .git/COMMIT_EDITMSG so direct `git commit -m`
+# calls still produce memory and changelog entries automatically.
+COMMIT_MSG=""
+[ -f ".git/COMMIT_EDITMSG" ] && COMMIT_MSG=$(head -1 .git/COMMIT_EDITMSG | sed 's/[[:space:]]*$//')
+
+if [ -n "$COMMIT_MSG" ] && ! echo "$COMMIT_MSG" | grep -qE "^Merge|^WIP|^fixup!|^squash!"; then
+  TODAY=$(date +%Y-%m-%d)
+  mkdir -p memory
+
+  # Auto-append memory log only if dev-sync hasn't already written this entry
+  if ! grep -qF "## $COMMIT_MSG" "memory/$TODAY.md" 2>/dev/null; then
+    FILE_LIST=$(echo "$STAGED" | grep -v "^memory/" | paste -sd ", " - || true)
+    SEPARATOR=""
+    [ -f "memory/$TODAY.md" ] && SEPARATOR=$'\n---\n\n'
+    printf "%s## %s\n- **Files**: %s\n- **Purpose**: (auto-logged by pre-commit)\n- **Decisions**: \n- **Issues**: None\n" \
+      "$SEPARATOR" "$COMMIT_MSG" "$FILE_LIST" >> "memory/$TODAY.md"
+    git add "memory/$TODAY.md"
+  fi
+
+  # Auto-update MEMORY.md index
+  if [ -f "scripts/sync-md.sh" ]; then
+    bash scripts/sync-md.sh "$TODAY" "$COMMIT_MSG" 2>/dev/null || true
+    [ -f "memory/MEMORY.md" ] && git add "memory/MEMORY.md"
+  fi
+
+  # Auto-add CHANGELOG entry if [Unreleased] section is empty
+  if [ -f "CHANGELOG.md" ] && ! echo "$STAGED" | grep -q "CHANGELOG.md"; then
+    SECTION=$(awk '/\[Unreleased\]/{f=1;next} f && /^## /{exit} f{print}' CHANGELOG.md)
+    if ! echo "$SECTION" | grep -qE "^[[:space:]]*[-*]|^### "; then
+      TODAY=$(date +%Y-%m-%d)
+      perl -i -pe 'BEGIN{$m=shift; $d=shift}
+        if (/^## \[Unreleased\]/) { $_ .= "\n- **[$d]**: $m\n" }
+      ' "$COMMIT_MSG" "$TODAY" CHANGELOG.md
+      git add CHANGELOG.md
+    fi
+  fi
+fi
+
+[ "$MEMORY_ONLY" = true ] && exit 0
 
 # ── 2. Block staged .env files ────────────────────────────────────────────────
 if echo "$STAGED" | grep -qE "^\.env$|^\.env\.[^s]|/\.env$|/\.env\.[^s]"; then


### PR DESCRIPTION
## Summary

- **Root cause fixed**: `memory/` and `CHANGELOG.md` entries were only created when using `dev-sync.sh`. Direct `git commit -m "..."` calls silently skipped both, causing session history gaps.
- **`.githooks/pre-commit`** (workspace + templates): New §1-B reads the commit message from `.git/COMMIT_EDITMSG` and auto-creates memory log and CHANGELOG entries when they are missing, then stages them into the same commit.

## Changes

| File | Change |
|------|--------|
| `.githooks/pre-commit` | Added §1-B: auto-log memory + CHANGELOG on direct commits |
| `templates/.githooks/pre-commit` | Same §1-B applied to project scaffold |
| `CHANGELOG.md` | Backfilled session entries (README fixes, PR language rule) |
| `memory/2026-05-23.md` | Backfilled full session summary |
| `memory/MEMORY.md` | Index updated |

## How §1-B works

1. Reads first line of `.git/COMMIT_EDITMSG` as the commit message
2. Skips merge commits, WIP, fixup!, squash! prefixes
3. Appends to `memory/YYYY-MM-DD.md` — deduplicates against entries already written by `dev-sync.sh`
4. Runs `scripts/sync-md.sh` to update `memory/MEMORY.md` index
5. Inserts a `- **[date]**: <msg>` line under `[Unreleased]` in `CHANGELOG.md` only when the section is empty
6. Stages all generated files so they land in the same commit

## Test Plan

- [ ] `bash scripts/audit.sh` passes (exit 0)
- [ ] `CHANGELOG.md` updated under `[Unreleased]`
- [ ] Direct `git commit -m "test: verify hook"` produces a `memory/YYYY-MM-DD.md` entry and a `CHANGELOG.md` entry automatically
- [ ] Running `dev-sync.sh` after the hook does not create duplicate memory entries

🤖 Generated with [Claude Code](https://claude.com/claude-code)