### PR TITLE
docs: update templates directory structure in readme

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ## [Unreleased]
 
 ### Changed
+- **[2026-05-26]**: docs: update templates directory structure in readme
+
+### Changed
 - **[2026-05-26]**: docs: sync readme structure with current repository state
 
 ### Changed
@@ -390,6 +393,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ---
 
 *Last Updated: 2026-05-26*
+
 
 
 

--- a/README.md
+++ b/README.md
@@ -121,18 +121,18 @@ C:\git\ (workspace root - this repo)
 ├── templates/               # Versioned template variants (tagged as template-vX.Y.Z)
 │   ├── VERSION              # Current template semver (0.5.0)
 │   ├── CHANGELOG.md         # Template-level change history
-│   ├── common/              # Shared skills across all variants
+│   ├── common/              # Shared base files across all variants
+│   │   ├── .githooks/       # Standard git hooks
+│   │   ├── .github/         # CODEOWNERS, workflows, pull_request_template.md
+│   │   ├── scripts/         # Setup, sync, and audit scripts (bash + PowerShell)
 │   │   └── skills/          # agent-lifecycle-manager, skill-lifecycle-manager, meeting-facilitation
 │   ├── co-develop/          # ✅ Stable — full software development agent team
 │   │   ├── variant.json     # Variant metadata (name, status, version)
 │   │   ├── agents/          # pm.md, architect.md, designer.md, code-writer.md, test-runner.md, security-monitor.md
-│   │   ├── docs/            # context.md (10-section template), security.md
-│   │   ├── scripts/         # dev-sync.sh/.ps1, sync-md.sh/.ps1, audit.sh/.ps1
+│   │   ├── docs/            # context.md (10-section template)
 │   │   ├── .claude/         # settings.json, commands/ (changelog, sync, memlog, etc.)
 │   │   │   └── skills/      # code-review, test-driven-development, refactoring
-│   │   ├── .gemini/         # settings.json, commands/
-│   │   ├── .githooks/       # pre-commit, pre-push
-│   │   └── .github/         # CODEOWNERS, workflows, dependabot
+│   │   └── .gemini/         # settings.json, commands/
 │   ├── co-design/           # ✅ Stable — UI/UX design workflow
 │   │   ├── agents/          # pm.md, design-lead.md, ux-researcher.md, visual-designer.md, prototype-engineer.md, storyteller.md, service-designer.md, typography-expert.md
 │   │   └── .claude/skills/  # ui-ux-design-intelligence, service-design

--- a/README_ko.md
+++ b/README_ko.md
@@ -119,18 +119,18 @@ C:\git\ (워크스페이스 루트 - 현재 저장소)
 ├── templates/               # 버전 관리되는 template variant (template-vX.Y.Z 태그로 관리)
 │   ├── VERSION              # 현재 template semver (0.5.0)
 │   ├── CHANGELOG.md         # Template 레벨 변경 이력
-│   ├── common/              # 모든 variant에서 공유하는 스킬
+│   ├── common/              # 모든 variant에서 공유하는 공통 파일
+│   │   ├── .githooks/       # 표준 Git 훅
+│   │   ├── .github/         # CODEOWNERS, workflows, pull_request_template.md
+│   │   ├── scripts/         # 설정, 동기화 및 문서 감사 스크립트 (bash + PowerShell)
 │   │   └── skills/          # agent-lifecycle-manager, skill-lifecycle-manager, meeting-facilitation
 │   ├── co-develop/          # ✅ Stable — 소프트웨어 개발 전용 에이전트 팀
 │   │   ├── variant.json     # Variant 메타데이터 (name, status, version)
 │   │   ├── agents/          # pm.md, architect.md, designer.md, code-writer.md, test-runner.md, security-monitor.md
-│   │   ├── docs/            # context.md (10섹션 템플릿), security.md
-│   │   ├── scripts/         # dev-sync.sh/.ps1, sync-md.sh/.ps1, audit.sh/.ps1
+│   │   ├── docs/            # context.md (10섹션 템플릿)
 │   │   ├── .claude/         # settings.json, commands/ (changelog, sync, memlog 등)
 │   │   │   └── skills/      # code-review, test-driven-development, refactoring
-│   │   ├── .gemini/         # settings.json, commands/
-│   │   ├── .githooks/       # pre-commit, pre-push
-│   │   └── .github/         # CODEOWNERS, workflows, dependabot
+│   │   └── .gemini/         # settings.json, commands/
 │   ├── co-design/           # ✅ Stable — UI/UX 디자인 워크플로
 │   │   ├── agents/          # pm.md, design-lead.md, ux-researcher.md, visual-designer.md, prototype-engineer.md, storyteller.md, service-designer.md, typography-expert.md
 │   │   └── .claude/skills/  # ui-ux-design-intelligence, service-design

--- a/memory/2026-05-26.md
+++ b/memory/2026-05-26.md
@@ -137,3 +137,11 @@
 - **Purpose**: 
 - **Decisions**: 
 - **Issues**: None
+
+---
+
+## docs: update templates directory structure in readme
+- **Files**: README.md, README_ko.md
+- **Purpose**: 
+- **Decisions**: 
+- **Issues**: None


### PR DESCRIPTION
## Why
docs: update templates directory structure in readme

## What Changed
- CHANGELOG.md
- README.md
- README_ko.md
- memory/2026-05-26.md

## Test Plan
- [ ] `bash scripts/audit.sh` passes
- [ ] CHANGELOG.md updated under `[Unreleased]`

## Security Checklist
- [ ] No secrets, credentials, or API keys committed
- [ ] No `.env` files staged (use `.env.sample` for templates)
- [ ] Dependencies unchanged or reviewed for new CVEs

## Notes
None

---