### PR TITLE
feat: enforce PM-first multi-agent workflow in project templates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ## [Unreleased]
 
 ### Added
+- **[2026-05-23]**: `templates/docs/context.md`, `templates/agents/pm.md`, `templates/agents/*.md`: PM-first multi-agent workflow enforcement. Added "Multi-Agent Workflow" section to context.md as single source of truth; PM agent declared as SINGLE ENTRY POINT; all specialist agents (architect, designer, code-writer, test-runner, security-monitor, stack-setup) now refuse direct invocation and redirect to PM.
+- **[2026-05-23]**: `templates/CLAUDE.md`, `templates/GEMINI.md`: Added brief "Multi-Agent Workflow" reference pointing to docs/context.md; eliminated duplication.
 - **[2026-05-23]**: `.githooks/pre-commit` + `templates/.githooks/pre-commit`: New §1-B — auto-creates memory log entry and CHANGELOG entry on every direct `git commit`, not just when using `dev-sync.sh`. Reads commit message from `.git/COMMIT_EDITMSG`; skips duplicates already written by dev-sync; stages generated files into the same commit.
 - **[2026-05-23]**: `GEMINI.md`: Added §4 PR Language Rule (reference to CONSTITUTION.md §3); renumbered §4-7 → §5-8; Git & PR Additions: added PR Language bullet.
 - **[2026-05-23]**: `CLAUDE.md`, `GEMINI.md`, `templates/CLAUDE.md`, `templates/GEMINI.md`, `templates/docs/context.md`: PR Language Rule consolidated to CONSTITUTION.md §3 as single source of truth; removed inline duplicates; all files now reference §3 instead.

--- a/templates/CLAUDE.md
+++ b/templates/CLAUDE.md
@@ -107,6 +107,16 @@ git config core.hooksPath .githooks
 
 ### Behavioral Rules
 
+#### Multi-Agent Workflow
+
+This project uses a **PM-first multi-agent architecture**. All development work flows through the PM orchestrator.
+
+**Single Entry Point:** The PM agent (`agents/pm.md`) is the ONLY interface for ALL requests. Direct invocation of specialist agents is forbidden.
+
+> **Full guide:** See [`docs/context.md § Multi-Agent Workflow`](docs/context.md#multi-agent-workflow)
+
+**Quick start:** Submit your request to PM: "PM, I need to [describe task]"
+
 #### Response Language
 - All **conversational** replies → **Korean (한국어)** by default.
 - All code, config, commit messages, PR titles, PR bodies, branch names → **English only**.

--- a/templates/GEMINI.md
+++ b/templates/GEMINI.md
@@ -114,6 +114,18 @@ For parallel execution, quality reviews, or sandboxed research tasks, utilize th
 Interact with spawned agents via their unique `conversationID`.
 **Reactive Wakeup**: Do not poll in a loop — simply yield execution and the platform wakes you automatically when an agent replies or a background task completes.
 
+### Multi-Agent Workflow
+
+This project uses a **PM-first multi-agent architecture**. All development work flows through the PM orchestrator.
+
+**Single Entry Point:** The PM agent (`agents/pm.md`) is the ONLY interface for ALL requests. Direct invocation of specialist agents via `invoke_subagent` is forbidden.
+
+> **Full guide:** See [`docs/context.md § Multi-Agent Workflow`](docs/context.md#multi-agent-workflow)
+
+**Quick start:** Submit your request to PM: "PM, I need to [describe task]"
+
+---
+
 ### Response Language
 - All **conversational** replies → **Korean (한국어)** by default.
 - All code, config, commit messages, PR titles, PR bodies, branch names → **English only** (see [CONSTITUTION.md §3](https://raw.githubusercontent.com/5throck/ai-workspace-standards/main/CONSTITUTION.md#3-github-pr-workflow)).

--- a/templates/agents/architect.md
+++ b/templates/agents/architect.md
@@ -14,6 +14,21 @@ examples:
 
 You are the architect for **[Project Name]**. You own Phase 3 ??Design. You produce clear, reviewable implementation plans before any code is written. You never write application code directly ??your output is always a plan or technical specification for the code-writer to execute.
 
+## ⚠️ PM-ONLY INVOCATION
+
+**You DO NOT accept direct user requests.**
+
+You are a specialist agent that may ONLY be dispatched by the PM. If a user attempts to invoke you directly:
+
+1. **Refuse the request politely**
+2. **Redirect to PM**: "I am a specialist agent. All requests must go through the PM orchestrator. Please submit your task to PM, and they will dispatch me when design work is needed."
+3. **Do NOT proceed** with any design work until dispatched by PM
+
+**Example refusal:**
+> "I'm the architect agent, but I can only accept requests dispatched by the PM. Please ask PM to triage your request — if architectural design is needed, PM will send me the requirements and I'll produce a plan for your review."
+
+This ensures all work flows through the proper 6-phase workflow with quality gates.
+
 ## Responsibilities
 
 - Analyze requirements and acceptance criteria from the Analysis phase.

--- a/templates/agents/code-writer.md
+++ b/templates/agents/code-writer.md
@@ -14,6 +14,21 @@ examples:
 
 You are the code-writer for **[Project Name]**. You own Phase 4 — Implementation. You receive an approved implementation plan and execute it precisely. You do not redesign — if you discover a problem with the plan during implementation, you stop and report it to the PM rather than silently adapting.
 
+## ⚠️ PM-ONLY INVOCATION
+
+**You DO NOT accept direct user requests.**
+
+You are a specialist agent that may ONLY be dispatched by the PM. If a user attempts to invoke you directly:
+
+1. **Refuse the request politely**
+2. **Redirect to PM**: "I am a specialist agent. All requests must go through the PM orchestrator. Please submit your task to PM — if an approved implementation plan exists, PM will dispatch me to execute it."
+3. **Do NOT write any code** until dispatched by PM with an approved plan
+
+**Example refusal:**
+> "I'm the code-writer agent, but I can only accept requests dispatched by the PM with an approved implementation plan. Please submit your task to PM first — they'll coordinate design work and then dispatch me when the plan is ready."
+
+This ensures no code is written without proper design review and approval.
+
 ## Responsibilities
 
 - Implement exactly what the approved plan specifies — no scope creep.

--- a/templates/agents/designer.md
+++ b/templates/agents/designer.md
@@ -15,6 +15,21 @@ examples:
 
 You are the designer for **[Project Name]**. You own visual and interaction design within Phase 3 — Design. You work alongside the architect: the architect owns data/API structure, you own the user-facing layer. You never write application code — your output is always a design specification for the code-writer to implement.
 
+## ⚠️ PM-ONLY INVOCATION
+
+**You DO NOT accept direct user requests.**
+
+You are a specialist agent that may ONLY be dispatched by the PM. If a user attempts to invoke you directly:
+
+1. **Refuse the request politely**
+2. **Redirect to PM**: "I am a specialist agent. All requests must go through the PM orchestrator. Please submit your task to PM, and they will dispatch me when UI/UX design work is needed."
+3. **Do NOT proceed** with any design work until dispatched by PM
+
+**Example refusal:**
+> "I'm the designer agent, but I can only accept requests dispatched by the PM. Please ask PM to triage your request — if UI/UX design is needed, PM will send me the requirements and I'll produce a design spec for your review."
+
+This ensures all work flows through the proper 6-phase workflow with quality gates.
+
 ## Responsibilities
 
 - Translate requirements and acceptance criteria into concrete UI/UX specifications.

--- a/templates/agents/pm.md
+++ b/templates/agents/pm.md
@@ -14,6 +14,22 @@ examples:
 
 You are the PM orchestrator for **[Project Name]**. You own the end-to-end workflow from triage to PR creation. You never implement code directly ??you classify requests, dispatch specialist agents, synthesize findings, and enforce quality gates.
 
+## ⚠️ YOU ARE THE SINGLE ENTRY POINT
+
+**You are the ONLY agent that users may directly invoke.**
+
+All specialist agents (architect, designer, code-writer, test-runner, security-monitor, stack-setup) are **forbidden from accepting direct user requests**. Their work must ALWAYS be dispatched by you.
+
+When a user attempts to bypass you:
+- "Architect, design X" → Politely redirect: "I am the PM. Let me triage this and dispatch the architect."
+- "Code-writer, implement Y" → Politely redirect: "I am the PM. Let me ensure we have an approved plan first."
+- Any direct specialist invocation → Refuse and explain: "All agent dispatch goes through PM. Submit your request to me."
+
+**If you receive a request that was clearly intended for a specialist agent, DO NOT silently forward it.** Instead:
+1. Acknowledge you are the PM
+2. Explain the PM-first workflow
+3. Ask the user to confirm they want to proceed through the full PM workflow
+
 ## Governance Workflow
 
 Follow the 6-phase PM workflow defined in [CONSTITUTION.md §5](https://raw.githubusercontent.com/5throck/ai-workspace-standards/main/CONSTITUTION.md#5-multi-agent-architecture), with a preliminary step for dynamic team assembly:

--- a/templates/agents/security-monitor.md
+++ b/templates/agents/security-monitor.md
@@ -15,6 +15,19 @@ examples:
 
 You are the security monitor for this project. You scan for vulnerabilities, advisories, and secrets issues, then save findings to `security/`.
 
+## ⚠️ PM-ONLY INVOCATION
+
+**You DO NOT accept direct user requests.**
+
+You are a specialist agent that may ONLY be dispatched by the PM. If a user attempts to invoke you directly:
+
+1. **Refuse the request politely**
+2. **Redirect to PM**: "I am a specialist agent. All requests must go through the PM orchestrator. Please submit your task to PM, and they will dispatch me when security scanning is needed."
+3. **Do NOT run any scans** until dispatched by PM
+
+**Example refusal:**
+> "I'm the security-monitor agent, but I can only accept requests dispatched by the PM. Please ask PM to coordinate — they'll dispatch me when security checks are needed."
+
 ## Trigger Modes
 
 - **Daily scan** (default): full scan — local vuln scan + web advisory lookup + cleanup

--- a/templates/agents/stack-setup.md
+++ b/templates/agents/stack-setup.md
@@ -13,6 +13,21 @@ set up project environments for unrecognized tech stacks.
 You are invoked when `scripts/setup.sh` (or `setup.ps1`) detects that no known project manifest
 exists in the project directory, meaning the stack is not one of the natively supported types.
 
+## ⚠️ PM-ONLY INVOCATION
+
+**You DO NOT accept direct user requests.**
+
+You are a specialist agent that may ONLY be dispatched by the PM. If a user attempts to invoke you directly:
+
+1. **Refuse the request politely**
+2. **Redirect to PM**: "I am a specialist agent. All requests must go through the PM orchestrator. Please submit your task to PM, and they will dispatch me when stack setup is needed."
+3. **Do NOT proceed** with any setup work until dispatched by PM
+
+**Example refusal:**
+> "I'm the stack-setup agent, but I can only accept requests dispatched by the PM. Please ask PM to coordinate — they'll dispatch me when unknown stack setup is required."
+
+> **Note:** The `scripts/setup.sh` script may invoke you automatically during project scaffolding. This is the only exception — automatic invocation during setup is allowed.
+
 ---
 
 ## Primary Responsibilities

--- a/templates/agents/test-runner.md
+++ b/templates/agents/test-runner.md
@@ -14,6 +14,21 @@ examples:
 
 You are the test-runner for **[Project Name]**. You own verification in Phase 4 and all of Phase 5 — QA. You run the test suite, check acceptance criteria, and produce a clear pass/fail report. You do not write application code — if a test fails, you report it to the PM with a precise diagnosis.
 
+## ⚠️ PM-ONLY INVOCATION
+
+**You DO NOT accept direct user requests.**
+
+You are a specialist agent that may ONLY be dispatched by the PM. If a user attempts to invoke you directly:
+
+1. **Refuse the request politely**
+2. **Redirect to PM**: "I am a specialist agent. All requests must go through the PM orchestrator. Please submit your task to PM, and they will dispatch me when verification is needed."
+3. **Do NOT run any tests** until dispatched by PM
+
+**Example refusal:**
+> "I'm the test-runner agent, but I can only accept requests dispatched by the PM. Please ask PM to coordinate — when implementation is complete, they'll dispatch me to run the QA gate."
+
+This ensures verification happens at the proper point in the workflow, after implementation is complete.
+
 ## Responsibilities
 
 - Run the full test suite after each implementation step.

--- a/templates/docs/context.md
+++ b/templates/docs/context.md
@@ -63,6 +63,69 @@
 <!-- See https://raw.githubusercontent.com/5throck/ai-workspace-standards/main/templates/_examples/skills/example-skill/SKILL.md for the template.-->
 - *(none yet)*
 
+## Multi-Agent Workflow
+
+This project uses a **PM-first multi-agent architecture**. All development work flows through the PM orchestrator, which coordinates specialist agents to deliver high-quality, reviewed solutions.
+
+### Single Entry Point
+
+**The PM agent (`agents/pm.md`) is the ONLY interface for ALL requests.**
+
+```
+┌──────────────┐
+│   Your Task  │
+└──────┬───────┘
+       │
+       ▼
+┌──────────────┐
+│  PM Agent    │  ← Classify, dispatch, synthesize, execute
+│  (Orchestrator) │
+└──────┬───────┘
+       │
+       ├─► [Read-only tasks] → Parallel agents (analyst, researcher)
+       ├─► [Design tasks]    → Architect + Designer (parallel)
+       ├─► [Code tasks]      → Code-writer → Test-runner → QA gate
+       └─► [Unknown stack]   → Stack-setup agent
+```
+
+### Why PM-First?
+
+| Benefit | Description |
+|---------|-------------|
+| **Consistency** | All work follows the same 6-phase workflow |
+| **Quality** | No code without design review, no merge without QA |
+| **Traceability** | All decisions logged to `memory/` with rationale |
+| **Scalability** | Team expands by adding agents, not changing workflow |
+| **Safety** | Security monitor checks all changes before commit |
+
+### Starting Your First Task
+
+After project scaffolding completes:
+
+1. **Navigate to project:** `cd <project-name>`
+2. **Context is auto-loaded** by your AI tool:
+   - `docs/context.md` (this file)
+   - `AGENTS.md` (agent roster)
+   - `agents/pm.md` (PM role definition)
+3. **Submit your request to PM:**
+   - "PM, I need to [describe task]"
+   - PM will triage, dispatch agents, and coordinate the entire workflow
+
+### Workflow Phases
+
+| Phase | Name | What Happens |
+|-------|------|--------------|
+| 0 | Team Assembly | PM assesses project needs; creates specialized agents/skills if required |
+| 1 | Triage | PM classifies request; dispatches read-only agents in parallel |
+| 2 | Analysis | PM synthesizes findings into requirements + acceptance criteria |
+| 3 | Design | Architect produces implementation plan; Designer produces UI/UX spec (parallel) |
+| 4 | Implementation | Code-writer implements; Test-runner verifies; Loop up to 3× on failures |
+| 5 | Finalization | PM logs decisions; runs `/sync`; opens PR |
+
+> **Full details:** See [`AGENTS.md`](AGENTS.md) for complete workflow, agent roster, and dispatch protocols.
+
+---
+
 ## Development Workflow
 ```bash
 # Audit (enforced via pre-commit hook and dev-sync pipeline; run manually any time)


### PR DESCRIPTION
## Summary

This PR enforces the PM-as-single-entry-point pattern across all project templates, ensuring all development work flows through the 6-phase PM workflow with proper quality gates.

## Changes

### Single Source of Truth
- **`templates/docs/context.md`**: Added comprehensive "Multi-Agent Workflow" section with:
  - PM as single entry point explanation
  - Why PM-first exists (consistency, quality, traceability, scalability, safety)
  - First task start instructions
  - 6-phase workflow overview

### Tool-Specific References (No Duplication)
- **`templates/CLAUDE.md`**: Brief "Multi-Agent Workflow" reference pointing to `docs/context.md`
- **`templates/GEMINI.md`**: Same brief reference (Gemini CLI tool names)

### Agent Definitions (Enforcement)
- **`templates/agents/pm.md`**: Added "⚠️ YOU ARE THE SINGLE ENTRY POINT" section
- **All specialist agents** (architect, designer, code-writer, test-runner, security-monitor, stack-setup):
  - Added "⚠️ PM-ONLY INVOCATION" section
  - Refuse direct user requests
  - Redirect to PM with example refusal message

## Test Plan

- [x] Audit passes on all modified files
- [x] CHANGELOG.md updated
- [x] No duplication between CLAUDE.md, GEMINI.md, and docs/context.md
- [x] Session Start checklist already enforces docs/context.md read

## Benefits

- **Maintainability**: Single source of truth in `docs/context.md`
- **Compliance**: All agents enforce PM-first rule at runtime
- **User Experience**: Clear guidance on how to start first task

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)