### PR TITLE
fix: write git archive to temp file to avoid PowerShell binary pipe corruption

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -10,7 +10,7 @@
 *.jsx text
 *.tsx text
 *.json text
-*.md text
+*.md text eol=lf
 *.html text
 *.css text
 *.ps1 text

--- a/scripts/new-project.ps1
+++ b/scripts/new-project.ps1
@@ -43,11 +43,22 @@ if ($Version -ne "") {
     $TempDir = [System.IO.Path]::GetTempPath() + [System.IO.Path]::GetRandomFileName()
     New-Item -ItemType Directory -Path $TempDir -Force | Out-Null
     # Extract BOTH common and variant from tag
-    $archiveOutput = git -C $WorkspaceRoot archive $Tag "templates/common/" "templates/$Variant/" 2>&1 | tar -x -C $TempDir 2>&1
-    if ($LASTEXITCODE -ne 0) {
-        Write-Host "❌ Failed to extract template version $Tag" -ForegroundColor Red
+    # Note: PowerShell pipes corrupt binary streams, so write the tar archive to a temp file first
+    $TarFile = [System.IO.Path]::GetTempFileName() + ".tar"
+    git -C $WorkspaceRoot archive --format=tar $Tag "templates/common/" "templates/$Variant/" -o $TarFile 2>&1
+    if ($LASTEXITCODE -ne 0 -or -not (Test-Path $TarFile) -or (Get-Item $TarFile).Length -eq 0) {
+        Write-Host "❌ Failed to create archive for template version $Tag" -ForegroundColor Red
         Write-Host "   This tag may predate the templates/common/ directory structure (introduced in v0.5.0)." -ForegroundColor Yellow
         Write-Host "   Available versions with common/ support: run .\scripts\list-template-versions.ps1" -ForegroundColor Yellow
+        Remove-Item $TarFile -Force -ErrorAction SilentlyContinue
+        Remove-Item $TempDir -Recurse -Force -ErrorAction SilentlyContinue
+        exit 1
+    }
+    tar -x -C $TempDir -f $TarFile 2>&1
+    $tarExit = $LASTEXITCODE
+    Remove-Item $TarFile -Force -ErrorAction SilentlyContinue
+    if ($tarExit -ne 0) {
+        Write-Host "❌ Failed to extract template version $Tag" -ForegroundColor Red
         Remove-Item $TempDir -Recurse -Force -ErrorAction SilentlyContinue
         exit 1
     }


### PR DESCRIPTION
## Summary

- `scripts/new-project.ps1`: PowerShell pipes convert binary streams to strings, corrupting the tar archive from `git archive`. Fix: use `git archive --format=tar -o <tempfile>` then `tar -x -f <tempfile>` to avoid the pipe entirely.
- `.gitattributes`: add `eol=lf` to `*.md` rule so SKILL.md frontmatter is not CRLF-corrupted on Windows checkout (was breaking YAML frontmatter parser in skill-lifecycle-audit.ts)
- `skills/*.md`: normalize existing CRLF line endings to LF

## Root cause

```powershell
# Before (broken): PowerShell pipe corrupts binary tar stream
git archive ... | tar -x -C $TempDir
# After (fixed): write to temp file, extract from file
git archive --format=tar ... -o $TarFile
tar -x -C $TempDir -f $TarFile
```

## Test plan

- [ ] Run `.\scripts\new-project.ps1 "test" -Version 0.5.0` — verify scaffold succeeds
- [ ] Verify `bun scripts/skill-lifecycle-audit.ts` passes after fresh `git pull` on Windows

🤖 Generated with [Claude Code](https://claude.com/claude-code)