### PR TITLE
docs: sync readme structure with current repository state

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ## [Unreleased]
 
 ### Changed
+- **[2026-05-26]**: docs: sync readme structure with current repository state
+
+### Changed
 - **[2026-05-26]**: docs: standardize powershell argument casing in readme
 
 ### Changed
@@ -387,6 +390,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ---
 
 *Last Updated: 2026-05-26*
+
 
 
 

--- a/README.md
+++ b/README.md
@@ -122,7 +122,7 @@ C:\git\ (workspace root - this repo)
 │   ├── VERSION              # Current template semver (0.5.0)
 │   ├── CHANGELOG.md         # Template-level change history
 │   ├── common/              # Shared skills across all variants
-│   │   └── skills/          # skill-lifecycle-manager, meeting-facilitation
+│   │   └── skills/          # agent-lifecycle-manager, skill-lifecycle-manager, meeting-facilitation
 │   ├── co-develop/          # ✅ Stable — full software development agent team
 │   │   ├── variant.json     # Variant metadata (name, status, version)
 │   │   ├── agents/          # pm.md, architect.md, designer.md, code-writer.md, test-runner.md, security-monitor.md
@@ -142,13 +142,17 @@ C:\git\ (workspace root - this repo)
 ├── scripts/
 │   ├── audit.sh / .ps1                         # Documentation audit (checks ## Coding Guidelines, CHANGELOG, etc.)
 │   ├── dev-sync.sh / .ps1                      # Full pipeline: memlog → sync-md → changelog → audit → commit → PR
-│   ├── sync-md.sh / .ps1                       # MEMORY.md index updater
 │   ├── new-project.sh / .ps1                   # New project scaffolding (--variant, --version flags)
-│   ├── list-template-versions.sh / .ps1        # List available template versions (git tags)
-│   └── validate-templates.sh / .ps1            # Validate template variant structural integrity
+│   ├── qa-gate.sh / .ps1                       # Independent QA gate execution script
+│   ├── sync-md.sh / .ps1                       # MEMORY.md index updater
+│   ├── validate-templates.ts                   # Template variant structural integrity validator
+│   └── *-lifecycle-audit.ts                    # Agent/Skill/README structural integrity checks
 ├── .githooks/
-│   ├── pre-commit           # Smart conditional audit (memory/ files exempt)
-│   └── pre-push             # Blocks direct push to main
+│   ├── commit-msg           # English-only PR artifact enforcement
+│   ├── post-checkout        # Background workspace config initialization
+│   ├── pre-commit           # Smart conditional audit & UTF-8 checks
+│   ├── pre-push             # Blocks direct push to main
+│   └── pre-rebase           # Gitleaks secret scanning before rebasing
 ├── .claude/
 │   ├── settings.json        # {} (hooks disabled; enforced via pre-commit + dev-sync)
 │   └── commands/            # Custom slash commands (/sync, /changelog, /memlog, etc.)
@@ -185,7 +189,7 @@ Every AI session begins by running this checklist (defined in `CONSTITUTION.md`)
 
 ## Multi-Agent Workflow
 
-Projects use a 5-role agent model across 6 governance phases:
+The default `co-develop` template uses a 5-role agent model across 6 governance phases:
 
 ```
 PM Orchestrator

--- a/README_ko.md
+++ b/README_ko.md
@@ -120,7 +120,7 @@ C:\git\ (워크스페이스 루트 - 현재 저장소)
 │   ├── VERSION              # 현재 template semver (0.5.0)
 │   ├── CHANGELOG.md         # Template 레벨 변경 이력
 │   ├── common/              # 모든 variant에서 공유하는 스킬
-│   │   └── skills/          # skill-lifecycle-manager, meeting-facilitation
+│   │   └── skills/          # agent-lifecycle-manager, skill-lifecycle-manager, meeting-facilitation
 │   ├── co-develop/          # ✅ Stable — 소프트웨어 개발 전용 에이전트 팀
 │   │   ├── variant.json     # Variant 메타데이터 (name, status, version)
 │   │   ├── agents/          # pm.md, architect.md, designer.md, code-writer.md, test-runner.md, security-monitor.md
@@ -140,13 +140,17 @@ C:\git\ (워크스페이스 루트 - 현재 저장소)
 ├── scripts/
 │   ├── audit.sh / .ps1                       # 문서 감사 (## Coding Guidelines, CHANGELOG 등 검사)
 │   ├── dev-sync.sh / .ps1                    # 전체 파이프라인: memlog → sync-md → changelog → audit → commit → PR
-│   ├── sync-md.sh / .ps1                     # MEMORY.md 인덱스 업데이트
 │   ├── new-project.sh / .ps1                 # 새 프로젝트 스캐폴딩 (--variant, --version 지원)
-│   ├── list-template-versions.sh / .ps1      # 사용 가능한 template 버전 목록 (git 태그 기반)
-│   └── validate-templates.sh / .ps1          # Template variant 구조 무결성 검증
+│   ├── qa-gate.sh / .ps1                     # 독립적인 품질 보증(QA) 게이트 실행 스크립트
+│   ├── sync-md.sh / .ps1                     # MEMORY.md 인덱스 업데이트
+│   ├── validate-templates.ts                 # Template variant 구조 무결성 검증
+│   └── *-lifecycle-audit.ts                  # Agent/Skill/README 구조 무결성 검사
 ├── .githooks/
-│   ├── pre-commit           # 스마트 조건부 감사 (memory/ 파일 예외 처리)
-│   └── pre-push             # main 브랜치로의 직접 push 차단
+│   ├── commit-msg           # 영어로만 작성된 PR 산출물 강제 검증
+│   ├── post-checkout        # 백그라운드 워크스페이스 설정 초기화
+│   ├── pre-commit           # 스마트 조건부 감사 및 UTF-8 인코딩 검사
+│   ├── pre-push             # main 브랜치로의 직접 push 차단
+│   └── pre-rebase           # Rebase 전 Gitleaks 시크릿 검사
 ├── .claude/
 │   ├── settings.json        # {} (훅 비활성화됨; pre-commit + dev-sync를 통해 강제 적용)
 │   └── commands/            # 커스텀 슬래시 명령어 (/sync, /changelog, /memlog 등)
@@ -183,7 +187,7 @@ C:\git\
 
 ## 멀티 에이전트 워크플로 (Multi-Agent Workflow)
 
-프로젝트는 6단계 거버넌스 단계에 걸쳐 5역할 에이전트 모델을 사용합니다:
+기본 `co-develop` 템플릿은 6단계 거버넌스 단계에 걸쳐 5역할 에이전트 모델을 사용합니다:
 
 ```
 PM Orchestrator (PM 오케스트레이터)

--- a/memory/2026-05-26.md
+++ b/memory/2026-05-26.md
@@ -129,3 +129,11 @@
 - **Purpose**: 
 - **Decisions**: 
 - **Issues**: None
+
+---
+
+## docs: sync readme structure with current repository state
+- **Files**: README.md, README_ko.md
+- **Purpose**: 
+- **Decisions**: 
+- **Issues**: None


### PR DESCRIPTION
## Why
docs: sync readme structure with current repository state

## What Changed
- CHANGELOG.md
- README.md
- README_ko.md
- memory/2026-05-26.md

## Test Plan
- [ ] `bash scripts/audit.sh` passes
- [ ] CHANGELOG.md updated under `[Unreleased]`

## Security Checklist
- [ ] No secrets, credentials, or API keys committed
- [ ] No `.env` files staged (use `.env.sample` for templates)
- [ ] Dependencies unchanged or reviewed for new CVEs

## Notes
None

---