### PR TITLE
fix: enforce pre-push hook on workspace root and add commit-msg to new-project.ps1

### DIFF
--- a/scripts/new-project.ps1
+++ b/scripts/new-project.ps1
@@ -49,7 +49,7 @@ git config core.hooksPath .githooks
 # ── 6. Set executable bit on hooks and scripts (for WSL / Git Bash users) ──────
 # Must run AFTER git init so the git index exists
 $executableFiles = @(
-    ".githooks\pre-commit", ".githooks\pre-push", ".githooks\post-checkout",
+    ".githooks\pre-commit", ".githooks\pre-push", ".githooks\post-checkout", ".githooks\commit-msg",
     "scripts\audit.sh", "scripts\dev-sync.sh", "scripts\sync-md.sh", "scripts\setup.sh",
     "scripts\dev-sync.ps1", "scripts\audit.ps1", "scripts\sync-md.ps1", "scripts\setup.ps1"
 )


### PR DESCRIPTION
## Summary

- **Root cause**: workspace root had \`core.hooksPath\` pointing to \`.git/hooks\` (default) instead of \`.githooks\`, so pre-push and pre-commit hooks were never firing.
- **Fix**: \`git config core.hooksPath .githooks\` applied to workspace root.
- **new-project.ps1**: added \`.githooks\commit-msg\` to the executable files list so new projects get the correct permissions on Windows (\`new-project.sh\` already uses \`find\`-based chmod, so it was already covered).

## Test plan

- [ ] Direct push to \`main\` from workspace root is now blocked by pre-push hook
- [ ] New project scaffolded on Windows: \`.githooks/commit-msg\` has executable bit set

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>