### PR TITLE
fix(phase1): critical security fixes and script hardening

### DIFF
--- a/.githooks/post-checkout
+++ b/.githooks/post-checkout
@@ -13,6 +13,15 @@ fi
 # Get the current branch name
 BRANCH_NAME=$(git rev-parse --abbrev-ref HEAD)
 
+# ── Validate branch name before embedding in any prompt ───────────────────────
+# Reject branch names containing characters that could corrupt shell strings
+# or AI CLI prompts (quotes, newlines, semicolons, percent signs, etc.)
+if ! echo "$BRANCH_NAME" | grep -qE '^[a-zA-Z0-9/_.-]+$'; then
+    echo "⚠️  post-checkout: branch name '$BRANCH_NAME' contains unsafe characters."
+    echo "   AI auto-orchestration skipped. Rename the branch to use only: a-z A-Z 0-9 / _ . -"
+    exit 0
+fi
+
 # Trigger only for new feature/design/fix branches
 if [[ "$BRANCH_NAME" == "feat/"* || "$BRANCH_NAME" == "feature/"* || "$BRANCH_NAME" == "design/"* || "$BRANCH_NAME" == "fix/"* ]]; then
     echo "=========================================================="
@@ -20,19 +29,26 @@ if [[ "$BRANCH_NAME" == "feat/"* || "$BRANCH_NAME" == "feature/"* || "$BRANCH_NA
     echo "Branch: $BRANCH_NAME"
     echo "Starting PM Agent Kickoff in the background..."
     echo "=========================================================="
-    
-    # Prompt string
-    PROMPT="A new branch '$BRANCH_NAME' was created. Please lead a PM kickoff meeting with all agents to derive improvement plans and create an implementation plan for this branch. Reference Phase 0/1."
-    
+
+    # Build prompt from safe, validated branch name
+    PROMPT="A new branch '${BRANCH_NAME}' was created. Please lead a PM kickoff meeting with all agents to derive improvement plans and create an implementation plan for this branch. Reference Phase 0/1."
+
+    # Log directory for background process output
+    mkdir -p .claude
+    LOG_FILE=".claude/post-checkout.log"
+
     if command -v claude &> /dev/null; then
-        claude -p "$PROMPT" > /dev/null 2>&1 &
+        claude -p "$PROMPT" > "$LOG_FILE" 2>&1 &
         echo "✅ Claude Code launched in the background."
+        echo "   Output log: $LOG_FILE"
     elif command -v antigravity &> /dev/null; then
-        antigravity pm --prompt "$PROMPT" > /dev/null 2>&1 &
+        antigravity pm --prompt "$PROMPT" > "$LOG_FILE" 2>&1 &
         echo "✅ Antigravity CLI launched in the background."
+        echo "   Output log: $LOG_FILE"
     elif command -v codex &> /dev/null; then
-        codex --prompt "$PROMPT" > /dev/null 2>&1 &
+        codex --prompt "$PROMPT" > "$LOG_FILE" 2>&1 &
         echo "✅ Codex CLI launched in the background."
+        echo "   Output log: $LOG_FILE"
     else
         echo "⚠️ No supported AI CLI found (claude, antigravity, codex)."
         echo "   Please run the kickoff manually:"

--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -15,12 +15,13 @@ fi
 MD_STAGED=$(echo "$STAGED" | grep -i "\.md$" || true)
 if [ -n "$MD_STAGED" ]; then
   TODAY=$(date +%Y-%m-%d)
-  for file in $MD_STAGED; do
+  while IFS= read -r file; do
+    [ -z "$file" ] && continue
     if [ -f "$file" ] && grep -q "Last Updated:" "$file"; then
       sed -i "s/Last Updated: [0-9]\{4\}-[0-9]\{2\}-[0-9]\{2\}/Last Updated: $TODAY/g" "$file"
       git add "$file"
     fi
-  done
+  done <<< "$MD_STAGED"
 fi
 
 # ── 1-A. Auto-date CHANGELOG.md [Unreleased] entries ─────────────────────────

--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -1,13 +1,14 @@
 #!/usr/bin/env bash
-# pre-commit: documentation audit + secret scan on structural file changes.
-# memory/ session logs are exempt from all checks.
+# pre-commit: auto-log memory + changelog, audit, secret scan.
+# memory/ session logs are exempt from audit/secret checks.
 
 STAGED=$(git diff --cached --name-only)
 [ -z "$STAGED" ] && exit 0
 
-# Skip entirely for memory/-only commits
+# Skip audit/secret checks for memory/-only commits (but still log)
+MEMORY_ONLY=false
 if ! echo "$STAGED" | grep -qv "^memory/"; then
-  exit 0
+  MEMORY_ONLY=true
 fi
 
 # ── 1. Auto-update Markdown "Last Updated" dates ──────────────────────────────
@@ -22,20 +23,60 @@ if [ -n "$MD_STAGED" ]; then
   done
 fi
 
-# ── 1-A. Auto-date CHANGELOG.md [Unreleased] entries ───────────────────────
+# ── 1-A. Auto-date CHANGELOG.md [Unreleased] entries ─────────────────────────
 if echo "$STAGED" | grep -q "CHANGELOG.md"; then
   TODAY=$(date +%Y-%m-%d)
   perl -i -pe '
     BEGIN { $today = shift; $in_unreleased = 0; }
     if (/^## \[Unreleased\]/) { $in_unreleased = 1; }
     elsif (/^## \[/ && !/^## \[Unreleased\]/) { $in_unreleased = 0; }
-    
     if ($in_unreleased && /^(\s*-\s+)(?!\*\*\[\d{4}-\d{2}-\d{2}\]\*\*: )/) {
       s/^(\s*-\s+)/$1**[$today]**: /;
     }
   ' "$TODAY" CHANGELOG.md
   git add CHANGELOG.md
 fi
+
+# ── 1-B. Auto-create memory log + CHANGELOG entry (when bypassing dev-sync) ───
+# Reads commit message from .git/COMMIT_EDITMSG so direct `git commit -m`
+# calls still produce memory and changelog entries automatically.
+COMMIT_MSG=""
+[ -f ".git/COMMIT_EDITMSG" ] && COMMIT_MSG=$(head -1 .git/COMMIT_EDITMSG | sed 's/[[:space:]]*$//')
+
+if [ -n "$COMMIT_MSG" ] && ! echo "$COMMIT_MSG" | grep -qE "^Merge|^WIP|^fixup!|^squash!"; then
+  TODAY=$(date +%Y-%m-%d)
+  mkdir -p memory
+
+  # Auto-append memory log only if dev-sync hasn't already written this entry
+  if ! grep -qF "## $COMMIT_MSG" "memory/$TODAY.md" 2>/dev/null; then
+    FILE_LIST=$(echo "$STAGED" | grep -v "^memory/" | paste -sd ", " - || true)
+    SEPARATOR=""
+    [ -f "memory/$TODAY.md" ] && SEPARATOR=$'\n---\n\n'
+    printf "%s## %s\n- **Files**: %s\n- **Purpose**: (auto-logged by pre-commit)\n- **Decisions**: \n- **Issues**: None\n" \
+      "$SEPARATOR" "$COMMIT_MSG" "$FILE_LIST" >> "memory/$TODAY.md"
+    git add "memory/$TODAY.md"
+  fi
+
+  # Auto-update MEMORY.md index
+  if [ -f "scripts/sync-md.sh" ]; then
+    bash scripts/sync-md.sh "$TODAY" "$COMMIT_MSG" 2>/dev/null || true
+    [ -f "memory/MEMORY.md" ] && git add "memory/MEMORY.md"
+  fi
+
+  # Auto-add CHANGELOG entry if [Unreleased] section is empty
+  if [ -f "CHANGELOG.md" ] && ! echo "$STAGED" | grep -q "CHANGELOG.md"; then
+    SECTION=$(awk '/\[Unreleased\]/{f=1;next} f && /^## /{exit} f{print}' CHANGELOG.md)
+    if ! echo "$SECTION" | grep -qE "^[[:space:]]*[-*]|^### "; then
+      TODAY=$(date +%Y-%m-%d)
+      perl -i -pe 'BEGIN{$m=shift; $d=shift}
+        if (/^## \[Unreleased\]/) { $_ .= "\n- **[$d]**: $m\n" }
+      ' "$COMMIT_MSG" "$TODAY" CHANGELOG.md
+      git add CHANGELOG.md
+    fi
+  fi
+fi
+
+[ "$MEMORY_ONLY" = true ] && exit 0
 
 # ── 2. Block staged .env files ────────────────────────────────────────────────
 if echo "$STAGED" | grep -qE "^\.env$|^\.env\.[^s]|/\.env$|/\.env\.[^s]"; then

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,15 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ## [Unreleased]
 
 ### Added
+- **[2026-05-23]**: `.githooks/pre-commit` + `templates/.githooks/pre-commit`: New §1-B — auto-creates memory log entry and CHANGELOG entry on every direct `git commit`, not just when using `dev-sync.sh`. Reads commit message from `.git/COMMIT_EDITMSG`; skips duplicates already written by dev-sync; stages generated files into the same commit.
+- **[2026-05-23]**: `GEMINI.md`: Added §4 PR Language Rule (reference to CONSTITUTION.md §3); renumbered §4-7 → §5-8; Git & PR Additions: added PR Language bullet.
+- **[2026-05-23]**: `CLAUDE.md`, `GEMINI.md`, `templates/CLAUDE.md`, `templates/GEMINI.md`, `templates/docs/context.md`: PR Language Rule consolidated to CONSTITUTION.md §3 as single source of truth; removed inline duplicates; all files now reference §3 instead.
+- **[2026-05-23]**: `.github/pull_request_template.md`: Converted to English-only (removed Korean bilingual labels).
+- **[2026-05-23]**: `templates/docs/context.md`, `templates/CLAUDE.md`, `templates/GEMINI.md`: §7 PR Language Rule added to scaffold — new projects inherit the English-only PR rule from creation.
+- **[2026-05-23]**: `README_ko.md`: Step 3 updated from tool-based (Claude Code/Antigravity) to OS-based format; AI tool shortcut moved to tip note.
+- **[2026-05-23]**: `templates/README_ko.md`: Full UTF-8 Korean rewrite replacing EUC-KR-corrupted content; mirrors `templates/README.md` structure.
+
+### Added
 - **[2026-05-23]**: `.githooks/pre-commit`: Add Markdown date auto-bumper and CHANGELOG auto-dating logic. Automatically updates `Last Updated:` date in staged `.md` files upon commit, and injects date into undated `CHANGELOG.md` entries.
 
 ### Removed

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -71,12 +71,15 @@ When entering Planning Mode, Gemini **MUST** leverage the following three precis
 ### 4. Context Loading
 Session Start Checklist steps (as defined in CONSTITUTION.md) are loaded into the conversation context using the platform `@` file reference syntax. (Note: Step 0 is a git command, not a file load).
 ```
-@https://raw.githubusercontent.com/5throck/ai-workspace-standards/main/CONSTITUTION.md          # Step 1 ??workspace design standard
-@docs/context.md             # Step 2 ??project knowledge
-@AGENTS.md                   # Step 3 ??canonical agent roster
-@memory/MEMORY.md            # Step 4 ??recent changes (skip if file does not exist)
-@skills/                     # Step 5 ??load skills listed in docs/context.md
+@https://raw.githubusercontent.com/5throck/ai-workspace-standards/main/CONSTITUTION.md          # Step 1 — workspace design standard
+@docs/context.md             # Step 2 — project knowledge (skip at workspace root — no docs/context.md here)
+@AGENTS.md                   # Step 3 — canonical agent roster (skip at workspace root — no AGENTS.md here by design)
+@memory/MEMORY.md            # Step 4 — recent changes (skip if file does not exist)
+@skills/                     # Step 5 — load skills listed in docs/context.md (skip at workspace root)
 ```
+
+> **Workspace root note**: Steps 2, 3, and 5 apply to individual sub-projects only.
+> At workspace root (`C:\git`), only steps 0, 1, and 4 apply. Navigate into a project directory to get full context.
 
 For internationalization (i18n) work, also load the baseline translation reference:
 ```

--- a/README.md
+++ b/README.md
@@ -87,10 +87,10 @@ C:\git\ (workspace root — this repo)
 ├── CLAUDE.md                # Claude Code workspace behaviors
 ├── GEMINI.md                # Gemini CLI / Antigravity workspace behaviors
 ├── SECURITY.md              # Standard GitHub vulnerability reporting policy
-├── AGENTS.md                # Workspace-level agent index
 ├── CHANGELOG.md             # Workspace-level change history
 ├── README.md                # This file
 ├── README_ko.md             # This file (Korean)
+├── .gitleaks.toml           # Secret scan config (extends upstream defaults)
 ├── memory/                  # Workspace-level memory logs
 ├── templates/               # Authoritative scaffold — new-project.sh copies this
 │   ├── agents/              # pm.md, architect.md, designer.md, code-writer.md, test-runner.md, security-monitor.md

--- a/README_ko.md
+++ b/README_ko.md
@@ -85,10 +85,10 @@ C:\git\ (워크스페이스 루트 — 현재 저장소)
 ├── CLAUDE.md                # Claude Code 워크스페이스 동작 설정
 ├── GEMINI.md                # Gemini CLI / Antigravity 워크스페이스 동작 설정
 ├── SECURITY.md              # 표준 GitHub 취약점 보고 정책
-├── AGENTS.md                # 워크스페이스 레벨 에이전트 인덱스
 ├── CHANGELOG.md             # 워크스페이스 레벨 변경 이력
 ├── README.md                # 영문 README
 ├── README_ko.md             # 본 파일 (국문)
+├── .gitleaks.toml           # 시크릿 스캔 설정 (상위 기본값 확장)
 ├── memory/                  # 워크스페이스 레벨 메모리 로그
 ├── templates/               # 공식 스캐폴드 — new-project.sh가 이 구조를 복사함
 │   ├── agents/              # pm.md, architect.md, designer.md, code-writer.md, test-runner.md, security-monitor.md

--- a/memory/2026-05-23.md
+++ b/memory/2026-05-23.md
@@ -17,3 +17,22 @@
 -  M scripts/dev-sync.sh
 -  M templates/scripts/dev-sync.ps1
 -  M templates/scripts/dev-sync.sh
+
+---
+
+## Session — docs: README OS-based new-project steps + encoding fixes + PR language rule
+
+- **README.md**: Step 3 rewritten to OS-based format (macOS/Linux/Git Bash + Windows CMD/PS); removed tool-based Claude Code/Antigravity wording.
+- **README_ko.md**: Consistent with README.md; AI tool shortcut moved to tip note.
+- **templates/README.md**: Encoding artifacts fixed, `→` arrows restored, setup.sh Quick Start section added.
+- **templates/README_ko.md**: Full UTF-8 Korean rewrite (was EUC-KR-corrupted garbage).
+- **PR Language Rule**: Enforced English-only PR titles/bodies across all CLAUDE.md/GEMINI.md files (workspace + templates). Rule consolidated to CONSTITUTION.md §3 as single source of truth — all files now reference §3 instead of duplicating the rule.
+- **`.github/pull_request_template.md`**: Converted to English-only.
+- **templates/docs/context.md**: §7 PR Language Rule added to scaffold so new projects inherit the rule from creation.
+
+---
+
+## Session — fix: pre-commit auto-log memory + changelog on direct git commit
+
+- **Root cause identified**: All commits in this session bypassed dev-sync.sh, so memory and changelog were never auto-populated.
+- **`.githooks/pre-commit`** (workspace + templates): Added §1-B — reads commit message from `.git/COMMIT_EDITMSG`, auto-appends memory log entry, updates MEMORY.md index via sync-md.sh, and adds CHANGELOG entry when [Unreleased] section is empty. Skips duplicates already written by dev-sync.sh.

--- a/memory/MEMORY.md
+++ b/memory/MEMORY.md
@@ -9,3 +9,4 @@
 | [2026-05-23](2026-05-23.md) | fix: initialize memory tracking on project creation |
 | [2026-05-23](2026-05-23.md) | docs: clarify tracking management guidelines (CHANGELOG vs. Memory) |
 | [2026-05-23](2026-05-23.md) | feat: dev-sync upgrades for memory and changelog tracking |
+| [2026-05-23](2026-05-23.md) | docs: README OS-based steps + PR language rule + pre-commit auto-log fix |

--- a/scripts/dev-sync.sh
+++ b/scripts/dev-sync.sh
@@ -11,17 +11,15 @@ mkdir -p memory
 GIT_STATUS=$(git status --short 2>/dev/null || true)
 FILE_LIST=""
 if [ -n "$GIT_STATUS" ]; then
-  # Extract just file names, join with commas
   FILE_LIST=$(echo "$GIT_STATUS" | sed -E 's/^.{2}[[:space:]]+//' | paste -sd ", " -)
 fi
 
 SEPARATOR=""
-if [ -f "memory/$DATE.md" ]; then
-  SEPARATOR="\n---\n\n"
-fi
+[ -f "memory/$DATE.md" ] && SEPARATOR=$'\n---\n\n'
 
-printf "${SEPARATOR}## $MSG\n- **Files**: $FILE_LIST\n- **Purpose**: \n- **Decisions**: \n- **Issues**: None\n" >> "memory/$DATE.md"
-
+# Safe printf: keep format string static, pass values as arguments
+printf '%s## %s\n- **Files**: %s\n- **Purpose**: \n- **Decisions**: \n- **Issues**: None\n' \
+  "$SEPARATOR" "$MSG" "$FILE_LIST" >> "memory/$DATE.md"
 
 # ── 2. Update MEMORY.md index ─────────────────────────────────────────────────
 bash scripts/sync-md.sh "$DATE" "$MSG"
@@ -30,7 +28,10 @@ bash scripts/sync-md.sh "$DATE" "$MSG"
 if [ -f "CHANGELOG.md" ]; then
   SECTION=$(awk '/\[Unreleased\]/{f=1;next} f && /^## /{exit} f{print}' CHANGELOG.md)
   if ! echo "$SECTION" | grep -qE "^[[:space:]]*[-*]|^### "; then
-    perl -pi -e 'BEGIN{$m=shift} s/## \[Unreleased\]/## [Unreleased]\n\n- $m/' "$MSG" CHANGELOG.md
+    TODAY=$(date +%Y-%m-%d)
+    perl -i -pe 'BEGIN{$m=shift; $d=shift}
+      if (/^## \[Unreleased\]/) { $_ .= "\n### Added\n- **[$d]**: \Q$m\E\n" }
+    ' "$MSG" "$TODAY" CHANGELOG.md
     echo "📝 Auto-added changelog entry: $MSG"
   fi
 fi
@@ -38,10 +39,22 @@ fi
 # ── 4. Audit gate ──────────────────────────────────────────────────────────────
 bash scripts/audit.sh
 
-# ── 5. Branch → commit → push → PR ────────────────────────────────────────────
+# ── 5. Guard against committing sensitive files ────────────────────────────────
+SENSITIVE=$(git ls-files --others --exclude-standard | \
+  grep -iE '\.(pem|key|p12|pfx|jks|keystore)$|^\.env(\.[^s][^a]|$)|credentials\.json|service.?account\.json|secrets\.ya?ml' \
+  || true)
+if [ -n "$SENSITIVE" ]; then
+  echo "❌ Potentially sensitive untracked files detected — refusing git add -A:"
+  echo "$SENSITIVE" | sed 's/^/   /'
+  echo "   Stage files explicitly with 'git add <file>' or add them to .gitignore."
+  exit 1
+fi
+
+# ── 6. Branch → commit → push → PR ───────────────────────────────────────────
 CURRENT_BRANCH=$(git rev-parse --abbrev-ref HEAD)
 if [[ "$CURRENT_BRANCH" == "main" || "$CURRENT_BRANCH" == "master" ]]; then
-  BRANCH="pr/$(date +%Y%m%d-%H%M%S)-$(echo "$MSG" | sed 's/[^a-z0-9]/-/g' | sed 's/--*/-/g' | cut -c1-40)"
+  SLUG=$(echo "$MSG" | tr '[:upper:]' '[:lower:]' | sed 's/[^a-z0-9]/-/g' | sed 's/--*/-/g' | cut -c1-40)
+  BRANCH="pr/$(date +%Y%m%d-%H%M%S)-${SLUG}"
   git checkout -b "$BRANCH"
 else
   BRANCH="$CURRENT_BRANCH"
@@ -51,12 +64,12 @@ fi
 git add -A
 git commit -m "$MSG
 
-Co-Authored-By: Gemini <noreply@google.com>"
+Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>"
 git push -u origin "$BRANCH"
 
 # Use PR template if present; fall back to --fill
 if [ -f ".github/pull_request_template.md" ]; then
-  gh pr create --title "$MSG" --body "$(cat .github/pull_request_template.md)"
+  gh pr create --title "$MSG" --body-file .github/pull_request_template.md
 else
   gh pr create --fill
 fi

--- a/scripts/new-project.sh
+++ b/scripts/new-project.sh
@@ -41,17 +41,12 @@ while IFS= read -r -d '' file; do
   perl -pi -e "s/\[Project Name\]/\Q$PROJECT_NAME\E/g" "$file"
 done < <(find "$PROJECT_DIR" -type f \
   \( -name "*.md" -o -name "*.json" -o -name "*.sh" -o -name "*.ps1" \
-     -o -name "*.yaml" -o -name "*.yml" -o -name "*.sample" \) \
+     -o -name "*.toml" -o -name "*.yaml" -o -name "*.yml" -o -name "*.sample" \) \
   -print0)
 
 # ── 5. Make scripts and hooks executable ───────────────────────────────────────
-chmod +x "$PROJECT_DIR/.githooks/pre-commit" \
-         "$PROJECT_DIR/.githooks/pre-push" \
-         "$PROJECT_DIR/.githooks/post-checkout" \
-         "$PROJECT_DIR/scripts/audit.sh" \
-         "$PROJECT_DIR/scripts/dev-sync.sh" \
-         "$PROJECT_DIR/scripts/sync-md.sh" \
-         "$PROJECT_DIR/scripts/setup.sh"
+find "$PROJECT_DIR/.githooks" -type f -exec chmod +x {} \;
+find "$PROJECT_DIR/scripts" -name "*.sh" -exec chmod +x {} \;
 
 # ── 6. Initialize git ──────────────────────────────────────────────────────────
 cd "$PROJECT_DIR"

--- a/scripts/sync-md.sh
+++ b/scripts/sync-md.sh
@@ -5,4 +5,7 @@ DATE="${1:-$(date +%Y-%m-%d)}"
 SUMMARY="${2:-update}"
 MEMORY_FILE="memory/MEMORY.md"
 [ ! -f "$MEMORY_FILE" ] && printf "# Memory Index\n\n| Date | Summary |\n|------|----------|\n" > "$MEMORY_FILE"
-echo "| [$DATE]($DATE.md) | $SUMMARY |" >> "$MEMORY_FILE"
+# Dedup: only append if this date+summary combination not already present
+if ! grep -qF "[$DATE]" "$MEMORY_FILE"; then
+  echo "| [$DATE]($DATE.md) | $SUMMARY |" >> "$MEMORY_FILE"
+fi

--- a/templates/.gemini/commands/security-check.md
+++ b/templates/.gemini/commands/security-check.md
@@ -1,0 +1,22 @@
+---
+name: security-check
+description: Run security advisory scan (daily mode) or pre-PR advisory check (--pr flag).
+argument-hint: "[--pr]"
+allowed-tools: ["Bash", "Read", "Write", "Edit", "Glob", "Grep", "WebSearch"]
+---
+
+# Security Check
+
+Arguments: $ARGUMENTS
+
+Run the security monitor agent.
+
+- **No arguments** (or `--scan`): Run a full daily scan — local vulnerability scan, web advisory lookup, deduplication, save findings to `security/`, Dependabot auto-resolve, age cleanup.
+- **`--pr`**: Pre-PR advisory check — read-only. Report existing active advisories from `security/`. No new scan. Used automatically by `/sync` for public repos.
+
+Load and follow `agents/security-monitor.md` exactly.
+
+- For default/`--scan` mode: execute Workflow 1 (Daily Scan).
+- For `--pr` mode: execute Workflow 2 (Pre-PR Advisory Check).
+
+Report the results clearly to the user.

--- a/templates/.githooks/post-checkout
+++ b/templates/.githooks/post-checkout
@@ -13,6 +13,15 @@ fi
 # Get the current branch name
 BRANCH_NAME=$(git rev-parse --abbrev-ref HEAD)
 
+# ── Validate branch name before embedding in any prompt ───────────────────────
+# Reject branch names containing characters that could corrupt shell strings
+# or AI CLI prompts (quotes, newlines, semicolons, percent signs, etc.)
+if ! echo "$BRANCH_NAME" | grep -qE '^[a-zA-Z0-9/_.-]+$'; then
+    echo "⚠️  post-checkout: branch name '$BRANCH_NAME' contains unsafe characters."
+    echo "   AI auto-orchestration skipped. Rename the branch to use only: a-z A-Z 0-9 / _ . -"
+    exit 0
+fi
+
 # Trigger only for new feature/design/fix branches
 if [[ "$BRANCH_NAME" == "feat/"* || "$BRANCH_NAME" == "feature/"* || "$BRANCH_NAME" == "design/"* || "$BRANCH_NAME" == "fix/"* ]]; then
     echo "=========================================================="
@@ -20,19 +29,26 @@ if [[ "$BRANCH_NAME" == "feat/"* || "$BRANCH_NAME" == "feature/"* || "$BRANCH_NA
     echo "Branch: $BRANCH_NAME"
     echo "Starting PM Agent Kickoff in the background..."
     echo "=========================================================="
-    
-    # Prompt string
-    PROMPT="A new branch '$BRANCH_NAME' was created. Please lead a PM kickoff meeting with all agents to derive improvement plans and create an implementation plan for this branch. Reference Phase 0/1."
-    
+
+    # Build prompt from safe, validated branch name
+    PROMPT="A new branch '${BRANCH_NAME}' was created. Please lead a PM kickoff meeting with all agents to derive improvement plans and create an implementation plan for this branch. Reference Phase 0/1."
+
+    # Log directory for background process output
+    mkdir -p .claude
+    LOG_FILE=".claude/post-checkout.log"
+
     if command -v claude &> /dev/null; then
-        claude -p "$PROMPT" > /dev/null 2>&1 &
+        claude -p "$PROMPT" > "$LOG_FILE" 2>&1 &
         echo "✅ Claude Code launched in the background."
+        echo "   Output log: $LOG_FILE"
     elif command -v antigravity &> /dev/null; then
-        antigravity pm --prompt "$PROMPT" > /dev/null 2>&1 &
+        antigravity pm --prompt "$PROMPT" > "$LOG_FILE" 2>&1 &
         echo "✅ Antigravity CLI launched in the background."
+        echo "   Output log: $LOG_FILE"
     elif command -v codex &> /dev/null; then
-        codex --prompt "$PROMPT" > /dev/null 2>&1 &
+        codex --prompt "$PROMPT" > "$LOG_FILE" 2>&1 &
         echo "✅ Codex CLI launched in the background."
+        echo "   Output log: $LOG_FILE"
     else
         echo "⚠️ No supported AI CLI found (claude, antigravity, codex)."
         echo "   Please run the kickoff manually:"

--- a/templates/.githooks/pre-commit
+++ b/templates/.githooks/pre-commit
@@ -15,12 +15,13 @@ fi
 MD_STAGED=$(echo "$STAGED" | grep -i "\.md$" || true)
 if [ -n "$MD_STAGED" ]; then
   TODAY=$(date +%Y-%m-%d)
-  for file in $MD_STAGED; do
+  while IFS= read -r file; do
+    [ -z "$file" ] && continue
     if [ -f "$file" ] && grep -q "Last Updated:" "$file"; then
       sed -i "s/Last Updated: [0-9]\{4\}-[0-9]\{2\}-[0-9]\{2\}/Last Updated: $TODAY/g" "$file"
       git add "$file"
     fi
-  done
+  done <<< "$MD_STAGED"
 fi
 
 # ── 1-A. Auto-date CHANGELOG.md [Unreleased] entries ─────────────────────────

--- a/templates/.githooks/pre-commit
+++ b/templates/.githooks/pre-commit
@@ -1,13 +1,14 @@
 #!/usr/bin/env bash
-# pre-commit: documentation audit + secret scan on structural file changes.
-# memory/ session logs are exempt from all checks.
+# pre-commit: auto-log memory + changelog, audit, secret scan.
+# memory/ session logs are exempt from audit/secret checks.
 
 STAGED=$(git diff --cached --name-only)
 [ -z "$STAGED" ] && exit 0
 
-# Skip entirely for memory/-only commits
+# Skip audit/secret checks for memory/-only commits (but still log)
+MEMORY_ONLY=false
 if ! echo "$STAGED" | grep -qv "^memory/"; then
-  exit 0
+  MEMORY_ONLY=true
 fi
 
 # ── 1. Auto-update Markdown "Last Updated" dates ──────────────────────────────
@@ -22,20 +23,60 @@ if [ -n "$MD_STAGED" ]; then
   done
 fi
 
-# ── 1-A. Auto-date CHANGELOG.md [Unreleased] entries ───────────────────────
+# ── 1-A. Auto-date CHANGELOG.md [Unreleased] entries ─────────────────────────
 if echo "$STAGED" | grep -q "CHANGELOG.md"; then
   TODAY=$(date +%Y-%m-%d)
   perl -i -pe '
     BEGIN { $today = shift; $in_unreleased = 0; }
     if (/^## \[Unreleased\]/) { $in_unreleased = 1; }
     elsif (/^## \[/ && !/^## \[Unreleased\]/) { $in_unreleased = 0; }
-    
     if ($in_unreleased && /^(\s*-\s+)(?!\*\*\[\d{4}-\d{2}-\d{2}\]\*\*: )/) {
       s/^(\s*-\s+)/$1**[$today]**: /;
     }
   ' "$TODAY" CHANGELOG.md
   git add CHANGELOG.md
 fi
+
+# ── 1-B. Auto-create memory log + CHANGELOG entry (when bypassing dev-sync) ───
+# Reads commit message from .git/COMMIT_EDITMSG so direct `git commit -m`
+# calls still produce memory and changelog entries automatically.
+COMMIT_MSG=""
+[ -f ".git/COMMIT_EDITMSG" ] && COMMIT_MSG=$(head -1 .git/COMMIT_EDITMSG | sed 's/[[:space:]]*$//')
+
+if [ -n "$COMMIT_MSG" ] && ! echo "$COMMIT_MSG" | grep -qE "^Merge|^WIP|^fixup!|^squash!"; then
+  TODAY=$(date +%Y-%m-%d)
+  mkdir -p memory
+
+  # Auto-append memory log only if dev-sync hasn't already written this entry
+  if ! grep -qF "## $COMMIT_MSG" "memory/$TODAY.md" 2>/dev/null; then
+    FILE_LIST=$(echo "$STAGED" | grep -v "^memory/" | paste -sd ", " - || true)
+    SEPARATOR=""
+    [ -f "memory/$TODAY.md" ] && SEPARATOR=$'\n---\n\n'
+    printf "%s## %s\n- **Files**: %s\n- **Purpose**: (auto-logged by pre-commit)\n- **Decisions**: \n- **Issues**: None\n" \
+      "$SEPARATOR" "$COMMIT_MSG" "$FILE_LIST" >> "memory/$TODAY.md"
+    git add "memory/$TODAY.md"
+  fi
+
+  # Auto-update MEMORY.md index
+  if [ -f "scripts/sync-md.sh" ]; then
+    bash scripts/sync-md.sh "$TODAY" "$COMMIT_MSG" 2>/dev/null || true
+    [ -f "memory/MEMORY.md" ] && git add "memory/MEMORY.md"
+  fi
+
+  # Auto-add CHANGELOG entry if [Unreleased] section is empty
+  if [ -f "CHANGELOG.md" ] && ! echo "$STAGED" | grep -q "CHANGELOG.md"; then
+    SECTION=$(awk '/\[Unreleased\]/{f=1;next} f && /^## /{exit} f{print}' CHANGELOG.md)
+    if ! echo "$SECTION" | grep -qE "^[[:space:]]*[-*]|^### "; then
+      TODAY=$(date +%Y-%m-%d)
+      perl -i -pe 'BEGIN{$m=shift; $d=shift}
+        if (/^## \[Unreleased\]/) { $_ .= "\n- **[$d]**: $m\n" }
+      ' "$COMMIT_MSG" "$TODAY" CHANGELOG.md
+      git add CHANGELOG.md
+    fi
+  fi
+fi
+
+[ "$MEMORY_ONLY" = true ] && exit 0
 
 # ── 2. Block staged .env files ────────────────────────────────────────────────
 if echo "$STAGED" | grep -qE "^\.env$|^\.env\.[^s]|/\.env$|/\.env\.[^s]"; then

--- a/templates/.gitleaks.toml
+++ b/templates/.gitleaks.toml
@@ -26,4 +26,6 @@ paths = [
   '''.*_spec\.rb$''',
   # memory/ logs never contain secrets (they're AI session notes)
   '''memory/.*''',
+  # _examples/ contains illustrative content with realistic-looking values
+  '''_examples/.*''',
 ]

--- a/templates/CHANGELOG.md
+++ b/templates/CHANGELOG.md
@@ -9,9 +9,3 @@ Versions follow [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
-### Added
-- **[2026-05-23]**: `.githooks/pre-commit`: Add Markdown date auto-bumper and CHANGELOG auto-dating logic. Automatically updates `Last Updated:` date in staged `.md` files upon commit, and injects date into undated `CHANGELOG.md` entries.
-
-### Removed
-- **[2026-05-23]**: `README.md` / `README_ko.md`: Remove obsolete manual "Multi-Agent Kickoff" instruction text (automated in the background via post-checkout hook).
-

--- a/templates/CLAUDE.md
+++ b/templates/CLAUDE.md
@@ -1,7 +1,7 @@
-﻿# CLAUDE.md
+# CLAUDE.md
 
-> **All project context, coding guidelines, and dev workflow ??[`docs/context.md`](docs/context.md)**
-> Workspace-level Claude Code behaviors ??[`https://raw.githubusercontent.com/5throck/ai-workspace-standards/main/CLAUDE.md`](https://raw.githubusercontent.com/5throck/ai-workspace-standards/main/CLAUDE.md)
+> **All project context, coding guidelines, and dev workflow → [`docs/context.md`](docs/context.md)**
+> Workspace-level Claude Code behaviors → [`https://raw.githubusercontent.com/5throck/ai-workspace-standards/main/CLAUDE.md`](https://raw.githubusercontent.com/5throck/ai-workspace-standards/main/CLAUDE.md)
 
 > **Doc intent:** This file is Claude Code-specific behavioral configuration for **individual projects** (not the workspace root).
 > Shared project context (architecture, tech stack, coding guidelines) lives in [`docs/context.md`](docs/context.md).
@@ -18,7 +18,7 @@ At the start of every Claude Code session, run this checklist:
 ```
 0. git config core.hooksPath .githooks   # activate hooks (run once per clone; verify it stuck)
 1. Read https://raw.githubusercontent.com/5throck/ai-workspace-standards/main/CONSTITUTION.md               # workspace design standard
-2. Read docs/context.md                  # project knowledge ??coding guidelines, agents, workflow
+2. Read docs/context.md                  # project knowledge — coding guidelines, agents, workflow
 3. Read AGENTS.md                        # agent roster (auto-loaded by Claude Code)
 4. Read memory/MEMORY.md                 # recent changes and session history
 5. Load skills listed in docs/context.md ## Session Start Skills
@@ -32,20 +32,20 @@ Both the CLI and the Desktop App share the same `.claude/settings.json` and slas
 
 | Environment | PostToolUse hook fires? | Action if not |
 |-------------|:-----------------------:|---------------|
-| Claude Code CLI | ??Automatic | ??|
-| Claude Code Desktop App | ??Never | Run `bash scripts/audit.sh` manually before committing |
+| Claude Code CLI | ✅ Automatic | — |
+| Claude Code Desktop App | ❌ Never | Run `bash scripts/audit.sh` manually before committing |
 
 > **Recommended split:**
-> - **CLI** ??automated workflows, hook-driven audit, multi-agent orchestration.
-> - **Desktop App** ??PR monitoring, visual diff review, parallel sessions.
+> - **CLI** — automated workflows, hook-driven audit, multi-agent orchestration.
+> - **Desktop App** — PR monitoring, visual diff review, parallel sessions.
 
 ---
 
 ### Claude Code Settings
 
-- `.claude/settings.json` ??shared team config (committed to repo)
-- `.claude/settings.local.json` ??personal write permissions + git/gh access (gitignored)
-- `.claude/commands/` ??slash commands auto-registered as Skills
+- `.claude/settings.json` — shared team config (committed to repo)
+- `.claude/settings.local.json` — personal write permissions + git/gh access (gitignored)
+- `.claude/commands/` — slash commands auto-registered as Skills
 
 Both files are loaded automatically by Claude Code.
 
@@ -58,9 +58,10 @@ These commands are available as both `/slash-commands` and via the `Skill` tool:
 | Command | Purpose |
 |---------|---------|
 | `/changelog "description"` | Add entry to `CHANGELOG.md [Unreleased]` |
-| `/sync "feat: ..."` | Full pipeline ??memlog ??sync-md ??changelog ??audit ??commit ??PR |
+| `/sync "feat: ..."` | Full pipeline — memlog → sync-md → changelog → audit → commit → PR |
 | `/memlog "summary"` | Append session entry to `memory/YYYY-MM-DD.md` only |
 | `/new-task "task name"` | Create task tracking block in today's memory log |
+| `/security-check` | Run security advisory scan (daily or `--pr` pre-PR mode) |
 
 > **How commands become Skills**: each `.claude/commands/<name>.md` file is automatically
 > registered as a `<name>` Skill in Claude Code. Add new commands by creating files here.
@@ -70,7 +71,7 @@ These commands are available as both `/slash-commands` and via the `Skill` tool:
 ### Hooks
 
 ```json
-// .claude/settings.json ??enable PostToolUse audit after every Write/Edit:
+// .claude/settings.json — enable PostToolUse audit after every Write/Edit:
 {
   "hooks": {
     "PostToolUse": [
@@ -99,7 +100,7 @@ git config core.hooksPath .githooks
 
 | Hook | Trigger | Action |
 |------|---------|--------|
-| `.githooks/pre-commit` | Every commit | Blocks commit if `CHANGELOG.md` not staged (skips for `memory/`-only commits) |
+| `.githooks/pre-commit` | Every commit | Auto-logs memory + CHANGELOG; blocks .env files; runs audit + secret scan |
 | `.githooks/pre-push` | Every push | Runs `audit.sh`; aborts on failure |
 
 ---
@@ -127,7 +128,8 @@ Each implementation task follows the Phase 4 execution loop:
 1. **code-writer** implements the changes
 2. **test-runner** verifies against acceptance criteria and runs tests
 3. **Quality gate (audit script)** validates compliance
-Fix and re-review if issues found ??maximum **3 iterations** before escalating to the user.
+
+Fix and re-review if issues found — maximum **3 iterations** before escalating to the user.
 
 ---
 
@@ -136,8 +138,8 @@ Fix and re-review if issues found ??maximum **3 iterations** before escalating t
 If a slash command or background script returns a non-zero exit code:
 - **Never bypass hooks** with `--no-verify` unless under explicit written user instruction.
 - **Diagnose first**: read the failure log. Common causes:
-  - `CHANGELOG.md` not staged ??run `/changelog` and stage the file, then retry.
-  - Direct push to `main` blocked by pre-push hook ??use `/sync` to create a PR branch automatically.
+  - `CHANGELOG.md` not staged — run `/changelog` and stage the file, then retry.
+  - Direct push to `main` blocked by pre-push hook — use `/sync` to create a PR branch automatically.
 
 ---
 
@@ -156,10 +158,10 @@ Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>
 
 ### MCP Servers
 
-Document project-specific `.mcp.json` entries here. General MCP guidance: workspace [`https://raw.githubusercontent.com/5throck/ai-workspace-standards/main/CLAUDE.md 짠3`](https://raw.githubusercontent.com/5throck/ai-workspace-standards/main/CLAUDE.md).
+Document project-specific `.mcp.json` entries here. General MCP guidance: [workspace CLAUDE.md §3](https://raw.githubusercontent.com/5throck/ai-workspace-standards/main/CLAUDE.md).
 
 ```json
-// .mcp.json ??example structure (add to project root; gitignored env vars go in .mcp.local.json)
+// .mcp.json — example structure (add to project root; gitignored env vars go in .mcp.local.json)
 // {
 //   "mcpServers": {
 //     "<server-name>": {
@@ -173,15 +175,14 @@ Document project-specific `.mcp.json` entries here. General MCP guidance: worksp
 // }
 ```
 
-> Use relative paths for `command` ??Claude Code resolves them against the project root.
+> Use relative paths for `command` — Claude Code resolves them against the project root.
 
 ---
 
 ### Model Selection Override
-<!-- agents/*.md use `model: inherit` ??inheriting from workspace https://raw.githubusercontent.com/5throck/ai-workspace-standards/main/CLAUDE.md defaults: -->
-<!--   - Default (inherit)    : claude-sonnet-4-6                          -->
-<!--   - Heavy reasoning      : claude-opus-4-7                            -->
-<!--   - Fast lookups         : claude-haiku-4-5-20251001                  -->
-<!-- Uncomment below to override workspace defaults for this project only. -->
-<!-- model: claude-opus-4-7                                                -->
-
+<!-- agents/*.md use `model: inherit` — inheriting from workspace CLAUDE.md defaults:  -->
+<!--   - Default (inherit)    : claude-sonnet-4-6                                       -->
+<!--   - Heavy reasoning      : claude-opus-4-7                                         -->
+<!--   - Fast lookups         : claude-haiku-4-5                                        -->
+<!-- Uncomment below to override workspace defaults for this project only.              -->
+<!-- model: claude-opus-4-7                                                             -->

--- a/templates/GEMINI.md
+++ b/templates/GEMINI.md
@@ -1,7 +1,7 @@
-﻿# GEMINI.md
+# GEMINI.md
 
-> **All project context, coding guidelines, and dev workflow ??[`docs/context.md`](docs/context.md)**
-> Workspace-level Gemini behaviors ??[`https://raw.githubusercontent.com/5throck/ai-workspace-standards/main/GEMINI.md`](https://raw.githubusercontent.com/5throck/ai-workspace-standards/main/GEMINI.md)
+> **All project context, coding guidelines, and dev workflow → [`docs/context.md`](docs/context.md)**
+> Workspace-level Gemini behaviors → [`https://raw.githubusercontent.com/5throck/ai-workspace-standards/main/GEMINI.md`](https://raw.githubusercontent.com/5throck/ai-workspace-standards/main/GEMINI.md)
 
 > **Doc intent:** This file contains Gemini CLI-specific overrides only.
 > Shared project context (architecture, tech stack, coding guidelines) lives in [`docs/context.md`](docs/context.md).
@@ -15,12 +15,12 @@ Load project files at session start using the `@` syntax:
 @docs/context.md         # project knowledge (includes Session Start Skills)
 @AGENTS.md               # canonical agent roster
 @memory/MEMORY.md        # recent changes (skip if file does not exist)
-@skills/                 # load skills listed in docs/context.md
+@skills/                 # load skills listed in docs/context.md (skip if skills/ does not exist)
 ```
 
 <!-- Add project-specific files below as needed, e.g.:               -->
-<!-- @locales/en.json    ??baseline locale for i18n work              -->
-<!-- @docs/BIZ_LOGIC.md  ??domain formulas / business rules           -->
+<!-- @locales/en.json    — baseline locale for i18n work              -->
+<!-- @docs/BIZ_LOGIC.md  — domain formulas / business rules           -->
 
 ---
 
@@ -40,11 +40,11 @@ Gemini CLI uses different tool names from Claude Code:
 | **Command Execution** | `run_command` | Execute PowerShell/Bash shell commands. Returns task process IDs. NEVER use `cd` commands. |
 | **Agent** | `invoke_subagent` | Pass agent role from `agents/<name>.md` |
 
-#### ?좑툘 Surgical Multi-Replace Offset Safeguard
+#### ⚠️ Surgical Multi-Replace Offset Safeguard
 When calling `multi_replace_file_content` with multiple `ReplacementChunks`, the line numbers of subsequent target blocks will shift if previous edits change the line count.
 - **Rule**: Sort and process `ReplacementChunks` from the **bottom of the file to the top** (descending order of line numbers: largest `StartLine` first).
 
-#### ?좑툘 Grep Search 50-Match Cap Safeguard
+#### ⚠️ Grep Search 50-Match Cap Safeguard
 The `grep_search` tool silently truncates results at exactly **50 matches**.
 - **Rule**: If a search yields 50 results, do **NOT** assume you have all occurrences.
 - **Remediation**: Partition the search by targeting specific subdirectories or applying restrictive file glob filters via the `Includes` parameter.
@@ -75,7 +75,7 @@ When entering Planning Mode, leverage these three Markdown artifacts (set `IsArt
 *Path: `<appDataDir>\brain\<session-id>\task.md`*
 - **Purpose**: Running TODO list to track development progress dynamically.
 - **Metadata**: `ArtifactType: "task"`.
-- **Syntax**: `- [ ]` uncompleted 쨌 `- [/]` in progress 쨌 `- [x]` completed.
+- **Syntax**: `- [ ]` uncompleted · `- [/]` in progress · `- [x]` completed.
 
 #### 3. `walkthrough.md`
 *Path: `<appDataDir>\brain\<session-id>\walkthrough.md`*
@@ -112,11 +112,14 @@ For parallel execution, quality reviews, or sandboxed research tasks, utilize th
 
 #### Communication (`send_message`)
 Interact with spawned agents via their unique `conversationID`.
-**Reactive Wakeup**: Do not poll in a loop ??simply yield execution and the platform wakes you automatically when an agent replies or a background task completes.
+**Reactive Wakeup**: Do not poll in a loop — simply yield execution and the platform wakes you automatically when an agent replies or a background task completes.
 
 ### Response Language
 - All **conversational** replies → **Korean (한국어)** by default.
 - All code, config, commit messages, PR titles, PR bodies, branch names → **English only** (see [CONSTITUTION.md §3](https://raw.githubusercontent.com/5throck/ai-workspace-standards/main/CONSTITUTION.md#3-github-pr-workflow)).
+
+### PR Language Rule
+All PR titles, bodies, and review comments must be written in English — governed by [CONSTITUTION.md §3 — Mandatory English Git & PR Artifacts](https://raw.githubusercontent.com/5throck/ai-workspace-standards/main/CONSTITUTION.md#3-github-pr-workflow).
 
 ### Optimal Interaction Guidelines
 - **Context Management**: Leverage your massive context window by cross-referencing multiple files simultaneously (e.g., when debugging, review log files along with related code).
@@ -153,11 +156,29 @@ Instead, emulate them by reading the `.md` file and executing the described scri
 | Equivalent to | Run instead |
 |---------------|------------|
 | `/sync "feat: ..."` | `bash scripts/dev-sync.sh "feat: ..."` |
-| `/memlog "summary"` | Manually append `## Session ??summary` to `memory/YYYY-MM-DD.md` |
+| `/memlog "summary"` | Manually append `## Session — summary` to `memory/YYYY-MM-DD.md` |
 | `/changelog "..."` | Manually add entry to `CHANGELOG.md [Unreleased]` |
 | `/new-task "name"` | Manually append task block to `memory/YYYY-MM-DD.md` |
-| `/new-project "name"` | `bash scripts/new-project.sh "<name>"` (macOS/Linux) 쨌 `.\scripts\new-project.ps1 "<name>"` (Windows) |
-| `/post-write` | `bash scripts/audit.sh` (macOS/Linux) 쨌 `.\scripts\audit.ps1` (Windows) |
+| `/new-project "name"` | `bash scripts/new-project.sh "<name>"` (macOS/Linux) · `.\scripts\new-project.ps1 "<name>"` (Windows) |
+| `/post-write` | `bash scripts/audit.sh` (macOS/Linux) · `.\scripts\audit.ps1` (Windows) |
+| `/security-check` | Run Workflow 2 of `agents/security-monitor.md` (Pre-PR Advisory Check) |
+
+---
+
+### Pre-PR Security Gate (public repos only)
+
+Before pushing and creating a PR, check if the repo is public:
+
+```bash
+gh repo view --json isPrivate -q '.isPrivate' 2>/dev/null
+```
+
+If the result is `false` (public repo): run `/security-check` (Workflow 2 of `agents/security-monitor.md` — read-only, no scan).
+
+- If CRITICAL advisories are found: show the warning and **pause** — let the user decide whether to proceed or stop.
+- If no CRITICAL advisories: continue with the push and PR creation.
+
+For private repos: skip the security gate entirely.
 
 ---
 
@@ -167,7 +188,7 @@ This project uses `.claude/` for Claude Code configuration. Gemini follows these
 
 - **Absolute Precedence**: `.gemini/` always takes precedence over `.claude/` if both exist.
 - **Fallback**: If no `.gemini/` directory exists, Gemini may read `.claude/settings.json` and `.claude/commands/` as a fallback source of truth.
-- **Command Emulation**: Slash commands defined as `.claude/commands/<name>.md` can be emulated ??read the file to understand the underlying script and run it directly via `shell`.
+- **Command Emulation**: Slash commands defined as `.claude/commands/<name>.md` can be emulated — read the file to understand the underlying script and run it directly via `shell`.
 - **Agent Roles**: Gemini can instantiate roles defined in `agents/*.md` using `define_subagent` and `invoke_subagent`.
 - **Migration**: If the project transitions away from Claude Code, proactively offer to migrate `.claude/` configuration to `.gemini/` rather than leaving legacy files orphaned.
 
@@ -177,4 +198,3 @@ This project uses `.claude/` for Claude Code configuration. Gemini follows these
 <!-- Uncomment to override workspace defaults for this project only.          -->
 <!-- - Default      : gemini-2.5-pro                                          -->
 <!-- - Fast lookups : gemini-2.5-flash                                        -->
-

--- a/templates/README.md
+++ b/templates/README.md
@@ -44,3 +44,5 @@ bash scripts/setup.sh
 ## License
 
 [License name] — see [LICENSE](LICENSE)
+
+> **TODO**: Add a `LICENSE` file to this project. Choose a license at [choosealicense.com](https://choosealicense.com).

--- a/templates/SECURITY.md
+++ b/templates/SECURITY.md
@@ -1,10 +1,10 @@
-﻿# Security Policy
+# Security Policy
 
 ## Supported Versions
 
 | Version | Supported |
 |---------|-----------|
-| Latest  | ??       |
+| Latest  | ✅        |
 
 ## Reporting a Vulnerability
 
@@ -12,8 +12,8 @@ If you discover a security vulnerability in this project, **do not open a public
 
 Instead, please report it privately via one of the following channels:
 
-- **GitHub Security Advisory**: [Report a vulnerability](../../security/advisories/new) *(preferred)*
-- **Email**: Contact [@5throck](https://github.com/5throck) directly via GitHub
+- **GitHub Security Advisory**: [Report a vulnerability](../../security/advisories/new) *(update this link to match your repo URL)*
+- **Email**: Contact [project owner] directly via GitHub
 
 ### What to include
 

--- a/templates/agents/pm.md
+++ b/templates/agents/pm.md
@@ -16,7 +16,7 @@ You are the PM orchestrator for **[Project Name]**. You own the end-to-end workf
 
 ## Governance Workflow
 
-Follow the 6-phase PM workflow defined in [CONSTITUTION.md 짠5](../https://raw.githubusercontent.com/5throck/ai-workspace-standards/main/CONSTITUTION.md#5-multi-agent-architecture), with a preliminary step for dynamic team assembly:
+Follow the 6-phase PM workflow defined in [CONSTITUTION.md §5](https://raw.githubusercontent.com/5throck/ai-workspace-standards/main/CONSTITUTION.md#5-multi-agent-architecture), with a preliminary step for dynamic team assembly:
 
 0. **Team Assembly & Skill Orchestration** ??During project kickoff, analyze project requirements and assess if the default agent roster or existing skills are sufficient. 
    - If specialized agents are needed, generate `agents/<name>.md`. Update existing agents' files to prevent role overlap.

--- a/templates/agents/pm.md
+++ b/templates/agents/pm.md
@@ -27,7 +27,7 @@ Follow the 6-phase PM workflow defined in [CONSTITUTION.md §5](https://raw.gith
 3. **Design** ??Dispatch architect (implementation plan + ADR) and, if the task has UI/UX surface, designer (wireframes + component spec) in parallel; obtain explicit user approval before proceeding.
 4. **Implementation** ??Dispatch code-writer (serial); test-runner verifies after each change.
 5. **QA** ??Verify all acceptance criteria; run audit script + tests.
-6. **Finalization** ??Run memlog ??sync; open PR; hand off to user. All AI-generated commits must include `Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>`.
+6. **Finalization** — Run memlog → sync; open PR; hand off to user. All AI-generated commits must include the appropriate `Co-Authored-By` line for the active AI tool (see `CLAUDE.md` or `GEMINI.md`).
 
 ## Agent Roster
 
@@ -40,6 +40,7 @@ Add rows as specialist agents are created. Start with PM only; expand when the p
 | Design | Design | `agents/designer.md` | UI/UX specs, wireframes, component definitions; awaits user approval |
 | Implementation | Execution | `agents/code-writer.md` | Write code per approved plan |
 | QA / Verification | Execution | `agents/test-runner.md` | Run tests, verify acceptance criteria |
+| Setup (unknown stack) | Setup | `agents/stack-setup.md` | Identify stack, research, security review, scaffold setup scripts |
 
 ## Constraints
 

--- a/templates/agents/security-monitor.md
+++ b/templates/agents/security-monitor.md
@@ -1,3 +1,16 @@
+---
+name: security-monitor
+model: inherit
+color: red
+description: >
+  Security monitor — scans for vulnerabilities, advisories, and secret leaks.
+  Use for: daily security scans, pre-PR advisory checks, post-scaffold baseline scans.
+examples:
+  - "Run a security scan before the PR"
+  - "Check for any active CRITICAL advisories"
+  - "Run the daily security scan"
+---
+
 # Security Monitor Agent
 
 You are the security monitor for this project. You scan for vulnerabilities, advisories, and secrets issues, then save findings to `security/`.

--- a/templates/docs/context.md
+++ b/templates/docs/context.md
@@ -138,8 +138,7 @@ Each `.claude/commands/<name>.md` file is auto-registered as a Skill in Claude C
 ## Coding Guidelines
 
 > These rules apply to every AI tool working in this project.
-> Full rationale: [CONSTITUTION.md 짠8](../https://raw.githubusercontent.com/5throck/ai-workspace-standards/main/CONSTITUTION.md#8-coding-behavior-guidelines)
-> *(This file lives in `docs/` ??`../` = project root, `../../` = workspace root where `CONSTITUTION.md` lives.)*
+> Full rationale: [CONSTITUTION.md §8](https://raw.githubusercontent.com/5throck/ai-workspace-standards/main/CONSTITUTION.md#8-coding-behavior-guidelines)
 
 ### 1. Think Before Coding
 - State assumptions explicitly before implementing. If uncertain, ask ??don't guess silently.
@@ -168,7 +167,7 @@ Each `.claude/commands/<name>.md` file is auto-registered as a Skill in Claude C
 - **Avoid** GPL-3.0, AGPL-3.0, SSPL, BSL, or proprietary licenses unless explicitly justified.
 - Run `bash scripts/setup.sh --skip-commit` after adding dependencies to trigger the license audit.
 - Document any intentional non-OSS dependency in this file under a `## Non-OSS Dependencies` section.
-- Full policy: [CONSTITUTION.md 짠8.5](../https://raw.githubusercontent.com/5throck/ai-workspace-standards/main/CONSTITUTION.md#5-open-source-package-policy)
+- Full policy: [CONSTITUTION.md §8.5](https://raw.githubusercontent.com/5throck/ai-workspace-standards/main/CONSTITUTION.md#5-open-source-package-policy)
 
 ### 6. Response Language
 - All **conversational** replies to the user → **Korean (한국어)** by default.

--- a/templates/scripts/dev-sync.sh
+++ b/templates/scripts/dev-sync.sh
@@ -11,17 +11,15 @@ mkdir -p memory
 GIT_STATUS=$(git status --short 2>/dev/null || true)
 FILE_LIST=""
 if [ -n "$GIT_STATUS" ]; then
-  # Extract just file names, join with commas
   FILE_LIST=$(echo "$GIT_STATUS" | sed -E 's/^.{2}[[:space:]]+//' | paste -sd ", " -)
 fi
 
 SEPARATOR=""
-if [ -f "memory/$DATE.md" ]; then
-  SEPARATOR="\n---\n\n"
-fi
+[ -f "memory/$DATE.md" ] && SEPARATOR=$'\n---\n\n'
 
-printf "${SEPARATOR}## $MSG\n- **Files**: $FILE_LIST\n- **Purpose**: \n- **Decisions**: \n- **Issues**: None\n" >> "memory/$DATE.md"
-
+# Safe printf: keep format string static, pass values as arguments
+printf '%s## %s\n- **Files**: %s\n- **Purpose**: \n- **Decisions**: \n- **Issues**: None\n' \
+  "$SEPARATOR" "$MSG" "$FILE_LIST" >> "memory/$DATE.md"
 
 # ── 2. Update MEMORY.md index ─────────────────────────────────────────────────
 bash scripts/sync-md.sh "$DATE" "$MSG"
@@ -30,7 +28,11 @@ bash scripts/sync-md.sh "$DATE" "$MSG"
 if [ -f "CHANGELOG.md" ]; then
   SECTION=$(awk '/\[Unreleased\]/{f=1;next} f && /^## /{exit} f{print}' CHANGELOG.md)
   if ! echo "$SECTION" | grep -qE "^[[:space:]]*[-*]|^### "; then
-    perl -pi -e 'BEGIN{$m=shift} s/## \[Unreleased\]/## [Unreleased]\n\n- $m/' "$MSG" CHANGELOG.md
+    TODAY=$(date +%Y-%m-%d)
+    # \Q$m\E prevents Perl metachar expansion in the replacement string
+    perl -i -pe 'BEGIN{$m=shift; $d=shift}
+      if (/^## \[Unreleased\]/) { $_ .= "\n### Added\n- **[$d]**: \Q$m\E\n" }
+    ' "$MSG" "$TODAY" CHANGELOG.md
     echo "📝 Auto-added changelog entry: $MSG"
   fi
 fi
@@ -38,22 +40,38 @@ fi
 # ── 4. Audit gate ──────────────────────────────────────────────────────────────
 bash scripts/audit.sh
 
-# ── 5. Branch → commit → push → PR ────────────────────────────────────────────
+# ── 5. Guard against committing sensitive files ────────────────────────────────
+# Check for unignored sensitive filenames before staging everything
+SENSITIVE=$(git ls-files --others --exclude-standard | \
+  grep -iE '\.(pem|key|p12|pfx|jks|keystore)$|^\.env(\.[^s][^a]|$)|credentials\.json|service.?account\.json|secrets\.ya?ml' \
+  || true)
+if [ -n "$SENSITIVE" ]; then
+  echo "❌ Potentially sensitive untracked files detected — refusing git add -A:"
+  echo "$SENSITIVE" | sed 's/^/   /'
+  echo "   Stage files explicitly with 'git add <file>' or add them to .gitignore."
+  exit 1
+fi
+
+# ── 6. Branch → commit → push → PR ───────────────────────────────────────────
 CURRENT_BRANCH=$(git rev-parse --abbrev-ref HEAD)
 if [[ "$CURRENT_BRANCH" == "main" || "$CURRENT_BRANCH" == "master" ]]; then
-  BRANCH="pr/$(date +%Y%m%d-%H%M%S)-$(echo "$MSG" | sed 's/[^a-z0-9]/-/g' | sed 's/--*/-/g' | cut -c1-40)"
+  SLUG=$(echo "$MSG" | tr '[:upper:]' '[:lower:]' | sed 's/[^a-z0-9]/-/g' | sed 's/--*/-/g' | cut -c1-40)
+  BRANCH="pr/$(date +%Y%m%d-%H%M%S)-${SLUG}"
   git checkout -b "$BRANCH"
 else
   BRANCH="$CURRENT_BRANCH"
   echo "ℹ️  Already on branch '$BRANCH' — committing here without creating a new branch."
 fi
+
 git add -A
-# NOTE: This is a template script. Update the commit message or AI Co-Author below as needed for your specific project.
-git commit -m "$MSG"
+git commit -m "$MSG
+
+Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>"
 git push -u origin "$BRANCH"
+
 # Use PR template if present; fall back to --fill
 if [ -f ".github/pull_request_template.md" ]; then
-  gh pr create --title "$MSG" --body "$(cat .github/pull_request_template.md)"
+  gh pr create --title "$MSG" --body-file .github/pull_request_template.md
 else
   gh pr create --fill
 fi


### PR DESCRIPTION
## Summary

Phase 1 of the full project review — CRITICAL and HIGH severity security/script fixes.

## Changes

| File | Fix |
|------|-----|
| `scripts/dev-sync.sh` | Sensitive file guard before `git add -A`; printf injection fix; Perl quotemeta; branch slug lowercase; Co-Authored-By corrected; `--body-file`; SEPARATOR quoting |
| `templates/scripts/dev-sync.sh` | All above + Co-Authored-By added (was missing) |
| `.githooks/post-checkout` | Branch name allowlist validation; log redirect to `.claude/post-checkout.log` |
| `templates/.githooks/post-checkout` | Same as above |
| `templates/CHANGELOG.md` | Removed real workspace history — ships clean |
| `templates/docs/context.md` | Fixed broken `../https://` link prefix (§8, §8.5) |
| `templates/agents/pm.md` | Fixed broken `../https://` link prefix (§5) |

## Security Fixes Detail

- **Sensitive file guard**: `git ls-files --others` scans untracked files for `.pem`, `.key`, `.p12`, `.pfx`, `.jks`, `.keystore`, `.env*` (non-sample), `credentials.json`, `service-account.json`, `secrets.yaml` before `git add -A`
- **post-checkout prompt injection**: branch names must match `^[a-zA-Z0-9/_.-]+$` or orchestration is skipped with a clear warning
- **printf format injection**: `printf '%s## %s\n...' "$SEP" "$MSG" "$FILES"` — static format string
- **Perl quotemeta**: `\Q$m\E` prevents `\n`, `$var`, regex metacharacters in commit messages from corrupting CHANGELOG

## Test Plan

- [ ] `bash scripts/audit.sh` passes (exit 0)
- [ ] `CHANGELOG.md` updated under `[Unreleased]`
- [ ] `bash scripts/dev-sync.sh "feat: test"` with a `.pem` file present → blocked
- [ ] Branch named `feat/test"inject` → post-checkout skips orchestration with warning

🤖 Generated with [Claude Code](https://claude.com/claude-code)