### PR TITLE
feat: restructure context.md into immutable common + variant-specific files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,14 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ## [Unreleased]
 
 ### Added
+- **[2026-05-27]**: `templates/common/docs/context.md` — new immutable common context file (project identity, architecture, key files, documentation standards) (#TBD)
+- **[2026-05-27]**: `templates/co-develop/docs/co-develop.context.md` — new variant config file (tech stack, agents, skills, scripts, workflow) with lifecycle status columns (#TBD)
+- **[2026-05-27]**: `templates/co-design/docs/co-design.context.md` — new variant config file for design projects (#TBD)
+- **[2026-05-27]**: `templates/co-work/docs/co-work.context.md` — new variant config file for collaboration projects (#TBD)
+- **[2026-05-27]**: All variant CLAUDE.md and GEMINI.md — `## Session Start — Context Loading Order` section added (context.md → variant.context.md → AGENTS.md read order) (#TBD)
+- **[2026-05-27]**: `scripts/new-project.sh` / `.ps1` — template provenance written to variant.context.md; `docs/context.md merge=ours` added to `.gitattributes` on project creation (#TBD)
+
+### Changed
 - **[2026-05-27]**: `.github/pull_request_template.md` redesigned with Summary/Changes table/Test Plan/Security Checklist sections — applied to workspace and all template variants (#93)
 - **[2026-05-27]**: `CONSTITUTION.md §2`: Memory session log mandatory four-section format (Session Summary, Changes, Decisions, Open Issues) with cross-tool consistency note (#93)
 - **[2026-05-27]**: `CONSTITUTION.md §2.1`: CHANGELOG entry `(#PR-number)` reference requirement (#93)

--- a/scripts/new-project.ps1
+++ b/scripts/new-project.ps1
@@ -157,15 +157,27 @@ Get-ChildItem -Path $ProjectDir -Recurse -File |
     }
   }
 
-# ── 4.5. Record template provenance in docs/context.md ────────────────────────
+# ── 4.5. Record template provenance in variant context file ───────────────────
 $TemplateVersion = if ($Version -ne "") { $Version } elseif (Test-Path $VersionFile) { (Get-Content $VersionFile -Raw).Trim() } else { "unknown" }
-$ContextMd = Join-Path $ProjectDir "docs\context.md"
-if (Test-Path $ContextMd) {
-    $contextContent = Get-Content $ContextMd -Raw -Encoding UTF8
-    if ($contextContent -notmatch "Template-Version:") {
+$VariantContextMd = Join-Path $ProjectDir "docs\$Variant.context.md"
+if (Test-Path $VariantContextMd) {
+    $variantContextContent = Get-Content $VariantContextMd -Raw -Encoding UTF8
+    if ($variantContextContent -notmatch "Template-Version:") {
         $provenance = "`n## Template Provenance`n`n- **Template-Version**: $TemplateVersion`n- **Template-Variant**: $Variant`n"
-        Add-Content $ContextMd $provenance -Encoding UTF8
+        Add-Content $VariantContextMd $provenance -Encoding UTF8
     }
+}
+
+# ── 4.6. Protect context.md from accidental overwrites (merge=ours) ───────────
+$GitAttributesPath = Join-Path $ProjectDir ".gitattributes"
+$mergeOursLine = "docs/context.md merge=ours"
+if (Test-Path $GitAttributesPath) {
+    $gitAttrContent = Get-Content $GitAttributesPath -Raw -Encoding UTF8
+    if ($gitAttrContent -notmatch "docs/context\.md") {
+        Add-Content $GitAttributesPath "`n$mergeOursLine" -Encoding UTF8
+    }
+} else {
+    Set-Content $GitAttributesPath $mergeOursLine -Encoding UTF8
 }
 
 # ── 4.6. Inject AGENTS.md Skills into docs/context.md ────────────────────────

--- a/scripts/new-project.sh
+++ b/scripts/new-project.sh
@@ -145,15 +145,25 @@ done < <(find "$PROJECT_DIR" -type f \
      -o -name "*.toml" -o -name "*.yaml" -o -name "*.yml" -o -name "*.sample" \) \
   -print0)
 
-# ── 4.5. Record template provenance in docs/context.md ────────────────────────
+# ── 4.5. Record template provenance in variant context file ───────────────────
 TEMPLATE_VERSION="${TEMPLATE_VER:-$(cat "$VERSION_FILE" 2>/dev/null | tr -d '[:space:]' || echo 'unknown')}"
-CONTEXT_MD="$PROJECT_DIR/docs/context.md"
-if [ -f "$CONTEXT_MD" ]; then
+VARIANT_CONTEXT_MD="$PROJECT_DIR/docs/$VARIANT.context.md"
+if [ -f "$VARIANT_CONTEXT_MD" ]; then
   # Add template provenance if not already present
-  if ! grep -q "Template-Version:" "$CONTEXT_MD"; then
+  if ! grep -q "Template-Version:" "$VARIANT_CONTEXT_MD"; then
     printf '\n## Template Provenance\n\n- **Template-Version**: %s\n- **Template-Variant**: %s\n' \
-      "$TEMPLATE_VERSION" "$VARIANT" >> "$CONTEXT_MD"
+      "$TEMPLATE_VERSION" "$VARIANT" >> "$VARIANT_CONTEXT_MD"
   fi
+fi
+
+# ── 4.6. Protect context.md from accidental overwrites (merge=ours) ───────────
+GITATTRIBUTES="$PROJECT_DIR/.gitattributes"
+if [ -f "$GITATTRIBUTES" ]; then
+  if ! grep -q "docs/context.md" "$GITATTRIBUTES"; then
+    echo "docs/context.md merge=ours" >> "$GITATTRIBUTES"
+  fi
+else
+  echo "docs/context.md merge=ours" > "$GITATTRIBUTES"
 fi
 
 # ── 5. Make scripts and hooks executable ───────────────────────────────────────

--- a/templates/co-design/CLAUDE.md
+++ b/templates/co-design/CLAUDE.md
@@ -1,11 +1,18 @@
 # CLAUDE.md
 
-> **All project context, coding guidelines, and dev workflow → [`docs/context.md`](docs/context.md)**
+> **Doc intent:** This file is Claude Code-specific behavioral configuration for **individual projects** (not the workspace root).
 > Workspace-level Claude Code behaviors → [`https://raw.githubusercontent.com/5throck/ai-workspace-standards/main/CLAUDE.md`](https://raw.githubusercontent.com/5throck/ai-workspace-standards/main/CLAUDE.md)
 
-> **Doc intent:** This file is Claude Code-specific behavioral configuration for **individual projects** (not the workspace root).
-> Shared project context (architecture, tech stack, coding guidelines) lives in [`docs/context.md`](docs/context.md).
-> Agent roles live in [`agents/*.md`](agents/) and [`AGENTS.md`](AGENTS.md).
+## Session Start — Context Loading Order
+
+At the start of every session, read these files **in order**:
+
+1. **[`docs/context.md`](docs/context.md)** — Immutable project identity (architecture, key files, documentation standards). Do NOT modify.
+2. **[`docs/co-design.context.md`](docs/co-design.context.md)** — Design stack, agents, skills, scripts, workflow. All project-specific changes go here.
+3. **[`AGENTS.md`](AGENTS.md)** — Canonical agent index and dispatch protocols.
+
+> The two-file split is intentional: `context.md` never changes after project creation;
+> `co-design.context.md` evolves with the project (agents, skills, design stack, workflow).
 
 ---
 

--- a/templates/co-design/GEMINI.md
+++ b/templates/co-design/GEMINI.md
@@ -1,11 +1,18 @@
 # GEMINI.md
 
-> **All project context, coding guidelines, and dev workflow → [`docs/context.md`](docs/context.md)**
+> **Doc intent:** This file contains Gemini CLI / Antigravity-specific overrides only.
 > Workspace-level Gemini behaviors → [`https://raw.githubusercontent.com/5throck/ai-workspace-standards/main/GEMINI.md`](https://raw.githubusercontent.com/5throck/ai-workspace-standards/main/GEMINI.md)
 
-> **Doc intent:** This file contains Gemini CLI-specific overrides only.
-> Shared project context (architecture, tech stack, coding guidelines) lives in [`docs/context.md`](docs/context.md).
-> Agent roles live in [`agents/*.md`](agents/) and [`AGENTS.md`](AGENTS.md).
+## Session Start — Context Loading Order
+
+At the start of every session, read these files **in order**:
+
+1. **[`docs/context.md`](docs/context.md)** — Immutable project identity (architecture, key files, documentation standards). Do NOT modify.
+2. **[`docs/co-design.context.md`](docs/co-design.context.md)** — Design stack, agents, skills, scripts, workflow. All project-specific changes go here.
+3. **[`AGENTS.md`](AGENTS.md)** — Canonical agent index and dispatch protocols.
+
+> The two-file split is intentional: `context.md` never changes after project creation;
+> `co-design.context.md` evolves with the project (agents, skills, design stack, workflow).
 
 ## Project-Specific Gemini Settings
 

--- a/templates/co-design/docs/co-design.context.md
+++ b/templates/co-design/docs/co-design.context.md
@@ -1,0 +1,148 @@
+# [Project Name] — co-design Configuration
+
+> Extends docs/context.md. This file IS the customization layer for this project.
+> context.md is IMMUTABLE — all project-specific changes belong here.
+>
+> Read order for all AI tools:
+>   1. docs/context.md             — immutable project identity (architecture, standards)
+>   2. docs/co-design.context.md   — THIS FILE — design stack, agents, skills, workflow
+
+---
+
+## Design Stack
+
+| Layer | Technology / Standard |
+|-------|----------------------|
+| **Design Tokens** | [e.g., Figma Variables / CSS Custom Properties] |
+| **Component Library** | [e.g., Custom / shadcn/ui / Material Design] |
+| **Prototyping Tool** | [e.g., Figma / Framer / Principle] |
+| **Handoff Format** | [e.g., Figma Dev Mode / Zeplin / Storybook] |
+| **Research Tools** | [e.g., Maze, UserTesting, Hotjar] |
+
+---
+
+## Agents
+
+<!-- Add/remove rows as agents are introduced or retired via lifecycle management. -->
+<!-- Status: active | deprecated | experimental -->
+
+| Agent | File | Role | Status |
+|-------|------|------|--------|
+| Design PM (Orchestrator) | `agents/pm.md` | Design workflow management, dispatch, quality gates | active |
+| UX Researcher | `agents/ux-researcher.md` | User research and insights | active |
+| Design Lead | `agents/design-lead.md` | Design direction and system architecture | active |
+| Visual Designer | `agents/visual-designer.md` | Visual designs and specifications | active |
+| Prototype Engineer | `agents/prototype-engineer.md` | Interactive prototypes and handoff | active |
+| Storyteller | `agents/storyteller.md` | Narrative and user journey definition | active |
+| Typography Expert | `agents/typography-expert.md` | Type hierarchy and font systems | active |
+| Service Designer | `agents/service-designer.md` | End-to-end service experience design | active |
+
+> Lifecycle management: `bun scripts/agent-lifecycle-audit.ts`
+> After any agent change, update AGENTS.md and this table.
+
+---
+
+## Skills
+
+<!-- Add/remove rows as skills are introduced or retired via lifecycle management. -->
+<!-- Status: active | deprecated | experimental -->
+
+| Skill | Directory | Trigger | Status |
+|-------|-----------|---------|--------|
+| UI/UX Design Intelligence | `.claude/skills/ui-ux-design-intelligence/` | Building design systems, visual designs, UI components | active |
+| Service Design | `.claude/skills/service-design/` | Designing end-to-end service experiences | active |
+| Agent Lifecycle Manager | `skills/agent-lifecycle-manager/` | Managing agent lifecycle | active |
+| Skill Lifecycle Manager | `skills/skill-lifecycle-manager/` | Managing skill lifecycle | active |
+| Meeting Facilitation | `skills/meeting-facilitation/` | Multi-agent meetings | active |
+
+> Lifecycle management: `bun scripts/skill-lifecycle-audit.ts`
+
+---
+
+## Scripts
+
+<!-- Source Layer: L0 = templates/common (SSOT) | L1 = workspace root | L2 = project-local -->
+<!-- Status: active | deprecated | experimental -->
+
+| Script | Source Layer | Status |
+|--------|-------------|--------|
+| `scripts/audit.sh` / `.ps1` | L0 | active |
+| `scripts/dev-sync.sh` / `.ps1` | L0 | active |
+| `scripts/sync-md.sh` / `.ps1` | L0 | active |
+
+> See SCRIPTS.md in templates/common/scripts/ for full lifecycle registry.
+
+---
+
+## Development Workflow
+
+```
+Design brief received
+  ↓
+/sync "feat: description"
+  ↓
+  1. audit.sh — abort on failure
+  2. memory/YYYY-MM-DD.md — session log (4-section format)
+  3. MEMORY.md index update
+  4. git add -A → commit
+  5. pr/<date>-<slug> branch created (if on main)
+  6. git push + gh pr create
+```
+
+### Agent Dispatch Order (co-design standard)
+
+```
+Design PM
+  → UX Researcher + Design Lead (parallel — research + strategy)
+  → Visual Designer → Prototype Engineer (sequential — design + prototype)
+  → UX Researcher (validation loop — continuous)
+  → Design Lead + Visual Designer (system refinement + handoff)
+```
+
+### Workflow Phases
+
+| Phase | Name | What Happens | Lead Agent(s) |
+|-------|------|--------------|---------------|
+| 0 | Team Assembly | PM creates specialized design agents/skills | Design PM |
+| 1 | Narrative & Ecosystem Mapping | Core user story, service touchpoints, problem space | Storyteller, UX Researcher |
+| 2 | Foundational Exploration | Typographic hierarchy, visual mood boards, layout frameworks | Typography Expert, Visual Designer |
+| 3 | Rapid Prototyping Loops | Continuous build/test low-fi → high-fi prototypes | Prototype Engineer, Design Lead |
+| 4 | Continuous Validation | Parallel user testing and a11y validation | UX Researcher, Design Lead |
+| 5 | System Refinement & Handoff | Polish, finalize design system, dev handoff | Visual Designer, Prototype Engineer |
+
+> Phases 3 and 4 operate as a continuous loop rather than sequential steps.
+
+---
+
+## Design Guidelines
+
+### Core Principles
+
+| Principle | Description |
+|-----------|-------------|
+| **User-Centered** | All design decisions start from user needs; validated through research |
+| **Accessible by Default** | WCAG AA compliance is a baseline, not an add-on |
+| **System-Thinking** | Every design decision considers the broader design system |
+| **Iterative Validation** | Designs validated through prototypes and user feedback |
+
+### Rules
+
+1. Start every design task with research or existing insights — document user needs before designing.
+2. Every design decision must consider the broader design system — reuse before creating new.
+3. WCAG AA is the minimum accessibility bar — aim higher when feasible.
+4. Create prototypes to validate decisions before finalizing.
+5. Explain design rationale and constraints explicitly, not just visual choices.
+6. All PR titles, bodies, and review comments must be in **English**.
+
+---
+
+## Domain Rules
+
+<!-- co-design variant specific rules — edit after project creation -->
+1. Design tokens must be documented before implementation.
+2. All new components require design system review from Design Lead.
+3. User testing findings must be logged to memory/ before design decisions are finalized.
+
+---
+
+*co-design.context.md version: 1.0 — created by /new-project*

--- a/templates/co-develop/CLAUDE.md
+++ b/templates/co-develop/CLAUDE.md
@@ -1,11 +1,18 @@
 # CLAUDE.md
 
-> **All project context, coding guidelines, and dev workflow → [`docs/context.md`](docs/context.md)**
+> **Doc intent:** This file is Claude Code-specific behavioral configuration for **individual projects** (not the workspace root).
 > Workspace-level Claude Code behaviors → [`https://raw.githubusercontent.com/5throck/ai-workspace-standards/main/CLAUDE.md`](https://raw.githubusercontent.com/5throck/ai-workspace-standards/main/CLAUDE.md)
 
-> **Doc intent:** This file is Claude Code-specific behavioral configuration for **individual projects** (not the workspace root).
-> Shared project context (architecture, tech stack, coding guidelines) lives in [`docs/context.md`](docs/context.md).
-> Agent roles live in [`agents/*.md`](agents/) and [`AGENTS.md`](AGENTS.md).
+## Session Start — Context Loading Order
+
+At the start of every session, read these files **in order**:
+
+1. **[`docs/context.md`](docs/context.md)** — Immutable project identity (architecture, key files, documentation standards). Do NOT modify.
+2. **[`docs/co-develop.context.md`](docs/co-develop.context.md)** — Tech stack, agents, skills, scripts, workflow. All project-specific changes go here.
+3. **[`AGENTS.md`](AGENTS.md)** — Canonical agent index and dispatch protocols.
+
+> The two-file split is intentional: `context.md` never changes after project creation;
+> `co-develop.context.md` evolves with the project (agents, skills, tech stack, workflow).
 
 ---
 

--- a/templates/co-develop/GEMINI.md
+++ b/templates/co-develop/GEMINI.md
@@ -1,11 +1,18 @@
 # GEMINI.md
 
-> **All project context, coding guidelines, and dev workflow → [`docs/context.md`](docs/context.md)**
+> **Doc intent:** This file contains Gemini CLI / Antigravity-specific overrides only.
 > Workspace-level Gemini behaviors → [`https://raw.githubusercontent.com/5throck/ai-workspace-standards/main/GEMINI.md`](https://raw.githubusercontent.com/5throck/ai-workspace-standards/main/GEMINI.md)
 
-> **Doc intent:** This file contains Gemini CLI-specific overrides only.
-> Shared project context (architecture, tech stack, coding guidelines) lives in [`docs/context.md`](docs/context.md).
-> Agent roles live in [`agents/*.md`](agents/) and [`AGENTS.md`](AGENTS.md).
+## Session Start — Context Loading Order
+
+At the start of every session, read these files **in order**:
+
+1. **[`docs/context.md`](docs/context.md)** — Immutable project identity (architecture, key files, documentation standards). Do NOT modify.
+2. **[`docs/co-develop.context.md`](docs/co-develop.context.md)** — Tech stack, agents, skills, scripts, workflow. All project-specific changes go here.
+3. **[`AGENTS.md`](AGENTS.md)** — Canonical agent index and dispatch protocols.
+
+> The two-file split is intentional: `context.md` never changes after project creation;
+> `co-develop.context.md` evolves with the project (agents, skills, tech stack, workflow).
 
 ## Project-Specific Gemini Settings
 

--- a/templates/co-develop/docs/co-develop.context.md
+++ b/templates/co-develop/docs/co-develop.context.md
@@ -1,0 +1,183 @@
+# [Project Name] — co-develop Configuration
+
+> Extends docs/context.md. This file IS the customization layer for this project.
+> context.md is IMMUTABLE — all project-specific changes belong here.
+>
+> Read order for all AI tools:
+>   1. docs/context.md              — immutable project identity (architecture, standards)
+>   2. docs/co-develop.context.md   — THIS FILE — tech stack, agents, skills, workflow
+
+---
+
+## Tech Stack
+
+| Layer | Technology |
+|-------|-----------|
+| **Language** | [e.g., TypeScript 5+ / Python 3.11+] |
+| **Framework** | [e.g., Next.js / FastAPI / none] |
+| **Database** | [e.g., PostgreSQL + Prisma / SQLite / none] |
+| **Key Libraries** | [e.g., react-query, zod, httpx] |
+| **Package Manager** | [e.g., pnpm / npm / uv] |
+| **Testing** | [e.g., Vitest + Playwright / pytest] |
+
+---
+
+## Agents
+
+<!-- Add/remove rows as agents are introduced or retired via lifecycle management. -->
+<!-- Status: active | deprecated | experimental -->
+
+| Agent | File | Role | Status |
+|-------|------|------|--------|
+| PM (Orchestrator) | `agents/pm.md` | Workflow management, dispatch, quality gates | active |
+| Architect | `agents/architect.md` | System design, ADR production | active |
+| Code Writer | `agents/code-writer.md` | Implementation per approved plan | active |
+| Test Runner | `agents/test-runner.md` | Test authoring and execution | active |
+| Security Monitor | `agents/security-monitor.md` | Security review, hook enforcement | active |
+| Designer | `agents/designer.md` | UI/UX specs and component definitions | active |
+
+> Lifecycle management: `bun scripts/agent-lifecycle-audit.ts`
+> After any agent change, update AGENTS.md and this table.
+
+---
+
+## Skills
+
+<!-- Add/remove rows as skills are introduced or retired via lifecycle management. -->
+<!-- Status: active | deprecated | experimental -->
+
+| Skill | Directory | Trigger | Status |
+|-------|-----------|---------|--------|
+| Agent Lifecycle Manager | `skills/agent-lifecycle-manager/` | Managing agent lifecycle | active |
+| Skill Lifecycle Manager | `skills/skill-lifecycle-manager/` | Managing skill lifecycle | active |
+| Meeting Facilitation | `skills/meeting-facilitation/` | Multi-agent meetings | active |
+| Code Review | `.claude/skills/code-review/` | Before PR creation | active |
+| TDD | `.claude/skills/test-driven-development/` | Any implementation task | active |
+| Refactoring | `.claude/skills/refactoring/` | Code improvement tasks | active |
+
+> Lifecycle management: `bun scripts/skill-lifecycle-audit.ts`
+
+---
+
+## Scripts
+
+<!-- Source Layer: L0 = templates/common (SSOT) | L1 = workspace root | L2 = project-local -->
+<!-- Status: active | deprecated | experimental -->
+
+| Script | Source Layer | Status |
+|--------|-------------|--------|
+| `scripts/audit.sh` / `.ps1` | L0 | active |
+| `scripts/dev-sync.sh` / `.ps1` | L0 | active |
+| `scripts/sync-md.sh` / `.ps1` | L0 | active |
+
+> See SCRIPTS.md in templates/common/scripts/ for full lifecycle registry.
+
+---
+
+## Environment Setup
+
+- Copy `.env.sample` → `.env` and fill in all required values.
+- **Node.js**: `pnpm install` (or `npm install`)
+- **Python**: `python -m venv .venv && source .venv/bin/activate && pip install -r requirements.txt`
+- Required env keys (see `.env.sample`): *(fill in after project creation)*
+
+---
+
+## Development Workflow
+
+```
+Edit code
+  ↓
+/sync "feat: description"
+  ↓
+  1. audit.sh — abort on failure
+  2. memory/YYYY-MM-DD.md — session log (4-section format)
+  3. MEMORY.md index update
+  4. git add -A → commit
+  5. pr/<date>-<slug> branch created (if on main)
+  6. git push + gh pr create
+```
+
+### Agent Dispatch Order (co-develop standard)
+
+```
+PM → Architect (design + ADR)
+   → Code Writer (implementation)
+   → Test Runner (QA gate)
+   → Security Monitor (review)
+```
+
+### Workflow Phases
+
+| Phase | Name | What Happens |
+|-------|------|--------------|
+| 0 | Team Assembly | PM creates specialized agents/skills if required |
+| 1 | Triage | PM classifies request; dispatches read-only agents in parallel |
+| 2 | Analysis | PM synthesizes findings into requirements + acceptance criteria |
+| 3 | Design | Architect produces implementation plan + ADR |
+| 4 | Implementation | Code Writer → Test Runner → loop up to 3× on failures |
+| 5 | Finalization | PM logs decisions; runs `/sync`; opens PR |
+
+---
+
+## Coding Guidelines
+
+### Core Rules
+
+1. **Think before coding** — state assumptions; if uncertain, ask.
+2. **Simplicity first** — minimum code that solves the problem.
+3. **Surgical changes** — touch only what is necessary.
+4. **No hardcoded secrets** — always use env vars / `.env.sample`.
+5. **PR required** — all changes via `/sync`; never direct push to main.
+
+### Plan Mode
+
+Enter plan mode when: new feature, significant refactor, or change touches more than 2 files.
+
+### Subagent Pattern
+
+Each implementation task follows the Phase 4 execution loop:
+1. **code-writer** implements
+2. **test-runner** verifies acceptance criteria
+3. **audit script** validates compliance
+Maximum 3 iterations before escalating to user.
+
+### Hybrid Scripting
+
+- Complex orchestration → **Bun TypeScript** (`.ts`)
+- Everyday utilities → **cross-platform shell** (`.sh` + `.ps1` pair, always kept in sync)
+
+### Package Policy
+
+Prefer OSI-approved licenses: MIT, Apache-2.0, BSD-2-Clause, BSD-3-Clause, ISC.
+Avoid: GPL-3.0, AGPL-3.0, SSPL, BSL unless explicitly justified.
+
+---
+
+## Git / PR Workflow
+
+```
+/sync "feat: description"
+  →  1. memory log (memlog)
+  →  2. MEMORY.md index update (sync-md)
+  →  3. CHANGELOG.md [Unreleased] auto-add
+  →  4. audit.sh  (must exit 0)
+  →  5. git checkout -b pr/<date>-<slug>
+  →  6. git commit + push
+  →  7. gh pr create
+```
+
+> All PR titles, bodies, and review comments must be in **English**.
+
+---
+
+## Domain Rules
+
+<!-- co-develop variant specific rules — edit after project creation -->
+1. All implementation must have a corresponding test.
+2. Architecture changes require Architect agent ADR before implementation.
+3. Security Monitor must review before any PR targeting auth, secrets, or infra.
+
+---
+
+*co-develop.context.md version: 1.0 — created by /new-project*

--- a/templates/co-work/CLAUDE.md
+++ b/templates/co-work/CLAUDE.md
@@ -1,11 +1,18 @@
 # CLAUDE.md
 
-> **All project context, coding guidelines, and dev workflow → [`docs/context.md`](docs/context.md)**
+> **Doc intent:** This file is Claude Code-specific behavioral configuration for **individual projects** (not the workspace root).
 > Workspace-level Claude Code behaviors → [`https://raw.githubusercontent.com/5throck/ai-workspace-standards/main/CLAUDE.md`](https://raw.githubusercontent.com/5throck/ai-workspace-standards/main/CLAUDE.md)
 
-> **Doc intent:** This file is Claude Code-specific behavioral configuration for **individual projects** (not the workspace root).
-> Shared project context (architecture, tech stack, coding guidelines) lives in [`docs/context.md`](docs/context.md).
-> Agent roles live in [`agents/*.md`](agents/) and [`AGENTS.md`](AGENTS.md).
+## Session Start — Context Loading Order
+
+At the start of every session, read these files **in order**:
+
+1. **[`docs/context.md`](docs/context.md)** — Immutable project identity (architecture, key files, documentation standards). Do NOT modify.
+2. **[`docs/co-work.context.md`](docs/co-work.context.md)** — Tool stack, agents, skills, scripts, workflow. All project-specific changes go here.
+3. **[`AGENTS.md`](AGENTS.md)** — Canonical agent index and dispatch protocols.
+
+> The two-file split is intentional: `context.md` never changes after project creation;
+> `co-work.context.md` evolves with the project (agents, skills, tool stack, workflow).
 
 ---
 

--- a/templates/co-work/GEMINI.md
+++ b/templates/co-work/GEMINI.md
@@ -1,11 +1,18 @@
 # GEMINI.md
 
-> **All project context, coding guidelines, and dev workflow → [`docs/context.md`](docs/context.md)**
+> **Doc intent:** This file contains Gemini CLI / Antigravity-specific overrides only.
 > Workspace-level Gemini behaviors → [`https://raw.githubusercontent.com/5throck/ai-workspace-standards/main/GEMINI.md`](https://raw.githubusercontent.com/5throck/ai-workspace-standards/main/GEMINI.md)
 
-> **Doc intent:** This file contains Gemini CLI-specific overrides only.
-> Shared project context (architecture, tech stack, coding guidelines) lives in [`docs/context.md`](docs/context.md).
-> Agent roles live in [`agents/*.md`](agents/) and [`AGENTS.md`](AGENTS.md).
+## Session Start — Context Loading Order
+
+At the start of every session, read these files **in order**:
+
+1. **[`docs/context.md`](docs/context.md)** — Immutable project identity (architecture, key files, documentation standards). Do NOT modify.
+2. **[`docs/co-work.context.md`](docs/co-work.context.md)** — Tool stack, agents, skills, scripts, workflow. All project-specific changes go here.
+3. **[`AGENTS.md`](AGENTS.md)** — Canonical agent index and dispatch protocols.
+
+> The two-file split is intentional: `context.md` never changes after project creation;
+> `co-work.context.md` evolves with the project (agents, skills, tool stack, workflow).
 
 ## Project-Specific Gemini Settings
 

--- a/templates/co-work/docs/co-work.context.md
+++ b/templates/co-work/docs/co-work.context.md
@@ -1,0 +1,148 @@
+# [Project Name] — co-work Configuration
+
+> Extends docs/context.md. This file IS the customization layer for this project.
+> context.md is IMMUTABLE — all project-specific changes belong here.
+>
+> Read order for all AI tools:
+>   1. docs/context.md            — immutable project identity (architecture, standards)
+>   2. docs/co-work.context.md    — THIS FILE — tool stack, agents, skills, workflow
+
+---
+
+## Tool Stack
+
+| Purpose | Tool |
+|---------|-------|
+| **Research** | [e.g., Perplexity, Google Scholar, Zotero] |
+| **Documentation** | [e.g., Notion, Google Docs, Markdown] |
+| **Coordination** | [e.g., Calendly, Slack, MS Teams] |
+| **Productivity Suite** | [e.g., MS365, Google Workspace] |
+| **Version Control** | Git + LFS for large assets |
+
+---
+
+## Agents
+
+<!-- Add/remove rows as agents are introduced or retired via lifecycle management. -->
+<!-- Status: active | deprecated | experimental -->
+
+| Agent | File | Role | Status |
+|-------|------|------|--------|
+| Collaboration PM (Orchestrator) | `agents/pm.md` | Collaboration workflow management, dispatch | active |
+| Analyst | `agents/analyst.md` | Research and data analysis | active |
+| Content Writer | `agents/content-writer.md` | Documentation and communication | active |
+| Project Coordinator | `agents/project-coordinator.md` | Schedule and stakeholder management | active |
+| Storyteller | `agents/storyteller.md` | Narrative framework and audience alignment | active |
+| Technical Writer | `agents/technical-writer.md` | Technical documentation and specifications | active |
+| MS365 Expert | `agents/ms365-expert.md` | MS365 / SharePoint automation and publishing | active |
+
+> Lifecycle management: `bun scripts/agent-lifecycle-audit.ts`
+> After any agent change, update AGENTS.md and this table.
+
+---
+
+## Skills
+
+<!-- Add/remove rows as skills are introduced or retired via lifecycle management. -->
+<!-- Status: active | deprecated | experimental -->
+
+| Skill | Directory | Trigger | Status |
+|-------|-----------|---------|--------|
+| Research Analysis | `.claude/skills/research-analysis/` | Analyzing topics, synthesizing research | active |
+| Documentation Writing | `.claude/skills/documentation-writing/` | Creating guides, drafting communications | active |
+| API Documentation | `.claude/skills/api-documentation/` | Documenting APIs and developer-facing specs | active |
+| Agent Lifecycle Manager | `skills/agent-lifecycle-manager/` | Managing agent lifecycle | active |
+| Skill Lifecycle Manager | `skills/skill-lifecycle-manager/` | Managing skill lifecycle | active |
+| Meeting Facilitation | `skills/meeting-facilitation/` | Multi-agent meetings | active |
+
+> Lifecycle management: `bun scripts/skill-lifecycle-audit.ts`
+
+---
+
+## Scripts
+
+<!-- Source Layer: L0 = templates/common (SSOT) | L1 = workspace root | L2 = project-local -->
+<!-- Status: active | deprecated | experimental -->
+
+| Script | Source Layer | Status |
+|--------|-------------|--------|
+| `scripts/audit.sh` / `.ps1` | L0 | active |
+| `scripts/dev-sync.sh` / `.ps1` | L0 | active |
+| `scripts/sync-md.sh` / `.ps1` | L0 | active |
+
+> See SCRIPTS.md in templates/common/scripts/ for full lifecycle registry.
+
+---
+
+## Development Workflow
+
+```
+Brief / task received
+  ↓
+/sync "feat: description"
+  ↓
+  1. audit.sh — abort on failure
+  2. memory/YYYY-MM-DD.md — session log (4-section format)
+  3. MEMORY.md index update
+  4. git add -A → commit
+  5. pr/<date>-<slug> branch created (if on main)
+  6. git push + gh pr create
+```
+
+### Agent Dispatch Order (co-work standard)
+
+```
+Collaboration PM
+  → Analyst (research — async)
+  → Storyteller (narrative framework)
+  → Content Writer + Technical Writer (parallel drafting)
+  → Project Coordinator (stakeholder review loop)
+  → Content Writer + Storyteller (polish)
+  → MS365 Expert (publication)
+```
+
+### Workflow Phases
+
+| Phase | Name | What Happens | Primary Owner |
+|-------|------|--------------|---------------|
+| 0 | Team Assembly | PM forms collaboration team and establishes objectives | PM |
+| 1 | Async Research & Discovery | Independent data gathering and fact-checking | Analyst |
+| 2 | Narrative Framework & Alignment | Draft core storyline; obtain stakeholder alignment | Storyteller |
+| 3 | Collaborative Drafting | Parallel creation of prose and technical docs | Content Writer, Technical Writer |
+| 4 | Iterative Stakeholder Review | Continuous feedback loops with SMEs | Project Coordinator |
+| 5 | Stylistic Polish & Finalization | Final formatting, brand voice refinement | Content Writer, Storyteller |
+| 6 | Automated Publication | Push artifacts to channels, archive, notify stakeholders | MS365 Expert |
+
+---
+
+## Collaboration Guidelines
+
+### Core Principles
+
+| Principle | Description |
+|-----------|-------------|
+| **Research-Driven** | All decisions start from evidence, validated through analysis |
+| **Clear Communication** | Complex information synthesized for diverse audiences |
+| **Stakeholder Alignment** | Inclusive communication and structured review processes |
+| **Knowledge Management** | Organized archives and consistent documentation standards |
+
+### Rules
+
+1. Start every task with research or existing data — document sources before drafting.
+2. All content must be reviewed by at least one stakeholder before publication.
+3. Archive source materials alongside final artifacts.
+4. Use templates and consistent formatting for all deliverables.
+5. All PR titles, bodies, and review comments must be in **English**.
+
+---
+
+## Domain Rules
+
+<!-- co-work variant specific rules — edit after project creation -->
+1. All research findings must be logged to memory/ with source citations.
+2. Stakeholder review comments must be tracked in the project coordination log.
+3. Publication artifacts must be version-controlled before distribution.
+
+---
+
+*co-work.context.md version: 1.0 — created by /new-project*

--- a/templates/common/docs/context.md
+++ b/templates/common/docs/context.md
@@ -1,0 +1,109 @@
+# [Project Name] — Project Context
+
+> Shared reference for all AI tools (Claude Code, Gemini CLI, Antigravity).
+> Tool-specific behaviors: CLAUDE.md (Claude Code), GEMINI.md (Gemini/Antigravity).
+> Variant-specific configuration (tech stack, agents, skills, scripts, workflow):
+>   → docs/<variant-name>.context.md
+>
+> ⚠️ This file is IMMUTABLE after project creation.
+>    All project-specific changes belong in docs/<variant-name>.context.md
+
+---
+
+## Project Overview
+
+[One-sentence description of what this project does and who it's for.]
+
+**Type**: web | cli | api | mcp
+**Status**: Active development
+
+---
+
+## Architecture
+
+Standard directory layout for all projects in this workspace:
+
+```
+<project-root>/
+├── src/          # Source code
+├── docs/         # context.md (this file) + <variant>.context.md + ADRs
+├── scripts/      # Automation scripts (.sh + .ps1 pairs)
+├── memory/       # Session logs (MEMORY.md index + daily logs)
+├── agents/       # Role-based agent definitions
+├── skills/       # Reusable workflow skills
+└── .claude/      # Claude Code settings and slash commands
+```
+
+---
+
+## Key Files
+
+| File | Purpose |
+|------|---------|
+| `docs/context.md` | This file — immutable project identity |
+| `docs/<variant>.context.md` | Variant config — tech stack, agents, skills, scripts, workflow |
+| `CLAUDE.md` | Claude Code session behavior and slash commands |
+| `GEMINI.md` | Gemini CLI / Antigravity session behavior |
+| `AGENTS.md` | Canonical agent index (auto-loaded by Claude Code) |
+| `scripts/audit.sh` / `.ps1` | Documentation audit (enforced on pre-commit) |
+| `scripts/dev-sync.sh` / `.ps1` | Full sync pipeline (memlog → audit → commit → PR) |
+| `memory/MEMORY.md` | Development log index |
+| `CHANGELOG.md` | User-visible change history |
+
+---
+
+## Documentation Standards
+
+### Session Log Format (`memory/YYYY-MM-DD.md`)
+
+Every session log entry MUST include the following four sections:
+
+```markdown
+## Session Summary
+<!-- One paragraph: what was accomplished this session -->
+
+## Changes
+<!-- File-level list of what was created, modified, or deleted -->
+- `path/to/file` — created: reason
+- `path/to/file` — modified: what changed and why
+- `path/to/file` — deleted: reason
+
+## Decisions
+<!-- Architectural or design choices made, with rationale -->
+- Decision: why this approach was chosen over alternatives
+
+## Open Issues
+<!-- Unresolved problems, blockers, or follow-up items -->
+- Issue: symptom → root cause → resolution (or "pending")
+```
+
+> All AI tools (Claude Code, Gemini CLI, Antigravity) MUST produce session logs
+> with these exact four section headings for cross-tool consistency.
+
+### CHANGELOG Entry Format (`CHANGELOG.md`)
+
+Every entry under `[Unreleased]` MUST include a PR reference:
+
+```markdown
+## [Unreleased]
+### Added
+- Short description of change (#PR-number)
+```
+
+### Language Policy
+
+| Content | Language |
+|---------|----------|
+| Conversational replies to user | Korean (default) |
+| Code, config, commit messages | English only |
+| PR titles, bodies, branch names | English only |
+| CHANGELOG.md entries | English only |
+| memory/ session logs | English only |
+
+### File Encoding
+
+All text files (Markdown, scripts) must be saved as **UTF-8 (without BOM)**.
+
+---
+
+*context.md version: 2.0 — created by /new-project*


### PR DESCRIPTION
## Summary
- Split `docs/context.md` into two layers for cleaner lifecycle management
- `context.md` (immutable): project identity, architecture, key files, documentation standards
- `<variant>.context.md` (mutable): tech stack, agents, skills, scripts, workflow — evolves with the project
- Add explicit context loading order to all variant CLAUDE.md and GEMINI.md

## Changes

| File | Action | Description |
|------|--------|-------------|
| `templates/common/docs/context.md` | Created | Immutable common context (architecture, standards) |
| `templates/co-develop/docs/co-develop.context.md` | Created | co-develop variant config with lifecycle status columns |
| `templates/co-design/docs/co-design.context.md` | Created | co-design variant config |
| `templates/co-work/docs/co-work.context.md` | Created | co-work variant config |
| `templates/co-*/CLAUDE.md` | Modified | Added `## Session Start — Context Loading Order` section |
| `templates/co-*/GEMINI.md` | Modified | Added `## Session Start — Context Loading Order` section |
| `scripts/new-project.sh` / `.ps1` | Modified | Provenance → variant.context.md; `.gitattributes` merge=ours |
| `CHANGELOG.md` | Modified | Added entries for new files |

## Design Rationale

| Section | Location | Why |
|---------|----------|-----|
| Project Overview, Architecture, Key Files, Documentation Standards | `context.md` | Immutable after creation — defines "what this project is" |
| Tech Stack, Agents, Skills, Scripts, Workflow | `<variant>.context.md` | Changes with lifecycle — defines "how to operate this project" |

Read order enforced in CLAUDE.md and GEMINI.md:
1. `docs/context.md` — immutable identity
2. `docs/<variant>.context.md` — operational config
3. `AGENTS.md` — agent roster

## Test Plan
- [x] `bash scripts/audit.sh` passes
- [x] Template lifecycle validation passes (0 errors, 0 warnings)
- [x] Secret scan passes
- [x] CHANGELOG.md `[Unreleased]` section updated with `(#TBD)` references
- [ ] Manual: run `/new-project` and verify both context files are created

---
🤖 Generated with [Claude Code](https://claude.ai/claude-code)