### PR TITLE
fix: wrap all git native commands in try/catch to suppress NativeCommandError

### DIFF
--- a/templates/common/scripts/setup.ps1
+++ b/templates/common/scripts/setup.ps1
@@ -390,7 +390,7 @@ if (-not (Test-Path $SuperpowersDir)) {
     Info "Gemini superpowers plugin not found ??installing globally??"
     $PluginsDir = Join-Path $HOME ".gemini\config\plugins"
     if (-not (Test-Path $PluginsDir)) { New-Item -ItemType Directory -Path $PluginsDir -Force | Out-Null }
-    git clone https://github.com/obra/superpowers $SuperpowersDir 2>$null
+    try { git clone https://github.com/obra/superpowers $SuperpowersDir 2>&1 | Out-Null } catch { }
     if ($LASTEXITCODE -eq 0) { Pass "superpowers plugin installed successfully" }
     else { Warn "Failed to install superpowers plugin" }
 } else {
@@ -449,10 +449,10 @@ if (Test-Path $IndexPath) {
 
 # ???? 7. Initial commit ??????????????????????????????????????????????????????????????????????????????????????????????????????????????????
 if (-not $SkipCommit) {
-    $gitDir = git rev-parse --git-dir 2>$null
+    try { git rev-parse --git-dir 2>&1 | Out-Null } catch { }
     if ($LASTEXITCODE -eq 0) {
-        git add -A 2>$null
-        git commit -m $msg 2>$null
+        try { git add -A 2>&1 | Out-Null } catch { }
+        try { git commit -m $msg 2>&1 | Out-Null } catch { }
         if ($LASTEXITCODE -eq 0) { Pass "Initial commit created" } else { Warn "Nothing to commit (already committed?)" }
     } else { Warn "Not inside a git repository ??skipping initial commit" }
 } else { Info "Skipping initial commit (-SkipCommit)" }


### PR DESCRIPTION
## Summary

- Under PS5.1, `ErrorActionPreference=Stop` is inherited when `new-project.ps1` calls `setup.ps1` via `&`
- Any git command that writes to stderr (even on success) raises `NativeCommandError`, terminating the script
- Previous fix only covered `git pull`; `git clone`, `git rev-parse`, `git add`, and `git commit` had the same vulnerability
- Fix: replaced all remaining `2>$null` git calls with `try { ... 2>&1 | Out-Null } catch { }`

## Affected lines

| Command | Before | After |
|---------|--------|-------|
| `git clone` (line ~393) | `2>$null` | `try/catch` |
| `git rev-parse` (line ~452) | `2>$null` | `try/catch` |
| `git add -A` (line ~454) | `2>$null` | `try/catch` |
| `git commit` (line ~455) | `2>$null` | `try/catch` |

## Test plan

- [ ] Run `.\scripts\new-project.ps1 "test-proj"` from workspace root
- [ ] Verify no `NativeCommandError` appears anywhere in setup output
- [ ] Verify `[PASS] Initial commit created` is shown at the end

🤖 Generated with [Claude Code](https://claude.com/claude-code)