### PR TITLE
docs: standardize powershell argument casing in readme

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ## [Unreleased]
 
 ### Changed
+- **[2026-05-26]**: docs: standardize powershell argument casing in readme
+
+### Changed
 - **[2026-05-26]**: chore: remove stale meeting summary files
 
 ### Added
@@ -384,6 +387,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ---
 
 *Last Updated: 2026-05-26*
+
 
 
 

--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ bash scripts/new-project.sh "my-project-name" --version 0.5.0
 
 # Windows PowerShell
 .\scripts\new-project.ps1 "my-project-name"
-.\scripts\new-project.ps1 "my-project-name" -Variant co-develop -Version 0.5.0
+.\scripts\new-project.ps1 "my-project-name" -variant co-develop -version 0.5.0
 ```
 
 > **AI tool shortcut**: In Claude Code, use `/new-project "my-project-name"` instead of running the script directly.

--- a/README_ko.md
+++ b/README_ko.md
@@ -57,7 +57,7 @@ bash scripts/new-project.sh "my-project-name" --version 0.5.0
 
 # Windows PowerShell
 .\scripts\new-project.ps1 "my-project-name"
-.\scripts\new-project.ps1 "my-project-name" -Variant co-develop -Version 0.5.0
+.\scripts\new-project.ps1 "my-project-name" -variant co-develop -version 0.5.0
 ```
 
 > **AI 도구 단축키**: Claude Code에서는 스크립트를 직접 실행하는 대신 `/new-project "my-project-name"`을 사용할 수 있습니다.

--- a/memory/2026-05-26.md
+++ b/memory/2026-05-26.md
@@ -121,3 +121,11 @@
 - **Purpose**: 
 - **Decisions**: 
 - **Issues**: None
+
+---
+
+## docs: standardize powershell argument casing in readme
+- **Files**: README.md, README_ko.md
+- **Purpose**: 
+- **Decisions**: 
+- **Issues**: None


### PR DESCRIPTION
## Why
docs: standardize powershell argument casing in readme

## What Changed
- CHANGELOG.md
- README.md
- README_ko.md
- memory/2026-05-26.md

## Test Plan
- [ ] `bash scripts/audit.sh` passes
- [ ] CHANGELOG.md updated under `[Unreleased]`

## Security Checklist
- [ ] No secrets, credentials, or API keys committed
- [ ] No `.env` files staged (use `.env.sample` for templates)
- [ ] Dependencies unchanged or reviewed for new CVEs

## Notes
None

---