### PR TITLE
fix: standardize Co-Authored-By to Claude & Gemini, fix commit-msg hook executable bit

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -139,7 +139,11 @@ If a custom slash command or background script returns a non-zero exit code:
 
 All shared Git/PR rules are in [CONSTITUTION.md §3](CONSTITUTION.md#3-github-pr-workflow). Claude Code-specific additions:
 
-- **AI Commit Signatures**: Always append `Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>` to the end of all AI-generated git commit messages.
+- **AI Commit Signatures**: Always append both co-author lines to all AI-generated git commit messages:
+  ```
+  Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>
+  Co-Authored-By: Gemini <noreply@google.com>
+  ```
 - **PR Language**: Governed by [CONSTITUTION.md §3 — Mandatory English Git & PR Artifacts](CONSTITUTION.md#3-github-pr-workflow). All PR titles, bodies, and review comments must be written in English — no exceptions.
 
 *Last Updated: 2026-05-24*

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -168,7 +168,11 @@ Many active repositories under the workspace root possess `.claude/` directories
 All shared Git/PR rules are in [CONSTITUTION.md 짠3](CONSTITUTION.md#3-github-pr-workflow). Gemini-specific additions:
 
 - **PostToolUse Limitation**: PostToolUse hooks are **disabled** in Gemini/Antigravity sessions. Manually execute `dev-sync` or audit scripts (`scripts/audit.sh` or `scripts/audit.ps1`) after local edits, and run commits at task boundaries.
-- **AI Commit Signatures**: Always append `Co-Authored-By: Gemini <noreply@google.com>` to the end of all AI-generated git commit messages.
+- **AI Commit Signatures**: Always append both co-author lines to all AI-generated git commit messages:
+  ```
+  Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>
+  Co-Authored-By: Gemini <noreply@google.com>
+  ```
 - **PR Language**: Governed by [CONSTITUTION.md §3 — Mandatory English Git & PR Artifacts](CONSTITUTION.md#3-github-pr-workflow). All PR titles, bodies, and review comments must be written in English — no exceptions.
 
 *Last Updated: 2026-05-24*

--- a/templates/CLAUDE.md
+++ b/templates/CLAUDE.md
@@ -167,6 +167,7 @@ Always append to AI-generated commit messages:
 
 ```
 Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>
+Co-Authored-By: Gemini <noreply@google.com>
 ```
 
 - **PR Language**: Governed by [CONSTITUTION.md §3 — Mandatory English Git & PR Artifacts](https://raw.githubusercontent.com/5throck/ai-workspace-standards/main/CONSTITUTION.md#3-github-pr-workflow). All PR titles, bodies, and review comments must be written in English — no exceptions.

--- a/templates/GEMINI.md
+++ b/templates/GEMINI.md
@@ -173,6 +173,7 @@ bash scripts/dev-sync.sh "feat: description"
 
 Always append to AI-generated commit messages:
 ```
+Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>
 Co-Authored-By: Gemini <noreply@google.com>
 ```
 


### PR DESCRIPTION
## Why
PR bodies and commits were inconsistently attributed — some had only Claude, some only Gemini, depending on which tool ran the sync. The `commit-msg` hook in sub-projects also had no executable bit (100644), so memory/CHANGELOG auto-log was silently skipped.

## What Changed
- All `dev-sync.sh/.ps1`, `gen-pr-body.sh/.ps1`, `setup.sh/.ps1`: now append both co-author lines
- `CLAUDE.md`, `GEMINI.md` (workspace + templates): documentation updated to show both lines
- Sub-project `.githooks/commit-msg`: executable bit corrected from 100644 → 100755

## Test Plan
- [ ] `bash scripts/audit.sh` passes
- [ ] Commit in any sub-project: `memory/` and `CHANGELOG.md` auto-updated by commit-msg hook
- [ ] `/sync` PR body includes both Co-Authored-By lines

## Security Checklist
- [ ] No secrets committed
- [ ] No .env files staged

## Notes
None