### PR TITLE
feat: add script lifecycle management (SCRIPTS.md, verify-scripts.ts, CONSTITUTION §6.5)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,12 +9,15 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ## [Unreleased]
 
 ### Added
-- **[2026-05-27]**: `templates/common/docs/context.md` — new immutable common context file (project identity, architecture, key files, documentation standards) (#TBD)
-- **[2026-05-27]**: `templates/co-develop/docs/co-develop.context.md` — new variant config file (tech stack, agents, skills, scripts, workflow) with lifecycle status columns (#TBD)
-- **[2026-05-27]**: `templates/co-design/docs/co-design.context.md` — new variant config file for design projects (#TBD)
-- **[2026-05-27]**: `templates/co-work/docs/co-work.context.md` — new variant config file for collaboration projects (#TBD)
-- **[2026-05-27]**: All variant CLAUDE.md and GEMINI.md — `## Session Start — Context Loading Order` section added (context.md → variant.context.md → AGENTS.md read order) (#TBD)
-- **[2026-05-27]**: `scripts/new-project.sh` / `.ps1` — template provenance written to variant.context.md; `docs/context.md merge=ours` added to `.gitattributes` on project creation (#TBD)
+- **[2026-05-27]**: `templates/common/docs/context.md` — new immutable common context file (project identity, architecture, key files, documentation standards) (#95)
+- **[2026-05-27]**: `templates/co-develop/docs/co-develop.context.md` — new variant config file (tech stack, agents, skills, scripts, workflow) with lifecycle status columns (#95)
+- **[2026-05-27]**: `templates/co-design/docs/co-design.context.md` — new variant config file for design projects (#95)
+- **[2026-05-27]**: `templates/co-work/docs/co-work.context.md` — new variant config file for collaboration projects (#95)
+- **[2026-05-27]**: All variant CLAUDE.md and GEMINI.md — Session Start context loading order added (#95)
+- **[2026-05-27]**: `scripts/new-project.sh` / `.ps1` — provenance to variant.context.md; docs/context.md merge=ours in .gitattributes (#95)
+- **[2026-05-27]**: `templates/common/scripts/SCRIPTS.md` — script lifecycle registry (Registry + Guide dual-section) (#TBD)
+- **[2026-05-27]**: `scripts/verify-scripts.ts` — script registry verifier with --verify / --generate / --report modes (#TBD)
+- **[2026-05-27]**: `CONSTITUTION.md §6.5` — Script Lifecycle Management section (ownership layers, states, deprecation/security protocols) (#TBD)
 
 ### Changed
 - **[2026-05-27]**: `.github/pull_request_template.md` redesigned with Summary/Changes table/Test Plan/Security Checklist sections — applied to workspace and all template variants (#93)

--- a/CONSTITUTION.md
+++ b/CONSTITUTION.md
@@ -618,6 +618,58 @@ If audit fails:
 
 ---
 
+### 6.5 Script Lifecycle Management
+
+Scripts are managed across three ownership layers. All changes originate at L0 and propagate downward.
+
+#### Ownership Layers
+
+| Layer | Location | Owner | Update Policy |
+|-------|----------|-------|---------------|
+| **L0 — Template SSOT** | `templates/common/scripts/` | templates team | Versioned via `SCRIPTS.md` Registry |
+| **L1 — Workspace** | `scripts/` (workspace root) | workspace maintainer | Sync from L0 on release |
+| **L2 — Project** | `<project>/scripts/` | project team | Independent snapshot after creation |
+
+**Propagation rule**: Changes flow L0 → L1 → L2 (at project creation time only).
+No automatic back-propagation. Reverse sync (project → workspace → template) requires an explicit PR.
+
+#### Script States
+
+| Status | Meaning | Enforcement |
+|--------|---------|-------------|
+| `active` | In production use | Version bump required on change |
+| `deprecated` | Scheduled for removal | `removal-date` required (90-day minimum notice); `dev-sync` warns L1/L2 |
+| `experimental` | Unstable / not propagated | Not synced to L1/L2 automatically |
+
+#### Deprecation Protocol
+
+1. Set `status: deprecated` and `removal-date: YYYY-MM-DD` in `SCRIPTS.md` Registry (≥ 90 days notice)
+2. `dev-sync.sh` warns all L1/L2 consumers on every run until removed
+3. On `removal-date`, `verify-scripts.ts --verify` **hard blocks** pre-commit
+
+#### Security Advisory Protocol
+
+When a security vulnerability is found in a script:
+1. Set `security-advisory: CVE-XXXX` in `SCRIPTS.md` Registry
+2. `dev-sync.sh` **hard blocks immediately** in L1/L2 (no grace period)
+3. Advisory is cleared only after the script is patched or removed
+
+#### SCRIPTS.md — Registry Format
+
+`templates/common/scripts/SCRIPTS.md` is the L0 manifest. It has two sections:
+
+- **`## Registry`** — machine-readable table parsed by `verify-scripts.ts`
+- **`## Guide`** — human-readable documentation (purpose, usage, deprecation notes)
+
+```markdown
+| script | source | version | status | removal-date | security-advisory |
+|--------|--------|---------|--------|--------------|-------------------|
+| `audit.sh` | L0 | 1.2.0 | active | — | — |
+| `old-tool.sh` | L0 | 2.1.0 | deprecated | 2026-08-01 | — |
+```
+
+---
+
 ### 7. New Project Initialization
 
 #### 7.1 Project Scaffolding Commands

--- a/scripts/verify-scripts.ts
+++ b/scripts/verify-scripts.ts
@@ -1,0 +1,356 @@
+#!/usr/bin/env bun
+/**
+ * verify-scripts.ts — Script Lifecycle Registry Verifier
+ *
+ * Validates that scripts/SCRIPTS.md Registry is in sync with actual script files,
+ * enforces deprecation removal dates, and blocks on security advisories.
+ *
+ * Usage:
+ *   bun scripts/verify-scripts.ts --verify    # CI / pre-commit: fail on drift
+ *   bun scripts/verify-scripts.ts --generate  # Generate Registry draft from filesystem
+ *   bun scripts/verify-scripts.ts --report    # Human-readable status report
+ *
+ * Exit codes:
+ *   0 = all checks passed
+ *   1 = drift, expired removal date, or active security advisory detected
+ */
+
+import { readFileSync, readdirSync, existsSync, writeFileSync } from "fs";
+import { join, dirname } from "path";
+
+// ── Configuration ────────────────────────────────────────────────────────────
+
+const SCRIPT_EXTENSIONS = [".sh", ".ps1", ".ts"];
+const SCRIPTS_MD_FILENAME = "SCRIPTS.md";
+
+// Resolve workspace root (this script lives in scripts/ or templates/common/scripts/)
+function findWorkspaceRoot(startDir: string): string {
+  let dir = startDir;
+  for (let i = 0; i < 6; i++) {
+    if (existsSync(join(dir, "CONSTITUTION.md"))) return dir;
+    dir = dirname(dir);
+  }
+  throw new Error("Could not find workspace root (CONSTITUTION.md not found)");
+}
+
+const scriptDir = import.meta.dir;
+const workspaceRoot = findWorkspaceRoot(scriptDir);
+const scriptsDir = join(workspaceRoot, "templates", "common", "scripts");
+const scriptsMdPath = join(scriptsDir, SCRIPTS_MD_FILENAME);
+
+// ── Types ────────────────────────────────────────────────────────────────────
+
+interface RegistryEntry {
+  script: string;
+  source: string;
+  version: string;
+  status: "active" | "deprecated" | "experimental";
+  removalDate: string; // "—" or "YYYY-MM-DD"
+  securityAdvisory: string; // "—" or "CVE-XXXX"
+}
+
+// ── Registry Parser ──────────────────────────────────────────────────────────
+
+function parseRegistry(content: string): RegistryEntry[] {
+  const lines = content.split("\n");
+  const entries: RegistryEntry[] = [];
+
+  let inRegistry = false;
+  let headerParsed = false;
+
+  for (const line of lines) {
+    if (line.startsWith("## Registry")) {
+      inRegistry = true;
+      headerParsed = false;
+      continue;
+    }
+    if (inRegistry && line.startsWith("## ")) {
+      // Next section — stop
+      break;
+    }
+    if (!inRegistry) continue;
+
+    const trimmed = line.trim();
+    if (!trimmed.startsWith("|") || trimmed.startsWith("|-")) continue;
+
+    const cols = trimmed
+      .split("|")
+      .slice(1, -1)
+      .map((c) => c.trim());
+
+    if (!headerParsed) {
+      headerParsed = true; // skip header row
+      continue;
+    }
+
+    if (cols.length < 6) continue;
+
+    // Strip backticks from script name
+    const script = cols[0].replace(/`/g, "");
+    const status = cols[3] as RegistryEntry["status"];
+
+    entries.push({
+      script,
+      source: cols[1],
+      version: cols[2],
+      status,
+      removalDate: cols[4],
+      securityAdvisory: cols[5],
+    });
+  }
+
+  return entries;
+}
+
+// ── Filesystem Scanner ───────────────────────────────────────────────────────
+
+function getActualScripts(): string[] {
+  if (!existsSync(scriptsDir)) return [];
+  return readdirSync(scriptsDir)
+    .filter(
+      (f) =>
+        SCRIPT_EXTENSIONS.some((ext) => f.endsWith(ext)) &&
+        f !== SCRIPTS_MD_FILENAME
+    )
+    .sort();
+}
+
+// ── Verify Mode ──────────────────────────────────────────────────────────────
+
+function verify(): boolean {
+  let passed = true;
+  const errors: string[] = [];
+  const warnings: string[] = [];
+
+  if (!existsSync(scriptsMdPath)) {
+    console.error(`❌ SCRIPTS.md not found at: ${scriptsMdPath}`);
+    console.error(
+      "   Run: bun scripts/verify-scripts.ts --generate  to create a draft"
+    );
+    return false;
+  }
+
+  const content = readFileSync(scriptsMdPath, "utf-8");
+  const registry = parseRegistry(content);
+  const actualScripts = getActualScripts();
+
+  const registeredNames = new Set(registry.map((e) => e.script));
+  const actualNames = new Set(actualScripts);
+
+  // Check 1: Scripts on disk but not in registry
+  for (const script of actualScripts) {
+    if (!registeredNames.has(script)) {
+      errors.push(`Unregistered script: \`${script}\` — add to SCRIPTS.md Registry`);
+    }
+  }
+
+  // Check 2: Scripts in registry but not on disk
+  for (const entry of registry) {
+    if (!actualNames.has(entry.script)) {
+      errors.push(
+        `Ghost entry: \`${entry.script}\` in Registry but not on disk — remove from SCRIPTS.md`
+      );
+    }
+  }
+
+  // Check 3: Security advisories — hard block
+  const today = new Date().toISOString().slice(0, 10);
+  for (const entry of registry) {
+    if (entry.securityAdvisory !== "—" && entry.securityAdvisory !== "") {
+      errors.push(
+        `🔒 SECURITY ADVISORY on \`${entry.script}\`: ${entry.securityAdvisory} — update or remove this script immediately`
+      );
+    }
+  }
+
+  // Check 4: Expired removal dates — hard block
+  for (const entry of registry) {
+    if (entry.status === "deprecated" && entry.removalDate !== "—" && entry.removalDate !== "") {
+      if (entry.removalDate <= today) {
+        errors.push(
+          `⏰ EXPIRED: \`${entry.script}\` removal-date ${entry.removalDate} has passed — delete this script and remove from Registry`
+        );
+      } else {
+        // Upcoming removal — warn only
+        const daysLeft = Math.ceil(
+          (new Date(entry.removalDate).getTime() - new Date(today).getTime()) /
+            86400000
+        );
+        warnings.push(
+          `⚠️  DEPRECATED: \`${entry.script}\` — scheduled removal on ${entry.removalDate} (${daysLeft} days remaining)`
+        );
+      }
+    }
+
+    // Check 5: deprecated without removal-date
+    if (entry.status === "deprecated" && (entry.removalDate === "—" || entry.removalDate === "")) {
+      errors.push(
+        `Missing removal-date for deprecated script: \`${entry.script}\` — add YYYY-MM-DD (min 90 days)`
+      );
+    }
+  }
+
+  // Output
+  console.log(`\n=== verify-scripts.ts ===`);
+  console.log(`Registry: ${scriptsMdPath}`);
+  console.log(`Scripts dir: ${scriptsDir}\n`);
+
+  if (warnings.length > 0) {
+    for (const w of warnings) console.warn(w);
+    console.log();
+  }
+
+  if (errors.length > 0) {
+    for (const e of errors) console.error(`❌ ${e}`);
+    console.log(`\n❌ ${errors.length} error(s) found — pre-commit blocked`);
+    passed = false;
+  } else {
+    console.log(
+      `✅ All ${registry.length} registered scripts verified (${warnings.length} warning(s))`
+    );
+  }
+
+  return passed;
+}
+
+// ── Generate Mode ────────────────────────────────────────────────────────────
+
+function generate(): void {
+  const actualScripts = getActualScripts();
+
+  if (!existsSync(scriptsMdPath)) {
+    console.log(`ℹ️  SCRIPTS.md not found — generating from scratch`);
+  } else {
+    // Load existing registry to preserve metadata for known scripts
+    const existing = readFileSync(scriptsMdPath, "utf-8");
+    const existingRegistry = parseRegistry(existing);
+    const existingMap = new Map(existingRegistry.map((e) => [e.script, e]));
+
+    const rows = actualScripts.map((script) => {
+      const known = existingMap.get(script);
+      if (known) {
+        // Preserve existing metadata
+        return `| \`${known.script}\` | ${known.source} | ${known.version} | ${known.status} | ${known.removalDate} | ${known.securityAdvisory} |`;
+      }
+      return `| \`${script}\` | L0 | 1.0.0 | active | — | — |`;
+    });
+
+    // Replace Registry section in existing file
+    const header =
+      "| script | source | version | status | removal-date | security-advisory |\n" +
+      "|--------|--------|---------|--------|--------------|-------------------|";
+
+    const updated = existing.replace(
+      /(\| script \|.*?\n\|[-| ]+\|\n)([\s\S]*?)(?=\n---|\n## )/,
+      `${header}\n${rows.join("\n")}\n`
+    );
+
+    writeFileSync(scriptsMdPath, updated, "utf-8");
+    console.log(
+      `✅ Registry updated: ${rows.length} scripts (${actualScripts.length} on disk)`
+    );
+    console.log(`   Review SCRIPTS.md before committing — metadata is preserved for known scripts`);
+    return;
+  }
+
+  // Fresh generate
+  const rows = actualScripts
+    .map(
+      (s) => `| \`${s}\` | L0 | 1.0.0 | active | — | — |`
+    )
+    .join("\n");
+
+  const draft = `# SCRIPTS.md — Script Lifecycle Registry
+
+> Auto-generated draft. Review and fill in the Guide section before committing.
+
+---
+
+## Registry
+
+| script | source | version | status | removal-date | security-advisory |
+|--------|--------|---------|--------|--------------|-------------------|
+${rows}
+
+---
+
+## Guide
+
+<!-- Add human-readable documentation for each script here -->
+`;
+
+  writeFileSync(scriptsMdPath, draft, "utf-8");
+  console.log(`✅ Generated SCRIPTS.md draft with ${actualScripts.length} scripts`);
+  console.log(`   Path: ${scriptsMdPath}`);
+  console.log(`   Next: fill in Guide section, then commit`);
+}
+
+// ── Report Mode ──────────────────────────────────────────────────────────────
+
+function report(): void {
+  if (!existsSync(scriptsMdPath)) {
+    console.error(`❌ SCRIPTS.md not found. Run --generate first.`);
+    process.exit(1);
+  }
+
+  const content = readFileSync(scriptsMdPath, "utf-8");
+  const registry = parseRegistry(content);
+  const actual = getActualScripts();
+  const registeredNames = new Set(registry.map((e) => e.script));
+  const today = new Date().toISOString().slice(0, 10);
+
+  const active = registry.filter((e) => e.status === "active");
+  const deprecated = registry.filter((e) => e.status === "deprecated");
+  const experimental = registry.filter((e) => e.status === "experimental");
+  const unregistered = actual.filter((s) => !registeredNames.has(s));
+  const advisories = registry.filter((e) => e.securityAdvisory !== "—" && e.securityAdvisory !== "");
+
+  console.log(`\n=== Script Lifecycle Report ===`);
+  console.log(`Date: ${today}`);
+  console.log(`Registry: ${registry.length} entries | Disk: ${actual.length} files\n`);
+
+  console.log(`📦 Active (${active.length})`);
+  for (const e of active) console.log(`   ✅ ${e.script} v${e.version}`);
+
+  if (deprecated.length > 0) {
+    console.log(`\n⚠️  Deprecated (${deprecated.length})`);
+    for (const e of deprecated) {
+      const expired = e.removalDate !== "—" && e.removalDate <= today;
+      const marker = expired ? "❌ EXPIRED" : "⏰";
+      console.log(`   ${marker} ${e.script} — removal: ${e.removalDate}`);
+    }
+  }
+
+  if (experimental.length > 0) {
+    console.log(`\n🧪 Experimental (${experimental.length})`);
+    for (const e of experimental) console.log(`   🔬 ${e.script} v${e.version}`);
+  }
+
+  if (advisories.length > 0) {
+    console.log(`\n🔒 Security Advisories (${advisories.length})`);
+    for (const e of advisories) console.log(`   🚨 ${e.script}: ${e.securityAdvisory}`);
+  }
+
+  if (unregistered.length > 0) {
+    console.log(`\n❓ Unregistered on disk (${unregistered.length})`);
+    for (const s of unregistered) console.log(`   ➕ ${s}`);
+  }
+
+  console.log();
+}
+
+// ── Entry Point ──────────────────────────────────────────────────────────────
+
+const args = process.argv.slice(2);
+
+if (args.includes("--generate")) {
+  generate();
+} else if (args.includes("--report")) {
+  report();
+} else if (args.includes("--verify") || args.length === 0) {
+  const ok = verify();
+  process.exit(ok ? 0 : 1);
+} else {
+  console.error(`Usage: bun scripts/verify-scripts.ts [--verify | --generate | --report]`);
+  process.exit(1);
+}

--- a/templates/common/scripts/SCRIPTS.md
+++ b/templates/common/scripts/SCRIPTS.md
@@ -1,0 +1,203 @@
+# SCRIPTS.md — Script Lifecycle Registry
+
+> This file is the Single Source of Truth (L0) for all scripts in `templates/common/scripts/`.
+> Workspace root `scripts/` (L1) and project `scripts/` (L2) derive from here.
+>
+> **Machine parsing**: `verify-scripts.ts --verify` reads the `## Registry` section only.
+> **Human reading**: see `## Guide` section below for purpose, usage, and deprecation notes.
+
+---
+
+## Registry
+
+<!-- verify-scripts.ts parses rows between the Registry header and the next ## header. -->
+<!-- Required columns: script | source | version | status | removal-date | security-advisory -->
+<!-- status: active | deprecated | experimental -->
+<!-- removal-date: YYYY-MM-DD (required when status=deprecated) or — -->
+<!-- security-advisory: CVE-XXXX or — -->
+
+| script | source | version | status | removal-date | security-advisory |
+|--------|--------|---------|--------|--------------|-------------------|
+| `audit.sh` | L0 | 1.2.0 | active | — | — |
+| `audit.ps1` | L0 | 1.2.0 | active | — | — |
+| `dev-sync.sh` | L0 | 1.3.0 | active | — | — |
+| `dev-sync.ps1` | L0 | 1.3.0 | active | — | — |
+| `sync-md.sh` | L0 | 1.1.0 | active | — | — |
+| `sync-md.ps1` | L0 | 1.1.0 | active | — | — |
+| `setup.sh` | L0 | 1.0.0 | active | — | — |
+| `setup.ps1` | L0 | 1.0.0 | active | — | — |
+| `gen-pr-body.sh` | L0 | 1.0.0 | active | — | — |
+| `gen-pr-body.ps1` | L0 | 1.0.0 | active | — | — |
+| `install-bun.sh` | L0 | 1.0.0 | active | — | — |
+| `install-bun.ps1` | L0 | 1.0.0 | active | — | — |
+| `agent-create.ts` | L0 | 1.0.0 | active | — | — |
+| `agent-delete.ts` | L0 | 1.0.0 | active | — | — |
+| `agent-list.ts` | L0 | 1.0.0 | active | — | — |
+| `agent-verify.ts` | L0 | 1.0.0 | active | — | — |
+| `agent-lifecycle-audit.ts` | L0 | 1.0.0 | active | — | — |
+| `skill-lifecycle-audit.ts` | L0 | 1.0.0 | active | — | — |
+| `readme-lifecycle-audit.ts` | L0 | 1.0.0 | active | — | — |
+| `verify-skills.ts` | L0 | 1.0.0 | active | — | — |
+| `dispatch.ts` | L0 | 1.0.0 | active | — | — |
+| `dispatch-parallel.ts` | L0 | 1.0.0 | active | — | — |
+| `dispatch-serial.ts` | L0 | 1.0.0 | active | — | — |
+| `retry-handler.ts` | L0 | 1.0.0 | active | — | — |
+
+---
+
+## Ownership Layers
+
+| Layer | Location | Owner | Update Policy |
+|-------|----------|-------|---------------|
+| **L0 — Template SSOT** | `templates/common/scripts/` | templates team | Versioned via this file |
+| **L1 — Workspace** | `scripts/` (workspace root) | workspace maintainer | Sync from L0 on release |
+| **L2 — Project** | `<project>/scripts/` | project team | Independent after creation (snapshot) |
+
+**Propagation rule**: L0 → L1 → L2 (creation time only). No automatic back-propagation.
+Reverse sync (L2 → L1 → L0) requires an explicit PR.
+
+---
+
+## Lifecycle States
+
+| Status | Meaning | Action Required |
+|--------|---------|-----------------|
+| `active` | In production use | Changes require version bump in Registry |
+| `deprecated` | Scheduled for removal | `removal-date` field required; L1/L2 warned on `dev-sync` |
+| `experimental` | Not guaranteed stable | Not synced to L1/L2 automatically |
+
+**Deprecation flow:**
+1. Set `status: deprecated` and `removal-date: YYYY-MM-DD` (minimum 90 days notice)
+2. `dev-sync.sh` warns L1/L2 consumers on every run
+3. On `removal-date`, `verify-scripts.ts --verify` **hard blocks** pre-commit
+
+**Security advisory flow:**
+1. Set `security-advisory: CVE-XXXX` (status can remain `active` or become `deprecated`)
+2. `dev-sync.sh` **hard blocks** in L1/L2 until the script is updated or removed
+3. Unlike deprecation, security advisories take immediate effect with no grace period
+
+---
+
+## Guide
+
+### Everyday Development Scripts
+
+#### `audit.sh` / `audit.ps1`
+**Purpose**: Documentation audit gate. Checks CHANGELOG.md, CONSTITUTION.md, AGENTS.md,
+agent frontmatter, skill health, and template lifecycle validation.
+**Usage**: `bash scripts/audit.sh` / `.\scripts\audit.ps1`
+**Runs automatically**: pre-commit hook, pre-push hook, `dev-sync.sh`
+**Pair rule**: `.sh` and `.ps1` must always be kept in sync.
+
+#### `dev-sync.sh` / `dev-sync.ps1`
+**Purpose**: Full sync pipeline — session log → MEMORY.md index → CHANGELOG auto-add →
+audit gate → sensitive file check → branch creation → commit → push → PR.
+**Usage**: `bash scripts/dev-sync.sh "feat: description"` / `.\scripts\dev-sync.ps1 "feat: ..."`
+**Claude Code**: `/sync "feat: description"`
+**Pair rule**: `.sh` and `.ps1` must always be kept in sync.
+
+#### `sync-md.sh` / `sync-md.ps1`
+**Purpose**: Updates `memory/MEMORY.md` index with today's session entry.
+**Usage**: Called automatically by `dev-sync.sh`. Rarely invoked directly.
+**Pair rule**: `.sh` and `.ps1` must always be kept in sync.
+
+#### `setup.sh` / `setup.ps1`
+**Purpose**: Project environment initialization — env file creation, dependency install,
+git hooks installation, initial commit.
+**Usage**: `bash scripts/setup.sh` (run once after `new-project`)
+
+#### `gen-pr-body.sh` / `gen-pr-body.ps1`
+**Purpose**: Generates PR body from commit log and memory log. Called by `dev-sync.sh`.
+**Usage**: Invoked automatically. Can be called standalone: `bash scripts/gen-pr-body.sh "msg"`
+
+---
+
+### Installation Scripts
+
+#### `install-bun.sh` / `install-bun.ps1`
+**Purpose**: Installs Bun runtime required for TypeScript scripts (`.ts`).
+**Usage**: `bash scripts/install-bun.sh` / `.\scripts\install-bun.ps1`
+**When needed**: Before running any `.ts` script for the first time.
+
+---
+
+### Agent Lifecycle Scripts (Bun / TypeScript)
+
+#### `agent-create.ts`
+**Purpose**: Creates a new agent file with proper frontmatter and required sections.
+**Usage**: `bun scripts/agent-create.ts <name> --role "Display Name" --group <group>`
+
+#### `agent-delete.ts`
+**Purpose**: Removes an agent file and updates AGENTS.md.
+**Usage**: `bun scripts/agent-delete.ts <name> [--force]`
+
+#### `agent-list.ts`
+**Purpose**: Lists all agents with their status, group, and tier.
+**Usage**: `bun scripts/agent-list.ts [--group <group>] [--verbose]`
+
+#### `agent-verify.ts`
+**Purpose**: Verifies agent/AGENTS.md synchronization (files vs. registry).
+**Usage**: `bun scripts/agent-verify.ts`
+
+#### `agent-lifecycle-audit.ts`
+**Purpose**: Full agent lifecycle audit — frontmatter validation, AGENTS.md consistency,
+deprecated agent references, missing fields.
+**Usage**: `bun scripts/agent-lifecycle-audit.ts`
+**Runs automatically**: pre-commit hook when `agents/*.md` files are staged.
+
+---
+
+### Skill Lifecycle Scripts (Bun / TypeScript)
+
+#### `skill-lifecycle-audit.ts`
+**Purpose**: Full skill lifecycle audit — owner validation, orphaned skills, deprecated
+skills still being modified, dependency graph, circular dependencies.
+**Usage**: `bun scripts/skill-lifecycle-audit.ts`
+**Runs automatically**: pre-commit hook when `skills/**` files are staged.
+
+#### `readme-lifecycle-audit.ts`
+**Purpose**: Validates README.md / README_ko.md pairing in `templates/` directories.
+**Usage**: `bun scripts/readme-lifecycle-audit.ts`
+
+#### `verify-skills.ts`
+**Purpose**: Cross-validates skills referenced in `docs/context.md` against actual
+skill files on disk. Detects missing or orphaned skill references.
+**Usage**: `bun scripts/verify-skills.ts`
+
+---
+
+### Multi-Agent Orchestration Scripts (Bun / TypeScript)
+
+#### `dispatch.ts`
+**Purpose**: Single-agent dispatch wrapper. Spawns one agent with a given prompt and
+waits for completion.
+**Usage**: `bun scripts/dispatch.ts --agent <name> --prompt "task"`
+
+#### `dispatch-parallel.ts`
+**Purpose**: Parallel multi-agent dispatch. Spawns multiple agents simultaneously and
+collects results when all complete.
+**Usage**: `bun scripts/dispatch-parallel.ts --agents agent1,agent2 --prompt "task"`
+
+#### `dispatch-serial.ts`
+**Purpose**: Serial multi-agent dispatch. Chains agents sequentially, passing each
+agent's output as input to the next.
+**Usage**: `bun scripts/dispatch-serial.ts --agents agent1,agent2 --prompt "task"`
+
+#### `retry-handler.ts`
+**Purpose**: Wraps any dispatch call with retry logic (configurable attempts, backoff).
+**Usage**: `import { withRetry } from './retry-handler.ts'` (library module)
+
+---
+
+## Version Bump Policy
+
+When modifying a script:
+1. Increment `version` in the Registry row (semver: patch for bugfix, minor for feature)
+2. Update the Guide section if the interface or behavior changes
+3. If the change is breaking, set `status: deprecated` on the old version entry and
+   add a new row for the replacement
+
+---
+
+*SCRIPTS.md maintained by: templates team*
+*Last updated: 2026-05-27*

--- a/templates/common/scripts/verify-scripts.ts
+++ b/templates/common/scripts/verify-scripts.ts
@@ -1,0 +1,356 @@
+#!/usr/bin/env bun
+/**
+ * verify-scripts.ts — Script Lifecycle Registry Verifier
+ *
+ * Validates that scripts/SCRIPTS.md Registry is in sync with actual script files,
+ * enforces deprecation removal dates, and blocks on security advisories.
+ *
+ * Usage:
+ *   bun scripts/verify-scripts.ts --verify    # CI / pre-commit: fail on drift
+ *   bun scripts/verify-scripts.ts --generate  # Generate Registry draft from filesystem
+ *   bun scripts/verify-scripts.ts --report    # Human-readable status report
+ *
+ * Exit codes:
+ *   0 = all checks passed
+ *   1 = drift, expired removal date, or active security advisory detected
+ */
+
+import { readFileSync, readdirSync, existsSync, writeFileSync } from "fs";
+import { join, dirname } from "path";
+
+// ── Configuration ────────────────────────────────────────────────────────────
+
+const SCRIPT_EXTENSIONS = [".sh", ".ps1", ".ts"];
+const SCRIPTS_MD_FILENAME = "SCRIPTS.md";
+
+// Resolve workspace root (this script lives in scripts/ or templates/common/scripts/)
+function findWorkspaceRoot(startDir: string): string {
+  let dir = startDir;
+  for (let i = 0; i < 6; i++) {
+    if (existsSync(join(dir, "CONSTITUTION.md"))) return dir;
+    dir = dirname(dir);
+  }
+  throw new Error("Could not find workspace root (CONSTITUTION.md not found)");
+}
+
+const scriptDir = import.meta.dir;
+const workspaceRoot = findWorkspaceRoot(scriptDir);
+const scriptsDir = join(workspaceRoot, "templates", "common", "scripts");
+const scriptsMdPath = join(scriptsDir, SCRIPTS_MD_FILENAME);
+
+// ── Types ────────────────────────────────────────────────────────────────────
+
+interface RegistryEntry {
+  script: string;
+  source: string;
+  version: string;
+  status: "active" | "deprecated" | "experimental";
+  removalDate: string; // "—" or "YYYY-MM-DD"
+  securityAdvisory: string; // "—" or "CVE-XXXX"
+}
+
+// ── Registry Parser ──────────────────────────────────────────────────────────
+
+function parseRegistry(content: string): RegistryEntry[] {
+  const lines = content.split("\n");
+  const entries: RegistryEntry[] = [];
+
+  let inRegistry = false;
+  let headerParsed = false;
+
+  for (const line of lines) {
+    if (line.startsWith("## Registry")) {
+      inRegistry = true;
+      headerParsed = false;
+      continue;
+    }
+    if (inRegistry && line.startsWith("## ")) {
+      // Next section — stop
+      break;
+    }
+    if (!inRegistry) continue;
+
+    const trimmed = line.trim();
+    if (!trimmed.startsWith("|") || trimmed.startsWith("|-")) continue;
+
+    const cols = trimmed
+      .split("|")
+      .slice(1, -1)
+      .map((c) => c.trim());
+
+    if (!headerParsed) {
+      headerParsed = true; // skip header row
+      continue;
+    }
+
+    if (cols.length < 6) continue;
+
+    // Strip backticks from script name
+    const script = cols[0].replace(/`/g, "");
+    const status = cols[3] as RegistryEntry["status"];
+
+    entries.push({
+      script,
+      source: cols[1],
+      version: cols[2],
+      status,
+      removalDate: cols[4],
+      securityAdvisory: cols[5],
+    });
+  }
+
+  return entries;
+}
+
+// ── Filesystem Scanner ───────────────────────────────────────────────────────
+
+function getActualScripts(): string[] {
+  if (!existsSync(scriptsDir)) return [];
+  return readdirSync(scriptsDir)
+    .filter(
+      (f) =>
+        SCRIPT_EXTENSIONS.some((ext) => f.endsWith(ext)) &&
+        f !== SCRIPTS_MD_FILENAME
+    )
+    .sort();
+}
+
+// ── Verify Mode ──────────────────────────────────────────────────────────────
+
+function verify(): boolean {
+  let passed = true;
+  const errors: string[] = [];
+  const warnings: string[] = [];
+
+  if (!existsSync(scriptsMdPath)) {
+    console.error(`❌ SCRIPTS.md not found at: ${scriptsMdPath}`);
+    console.error(
+      "   Run: bun scripts/verify-scripts.ts --generate  to create a draft"
+    );
+    return false;
+  }
+
+  const content = readFileSync(scriptsMdPath, "utf-8");
+  const registry = parseRegistry(content);
+  const actualScripts = getActualScripts();
+
+  const registeredNames = new Set(registry.map((e) => e.script));
+  const actualNames = new Set(actualScripts);
+
+  // Check 1: Scripts on disk but not in registry
+  for (const script of actualScripts) {
+    if (!registeredNames.has(script)) {
+      errors.push(`Unregistered script: \`${script}\` — add to SCRIPTS.md Registry`);
+    }
+  }
+
+  // Check 2: Scripts in registry but not on disk
+  for (const entry of registry) {
+    if (!actualNames.has(entry.script)) {
+      errors.push(
+        `Ghost entry: \`${entry.script}\` in Registry but not on disk — remove from SCRIPTS.md`
+      );
+    }
+  }
+
+  // Check 3: Security advisories — hard block
+  const today = new Date().toISOString().slice(0, 10);
+  for (const entry of registry) {
+    if (entry.securityAdvisory !== "—" && entry.securityAdvisory !== "") {
+      errors.push(
+        `🔒 SECURITY ADVISORY on \`${entry.script}\`: ${entry.securityAdvisory} — update or remove this script immediately`
+      );
+    }
+  }
+
+  // Check 4: Expired removal dates — hard block
+  for (const entry of registry) {
+    if (entry.status === "deprecated" && entry.removalDate !== "—" && entry.removalDate !== "") {
+      if (entry.removalDate <= today) {
+        errors.push(
+          `⏰ EXPIRED: \`${entry.script}\` removal-date ${entry.removalDate} has passed — delete this script and remove from Registry`
+        );
+      } else {
+        // Upcoming removal — warn only
+        const daysLeft = Math.ceil(
+          (new Date(entry.removalDate).getTime() - new Date(today).getTime()) /
+            86400000
+        );
+        warnings.push(
+          `⚠️  DEPRECATED: \`${entry.script}\` — scheduled removal on ${entry.removalDate} (${daysLeft} days remaining)`
+        );
+      }
+    }
+
+    // Check 5: deprecated without removal-date
+    if (entry.status === "deprecated" && (entry.removalDate === "—" || entry.removalDate === "")) {
+      errors.push(
+        `Missing removal-date for deprecated script: \`${entry.script}\` — add YYYY-MM-DD (min 90 days)`
+      );
+    }
+  }
+
+  // Output
+  console.log(`\n=== verify-scripts.ts ===`);
+  console.log(`Registry: ${scriptsMdPath}`);
+  console.log(`Scripts dir: ${scriptsDir}\n`);
+
+  if (warnings.length > 0) {
+    for (const w of warnings) console.warn(w);
+    console.log();
+  }
+
+  if (errors.length > 0) {
+    for (const e of errors) console.error(`❌ ${e}`);
+    console.log(`\n❌ ${errors.length} error(s) found — pre-commit blocked`);
+    passed = false;
+  } else {
+    console.log(
+      `✅ All ${registry.length} registered scripts verified (${warnings.length} warning(s))`
+    );
+  }
+
+  return passed;
+}
+
+// ── Generate Mode ────────────────────────────────────────────────────────────
+
+function generate(): void {
+  const actualScripts = getActualScripts();
+
+  if (!existsSync(scriptsMdPath)) {
+    console.log(`ℹ️  SCRIPTS.md not found — generating from scratch`);
+  } else {
+    // Load existing registry to preserve metadata for known scripts
+    const existing = readFileSync(scriptsMdPath, "utf-8");
+    const existingRegistry = parseRegistry(existing);
+    const existingMap = new Map(existingRegistry.map((e) => [e.script, e]));
+
+    const rows = actualScripts.map((script) => {
+      const known = existingMap.get(script);
+      if (known) {
+        // Preserve existing metadata
+        return `| \`${known.script}\` | ${known.source} | ${known.version} | ${known.status} | ${known.removalDate} | ${known.securityAdvisory} |`;
+      }
+      return `| \`${script}\` | L0 | 1.0.0 | active | — | — |`;
+    });
+
+    // Replace Registry section in existing file
+    const header =
+      "| script | source | version | status | removal-date | security-advisory |\n" +
+      "|--------|--------|---------|--------|--------------|-------------------|";
+
+    const updated = existing.replace(
+      /(\| script \|.*?\n\|[-| ]+\|\n)([\s\S]*?)(?=\n---|\n## )/,
+      `${header}\n${rows.join("\n")}\n`
+    );
+
+    writeFileSync(scriptsMdPath, updated, "utf-8");
+    console.log(
+      `✅ Registry updated: ${rows.length} scripts (${actualScripts.length} on disk)`
+    );
+    console.log(`   Review SCRIPTS.md before committing — metadata is preserved for known scripts`);
+    return;
+  }
+
+  // Fresh generate
+  const rows = actualScripts
+    .map(
+      (s) => `| \`${s}\` | L0 | 1.0.0 | active | — | — |`
+    )
+    .join("\n");
+
+  const draft = `# SCRIPTS.md — Script Lifecycle Registry
+
+> Auto-generated draft. Review and fill in the Guide section before committing.
+
+---
+
+## Registry
+
+| script | source | version | status | removal-date | security-advisory |
+|--------|--------|---------|--------|--------------|-------------------|
+${rows}
+
+---
+
+## Guide
+
+<!-- Add human-readable documentation for each script here -->
+`;
+
+  writeFileSync(scriptsMdPath, draft, "utf-8");
+  console.log(`✅ Generated SCRIPTS.md draft with ${actualScripts.length} scripts`);
+  console.log(`   Path: ${scriptsMdPath}`);
+  console.log(`   Next: fill in Guide section, then commit`);
+}
+
+// ── Report Mode ──────────────────────────────────────────────────────────────
+
+function report(): void {
+  if (!existsSync(scriptsMdPath)) {
+    console.error(`❌ SCRIPTS.md not found. Run --generate first.`);
+    process.exit(1);
+  }
+
+  const content = readFileSync(scriptsMdPath, "utf-8");
+  const registry = parseRegistry(content);
+  const actual = getActualScripts();
+  const registeredNames = new Set(registry.map((e) => e.script));
+  const today = new Date().toISOString().slice(0, 10);
+
+  const active = registry.filter((e) => e.status === "active");
+  const deprecated = registry.filter((e) => e.status === "deprecated");
+  const experimental = registry.filter((e) => e.status === "experimental");
+  const unregistered = actual.filter((s) => !registeredNames.has(s));
+  const advisories = registry.filter((e) => e.securityAdvisory !== "—" && e.securityAdvisory !== "");
+
+  console.log(`\n=== Script Lifecycle Report ===`);
+  console.log(`Date: ${today}`);
+  console.log(`Registry: ${registry.length} entries | Disk: ${actual.length} files\n`);
+
+  console.log(`📦 Active (${active.length})`);
+  for (const e of active) console.log(`   ✅ ${e.script} v${e.version}`);
+
+  if (deprecated.length > 0) {
+    console.log(`\n⚠️  Deprecated (${deprecated.length})`);
+    for (const e of deprecated) {
+      const expired = e.removalDate !== "—" && e.removalDate <= today;
+      const marker = expired ? "❌ EXPIRED" : "⏰";
+      console.log(`   ${marker} ${e.script} — removal: ${e.removalDate}`);
+    }
+  }
+
+  if (experimental.length > 0) {
+    console.log(`\n🧪 Experimental (${experimental.length})`);
+    for (const e of experimental) console.log(`   🔬 ${e.script} v${e.version}`);
+  }
+
+  if (advisories.length > 0) {
+    console.log(`\n🔒 Security Advisories (${advisories.length})`);
+    for (const e of advisories) console.log(`   🚨 ${e.script}: ${e.securityAdvisory}`);
+  }
+
+  if (unregistered.length > 0) {
+    console.log(`\n❓ Unregistered on disk (${unregistered.length})`);
+    for (const s of unregistered) console.log(`   ➕ ${s}`);
+  }
+
+  console.log();
+}
+
+// ── Entry Point ──────────────────────────────────────────────────────────────
+
+const args = process.argv.slice(2);
+
+if (args.includes("--generate")) {
+  generate();
+} else if (args.includes("--report")) {
+  report();
+} else if (args.includes("--verify") || args.length === 0) {
+  const ok = verify();
+  process.exit(ok ? 0 : 1);
+} else {
+  console.error(`Usage: bun scripts/verify-scripts.ts [--verify | --generate | --report]`);
+  process.exit(1);
+}


### PR DESCRIPTION
## Summary
- Introduces L0/L1/L2 script ownership model with formal registry and automated drift detection
- `SCRIPTS.md`: dual-section registry (machine-readable + human-readable) for all 24 L0 scripts
- `verify-scripts.ts`: pre-commit verifier with `--verify`, `--generate`, `--report` modes
- `CONSTITUTION.md §6.5`: governing rules for script lifecycle, deprecation, and security advisories

## Changes

| File | Action | Description |
|------|--------|-------------|
| `templates/common/scripts/SCRIPTS.md` | Created | L0 script registry — Registry + Guide dual sections |
| `scripts/verify-scripts.ts` | Created | Registry verifier: hard blocks on drift / expired removal-date / security advisory |
| `templates/common/scripts/verify-scripts.ts` | Created | L0 copy of verify-scripts.ts |
| `CONSTITUTION.md` | Modified | Added §6.5 Script Lifecycle Management |
| `CHANGELOG.md` | Modified | Updated entries (#95 confirmed, #TBD for this PR) |

## Lifecycle Model

```
L0: templates/common/scripts/  ← SSOT (this PR governs)
L1: scripts/                   ← workspace, sync from L0 on release
L2: <project>/scripts/         ← snapshot at project creation, independent after
```

## verify-scripts.ts Modes

| Flag | Use case | On failure |
|------|----------|------------|
| `--verify` | pre-commit / CI | exit 1 (hard block) |
| `--generate` | After adding scripts | Updates Registry, preserves metadata |
| `--report` | Manual status check | Human-readable summary, no exit code |

## Hard Block Conditions
- Script on disk not in Registry
- Script in Registry but not on disk
- `security-advisory` field is not `—`
- `status: deprecated` with `removal-date` in the past

## Test Plan
- [x] `bash scripts/audit.sh` passes
- [x] Template lifecycle validation passes (0 errors, 0 warnings)
- [x] Secret scan passes
- [x] CHANGELOG.md `[Unreleased]` updated
- [ ] Manual: `bun scripts/verify-scripts.ts --report` to confirm all 24 scripts listed

---
🤖 Generated with [Claude Code](https://claude.ai/claude-code)