### PR TITLE
fix: suppress git pull stderr false-positive in setup.ps1

### DIFF
--- a/templates/common/scripts/setup.ps1
+++ b/templates/common/scripts/setup.ps1
@@ -396,7 +396,7 @@ if (-not (Test-Path $SuperpowersDir)) {
 } else {
     Info "Gemini superpowers plugin already installed -- updating"
     Push-Location $SuperpowersDir
-    git pull origin main 2>$null
+    git pull origin main 2>&1 | Out-Null
     Pop-Location
 }
 


### PR DESCRIPTION
## Summary

- Changed `git pull origin main 2>$null` to `git pull origin main 2>&1 | Out-Null` in `templates/common/scripts/setup.ps1`
- git writes informational output to stderr even on success; `2>$null` does not fully suppress this in PowerShell 5.1 with `ErrorActionPreference=Stop`, causing a false `NativeCommandError`

## Test plan

- [ ] Run `.\scripts\new-project.ps1 "tetris"` — expect no NativeCommandError from git pull
- [ ] Confirm setup.ps1 completes cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)