### PR TITLE
fix: move memory/CHANGELOG auto-log to commit-msg hook

### DIFF
--- a/.githooks/commit-msg
+++ b/.githooks/commit-msg
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+# commit-msg: auto-log memory + CHANGELOG on every direct git commit.
+# Receives the commit message file path as $1.
+# Runs AFTER pre-commit, so the message is guaranteed to be available.
+
+COMMIT_MSG_FILE="$1"
+COMMIT_MSG=$(head -1 "$COMMIT_MSG_FILE" | sed 's/[[:space:]]*$//')
+
+# Skip empty, Merge, WIP, fixup!, squash! commits
+[ -z "$COMMIT_MSG" ] && exit 0
+echo "$COMMIT_MSG" | grep -qE "^Merge|^WIP|^fixup!|^squash!" && exit 0
+
+TODAY=$(date +%Y-%m-%d)
+mkdir -p memory
+
+STAGED=$(git diff --cached --name-only)
+
+# ── Auto-append memory log (skip if dev-sync already wrote this entry) ────────
+if ! grep -qF "## $COMMIT_MSG" "memory/$TODAY.md" 2>/dev/null; then
+  FILE_LIST=$(echo "$STAGED" | grep -v "^memory/" | paste -sd ", " - || true)
+  SEPARATOR=""
+  [ -f "memory/$TODAY.md" ] && SEPARATOR=$'\n---\n\n'
+  printf "%s## %s\n- **Files**: %s\n- **Purpose**: (auto-logged by commit-msg)\n- **Decisions**: \n- **Issues**: None\n" \
+    "$SEPARATOR" "$COMMIT_MSG" "$FILE_LIST" >> "memory/$TODAY.md"
+fi
+
+# ── Auto-update MEMORY.md index ───────────────────────────────────────────────
+if [ -f "scripts/sync-md.sh" ]; then
+  bash scripts/sync-md.sh "$TODAY" "$COMMIT_MSG" 2>/dev/null || true
+fi
+
+# ── Auto-add CHANGELOG entry if [Unreleased] section has no entries yet ───────
+if [ -f "CHANGELOG.md" ] && ! echo "$STAGED" | grep -q "CHANGELOG.md"; then
+  SECTION=$(awk '/\[Unreleased\]/{f=1;next} f && /^## /{exit} f{print}' CHANGELOG.md)
+  if ! echo "$SECTION" | grep -qE "^[[:space:]]*[-*]|^### "; then
+    perl -i -pe 'BEGIN{$m=shift; $d=shift}
+      if (/^## \[Unreleased\]/) { $_ .= "\n### Added\n- **[$d]**: \Q$m\E\n" }
+    ' "$COMMIT_MSG" "$TODAY" CHANGELOG.md
+  fi
+fi
+
+exit 0

--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -38,44 +38,6 @@ if echo "$STAGED" | grep -q "CHANGELOG.md"; then
   git add CHANGELOG.md
 fi
 
-# ── 1-B. Auto-create memory log + CHANGELOG entry (when bypassing dev-sync) ───
-# Reads commit message from .git/COMMIT_EDITMSG so direct `git commit -m`
-# calls still produce memory and changelog entries automatically.
-COMMIT_MSG=""
-[ -f ".git/COMMIT_EDITMSG" ] && COMMIT_MSG=$(head -1 .git/COMMIT_EDITMSG | sed 's/[[:space:]]*$//')
-
-if [ -n "$COMMIT_MSG" ] && ! echo "$COMMIT_MSG" | grep -qE "^Merge|^WIP|^fixup!|^squash!"; then
-  TODAY=$(date +%Y-%m-%d)
-  mkdir -p memory
-
-  # Auto-append memory log only if dev-sync hasn't already written this entry
-  if ! grep -qF "## $COMMIT_MSG" "memory/$TODAY.md" 2>/dev/null; then
-    FILE_LIST=$(echo "$STAGED" | grep -v "^memory/" | paste -sd ", " - || true)
-    SEPARATOR=""
-    [ -f "memory/$TODAY.md" ] && SEPARATOR=$'\n---\n\n'
-    printf "%s## %s\n- **Files**: %s\n- **Purpose**: (auto-logged by pre-commit)\n- **Decisions**: \n- **Issues**: None\n" \
-      "$SEPARATOR" "$COMMIT_MSG" "$FILE_LIST" >> "memory/$TODAY.md"
-    git add "memory/$TODAY.md"
-  fi
-
-  # Auto-update MEMORY.md index
-  if [ -f "scripts/sync-md.sh" ]; then
-    bash scripts/sync-md.sh "$TODAY" "$COMMIT_MSG" 2>/dev/null || true
-    [ -f "memory/MEMORY.md" ] && git add "memory/MEMORY.md"
-  fi
-
-  # Auto-add CHANGELOG entry if [Unreleased] section is empty
-  if [ -f "CHANGELOG.md" ] && ! echo "$STAGED" | grep -q "CHANGELOG.md"; then
-    SECTION=$(awk '/\[Unreleased\]/{f=1;next} f && /^## /{exit} f{print}' CHANGELOG.md)
-    if ! echo "$SECTION" | grep -qE "^[[:space:]]*[-*]|^### "; then
-      TODAY=$(date +%Y-%m-%d)
-      perl -i -pe 'BEGIN{$m=shift; $d=shift}
-        if (/^## \[Unreleased\]/) { $_ .= "\n- **[$d]**: $m\n" }
-      ' "$COMMIT_MSG" "$TODAY" CHANGELOG.md
-      git add CHANGELOG.md
-    fi
-  fi
-fi
 
 [ "$MEMORY_ONLY" = true ] && exit 0
 

--- a/templates/.githooks/commit-msg
+++ b/templates/.githooks/commit-msg
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+# commit-msg: auto-log memory + CHANGELOG on every direct git commit.
+# Receives the commit message file path as $1.
+# Runs AFTER pre-commit, so the message is guaranteed to be available.
+
+COMMIT_MSG_FILE="$1"
+COMMIT_MSG=$(head -1 "$COMMIT_MSG_FILE" | sed 's/[[:space:]]*$//')
+
+# Skip empty, Merge, WIP, fixup!, squash! commits
+[ -z "$COMMIT_MSG" ] && exit 0
+echo "$COMMIT_MSG" | grep -qE "^Merge|^WIP|^fixup!|^squash!" && exit 0
+
+TODAY=$(date +%Y-%m-%d)
+mkdir -p memory
+
+STAGED=$(git diff --cached --name-only)
+
+# ── Auto-append memory log (skip if dev-sync already wrote this entry) ────────
+if ! grep -qF "## $COMMIT_MSG" "memory/$TODAY.md" 2>/dev/null; then
+  FILE_LIST=$(echo "$STAGED" | grep -v "^memory/" | paste -sd ", " - || true)
+  SEPARATOR=""
+  [ -f "memory/$TODAY.md" ] && SEPARATOR=$'\n---\n\n'
+  printf "%s## %s\n- **Files**: %s\n- **Purpose**: (auto-logged by commit-msg)\n- **Decisions**: \n- **Issues**: None\n" \
+    "$SEPARATOR" "$COMMIT_MSG" "$FILE_LIST" >> "memory/$TODAY.md"
+fi
+
+# ── Auto-update MEMORY.md index ───────────────────────────────────────────────
+if [ -f "scripts/sync-md.sh" ]; then
+  bash scripts/sync-md.sh "$TODAY" "$COMMIT_MSG" 2>/dev/null || true
+fi
+
+# ── Auto-add CHANGELOG entry if [Unreleased] section has no entries yet ───────
+if [ -f "CHANGELOG.md" ] && ! echo "$STAGED" | grep -q "CHANGELOG.md"; then
+  SECTION=$(awk '/\[Unreleased\]/{f=1;next} f && /^## /{exit} f{print}' CHANGELOG.md)
+  if ! echo "$SECTION" | grep -qE "^[[:space:]]*[-*]|^### "; then
+    perl -i -pe 'BEGIN{$m=shift; $d=shift}
+      if (/^## \[Unreleased\]/) { $_ .= "\n### Added\n- **[$d]**: \Q$m\E\n" }
+    ' "$COMMIT_MSG" "$TODAY" CHANGELOG.md
+  fi
+fi
+
+exit 0

--- a/templates/.githooks/pre-commit
+++ b/templates/.githooks/pre-commit
@@ -38,44 +38,6 @@ if echo "$STAGED" | grep -q "CHANGELOG.md"; then
   git add CHANGELOG.md
 fi
 
-# ── 1-B. Auto-create memory log + CHANGELOG entry (when bypassing dev-sync) ───
-# Reads commit message from .git/COMMIT_EDITMSG so direct `git commit -m`
-# calls still produce memory and changelog entries automatically.
-COMMIT_MSG=""
-[ -f ".git/COMMIT_EDITMSG" ] && COMMIT_MSG=$(head -1 .git/COMMIT_EDITMSG | sed 's/[[:space:]]*$//')
-
-if [ -n "$COMMIT_MSG" ] && ! echo "$COMMIT_MSG" | grep -qE "^Merge|^WIP|^fixup!|^squash!"; then
-  TODAY=$(date +%Y-%m-%d)
-  mkdir -p memory
-
-  # Auto-append memory log only if dev-sync hasn't already written this entry
-  if ! grep -qF "## $COMMIT_MSG" "memory/$TODAY.md" 2>/dev/null; then
-    FILE_LIST=$(echo "$STAGED" | grep -v "^memory/" | paste -sd ", " - || true)
-    SEPARATOR=""
-    [ -f "memory/$TODAY.md" ] && SEPARATOR=$'\n---\n\n'
-    printf "%s## %s\n- **Files**: %s\n- **Purpose**: (auto-logged by pre-commit)\n- **Decisions**: \n- **Issues**: None\n" \
-      "$SEPARATOR" "$COMMIT_MSG" "$FILE_LIST" >> "memory/$TODAY.md"
-    git add "memory/$TODAY.md"
-  fi
-
-  # Auto-update MEMORY.md index
-  if [ -f "scripts/sync-md.sh" ]; then
-    bash scripts/sync-md.sh "$TODAY" "$COMMIT_MSG" 2>/dev/null || true
-    [ -f "memory/MEMORY.md" ] && git add "memory/MEMORY.md"
-  fi
-
-  # Auto-add CHANGELOG entry if [Unreleased] section is empty
-  if [ -f "CHANGELOG.md" ] && ! echo "$STAGED" | grep -q "CHANGELOG.md"; then
-    SECTION=$(awk '/\[Unreleased\]/{f=1;next} f && /^## /{exit} f{print}' CHANGELOG.md)
-    if ! echo "$SECTION" | grep -qE "^[[:space:]]*[-*]|^### "; then
-      TODAY=$(date +%Y-%m-%d)
-      perl -i -pe 'BEGIN{$m=shift; $d=shift}
-        if (/^## \[Unreleased\]/) { $_ .= "\n- **[$d]**: $m\n" }
-      ' "$COMMIT_MSG" "$TODAY" CHANGELOG.md
-      git add CHANGELOG.md
-    fi
-  fi
-fi
 
 [ "$MEMORY_ONLY" = true ] && exit 0
 


### PR DESCRIPTION
## Summary

- **Root cause**: `pre-commit` runs before git writes the commit message to `COMMIT_EDITMSG`, so §1-B could never read the current commit message — it was always reading the *previous* commit's message or nothing.
- **Fix**: Add a `commit-msg` hook that receives the message file path via `$1` (guaranteed available). Remove §1-B from `pre-commit`.
- **Scope**: Workspace `.githooks/` + `templates/.githooks/` (new projects inherit automatically via `new-project.sh`)

## Files Changed

- `.githooks/commit-msg` (new)
- `.githooks/pre-commit` — §1-B removed
- `templates/.githooks/commit-msg` (new)
- `templates/.githooks/pre-commit` — §1-B removed

## Test plan

- [ ] `git commit -m "test: verify auto-log"` → `memory/YYYY-MM-DD.md` gets new entry
- [ ] `CHANGELOG.md [Unreleased]` gets new entry if section was empty
- [ ] `memory/MEMORY.md` index updated

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>