### PR TITLE
fix: setup.ps1 exit 0 + improve versioned-archive error message

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -118,6 +118,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - **[2026-05-25]**: docs: apply same README improvements to README_ko.md for bilingual consistency
 
 ### Fixed
+- **[2026-05-27]**: Wrap all git native commands in `setup.ps1` with `try/catch` to suppress PS5.1 `NativeCommandError` inheritance from `new-project.ps1` — affects `git clone`, `git rev-parse`, `git add`, `git commit` (`templates/common/scripts/setup.ps1`, #107, #108)
 - **[2026-05-25]**: feat: enhance memory log format - commit-msg hook now captures rich context (summary, file count, decisions, issues) from commit body instead of generic placeholders
 - **[2026-05-25]**: fix: resolve param syntax bug in powershell scripts
 

--- a/memory/2026-05-27.md
+++ b/memory/2026-05-27.md
@@ -1009,3 +1009,46 @@ fix: suppress git pull stderr false-positive in setup.ps1
 
 ## Open Issues
 - None
+
+---
+
+## Session Summary
+fix: wrap git pull in try/catch to absorb PS5.1 NativeCommandError inheritance
+
+## Changes
+- `templates/common/scripts/setup.ps1`
+
+## Decisions
+- None
+
+## Open Issues
+- None
+
+---
+
+## Session Summary
+fix: wrap all git native commands in try/catch to suppress NativeCommandError
+
+## Changes
+- `templates/common/scripts/setup.ps1`
+
+## Decisions
+- None
+
+## Open Issues
+- None
+
+---
+
+## Session Summary
+fix: resolve PS5.1 NativeCommandError inheritance in setup.ps1 git commands
+
+## Changes
+- `templates/common/scripts/setup.ps1` — replaced all remaining `2>$null` git calls (`clone`, `rev-parse`, `add`, `commit`) with `try { ... 2>&1 | Out-Null } catch { }` to fully suppress NativeCommandError under inherited ErrorActionPreference=Stop
+
+## Decisions
+- **Root cause confirmed as systemic**: PS5.1 `ErrorActionPreference=Stop` inherited from `new-project.ps1` via `&` operator causes any git stderr output (even on success) to raise `NativeCommandError`. `2>$null` is insufficient in this scenario — `try/catch` is the only reliable suppression mechanism.
+- **Applied uniformly**: Rather than patching one command at a time, all remaining git native calls in `setup.ps1` were converted to `try/catch` in a single PR (#108) to prevent recurrence.
+
+## Open Issues
+- None

--- a/scripts/new-project.ps1
+++ b/scripts/new-project.ps1
@@ -43,9 +43,11 @@ if ($Version -ne "") {
     $TempDir = [System.IO.Path]::GetTempPath() + [System.IO.Path]::GetRandomFileName()
     New-Item -ItemType Directory -Path $TempDir -Force | Out-Null
     # Extract BOTH common and variant from tag
-    git -C $WorkspaceRoot archive $Tag "templates/common/" "templates/$Variant/" | tar -x -C $TempDir 2>$null
+    $archiveOutput = git -C $WorkspaceRoot archive $Tag "templates/common/" "templates/$Variant/" 2>&1 | tar -x -C $TempDir 2>&1
     if ($LASTEXITCODE -ne 0) {
         Write-Host "❌ Failed to extract template version $Tag" -ForegroundColor Red
+        Write-Host "   This tag may predate the templates/common/ directory structure (introduced in v0.5.0)." -ForegroundColor Yellow
+        Write-Host "   Available versions with common/ support: run .\scripts\list-template-versions.ps1" -ForegroundColor Yellow
         Remove-Item $TempDir -Recurse -Force -ErrorAction SilentlyContinue
         exit 1
     }

--- a/templates/common/scripts/setup.ps1
+++ b/templates/common/scripts/setup.ps1
@@ -464,4 +464,5 @@ Write-Host "Next:" -ForegroundColor Cyan
 Write-Host "  git remote add origin <url>"
 Write-Host "  git push -u origin main"
 
+exit 0
 


### PR DESCRIPTION
## Summary

- `templates/common/scripts/setup.ps1`: add explicit `exit 0` at end — when `git commit` returns exit code 1 (nothing to commit), the script previously exited with code 1, causing `new-project.ps1` to display a false ⚠️ Setup error warning even though setup completed successfully
- `scripts/new-project.ps1`: improve error message when `git archive` fails for old tags (< v0.5.0) that predate the `templates/common/` directory structure

## Also pushed

- Tag `template-v0.5.0` — points to the commit that introduced `templates/common/` layer; now available for `.\scripts\new-project.ps1 "name" -Version 0.5.0`

## Test plan

- [ ] Run `.\scripts\new-project.ps1 "test-proj"` — verify no `⚠️ Setup encountered an error` at the end
- [ ] Run `.\scripts\new-project.ps1 "test-proj" -Version 0.5.0` — verify scaffold works with pinned version
- [ ] Run `.\scripts\new-project.ps1 "test-proj" -Version 0.4.0` — verify improved error message appears

🤖 Generated with [Claude Code](https://claude.com/claude-code)