### PR TITLE
fix: wrap git pull in try/catch to absorb PS5.1 NativeCommandError inheritance

### DIFF
--- a/memory/2026-05-27.md
+++ b/memory/2026-05-27.md
@@ -967,3 +967,45 @@ fix: resolve three scaffold errors in common template
 
 ## Open Issues
 - None
+
+---
+
+## Session Summary
+chore: add session memory logs for scaffold fix series
+
+## Changes
+- N/A
+
+## Decisions
+- None
+
+## Open Issues
+- None
+
+---
+
+## Session Summary
+fix: close 9 unclosed string literals in setup.ps1
+
+## Changes
+- `templates/common/scripts/setup.ps1`
+
+## Decisions
+- None
+
+## Open Issues
+- None
+
+---
+
+## Session Summary
+fix: suppress git pull stderr false-positive in setup.ps1
+
+## Changes
+- `templates/common/scripts/setup.ps1`
+
+## Decisions
+- None
+
+## Open Issues
+- None

--- a/templates/common/scripts/setup.ps1
+++ b/templates/common/scripts/setup.ps1
@@ -396,7 +396,7 @@ if (-not (Test-Path $SuperpowersDir)) {
 } else {
     Info "Gemini superpowers plugin already installed -- updating"
     Push-Location $SuperpowersDir
-    git pull origin main 2>&1 | Out-Null
+    try { git pull origin main 2>&1 | Out-Null } catch { }
     Pop-Location
 }
 


### PR DESCRIPTION
## Summary

- `setup.ps1` called `git pull origin main 2>&1 | Out-Null` inside an `else` block
- When `new-project.ps1` invokes `setup.ps1` via `&`, `ErrorActionPreference=Stop` is inherited
- `git pull` writes informational messages to stderr on success, triggering a `NativeCommandError` even though the command succeeded
- `2>&1 | Out-Null` is insufficient to suppress this under PS5.1 inheritance
- Fix: wrap the call in `try { ... } catch { }` to silently absorb the false-positive error

## Test plan

- [ ] Run `.\scripts\new-project.ps1 "test-proj"` from workspace root
- [ ] Verify setup.ps1 completes without NativeCommandError on the git pull step
- [ ] Verify CodeGraph initialization proceeds normally after git pull

🤖 Generated with [Claude Code](https://claude.com/claude-code)