### PR TITLE
fix: new-project.ps1 now exits at workspace root to match SH behavior

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - **[2026-05-29]**: Meeting transcript: `memory/meeting-2026-05-28-script-pair-sync.md` — structural analysis of `intentional drift` policy flaw in `.sh`/`.ps1` horizontal sync; proposed `pair` field to SCRIPTS.md schema; 5 action items (A-01~A-05)
 
 ### Changed
+- **[2026-05-29]**: `scripts/new-project.ps1` — fixed final working directory to match SH behavior; script now exits at workspace root (not project directory) after saving original location; aligns with README instructions for manual `cd`
 - **[2026-05-29]**: `docs/getting-started.md` — removed redundant "Python 3 (Optional - Project-Specific)" section; simplified to avoid duplication with Optional Software section
 - **[2026-05-29]**: `README.md` — added "Project-Specific Tools" table; removed Python/uv from Optional Tools; clarified project-specific tool installation
 - **[2026-05-29]**: `docs/getting-started.md` — reclassified Python 3 from "essential" to "optional" (project-specific); updated prerequisites checklist to reflect Git + Bun as the only truly essential tools

--- a/scripts/new-project.ps1
+++ b/scripts/new-project.ps1
@@ -370,6 +370,7 @@ if (Get-Command "bun" -ErrorAction SilentlyContinue) {
 }
 
 # ── 5. Initialize git ──────────────────────────────────────────────────────────  # TEST: Test 4
+$OriginalLocation = Get-Location
 Set-Location $ProjectDir
 try { git init 2>&1 | Out-Null } catch { }
 git config core.hooksPath .githooks
@@ -441,6 +442,9 @@ if (-not $SecurityOk) {
 }
 Write-Host "  ✅ All security bootstrap checks passed" -ForegroundColor Green
 
+# ── Return to workspace root ───────────────────────────────────────────────────  # TEST: none
+Set-Location $OriginalLocation
+
 # ── 7. Post-scaffold audit ────────────────────────────────────────────────────  # TEST: none
 Write-Host ""
 Write-Host "Running post-scaffold audit..." -ForegroundColor Cyan
@@ -474,9 +478,6 @@ Write-Host "   cd '$ProjectDir'" -ForegroundColor Green
 Write-Host ""
 Write-Host "All subsequent work must be run from inside this directory."
 Write-Host ("=" * 60) -ForegroundColor DarkGray
-Write-Host ""
-
-Set-Location $ProjectDir
 Write-Host ""
 Write-Host "Extension templates (ADR, analyst agent, skill, daily log):" -ForegroundColor DarkGray
 Write-Host "  -> $TemplatesDir\docs\_examples" -ForegroundColor DarkGray


### PR DESCRIPTION
## Summary

Fixed inconsistent exit behavior between `new-project.sh` and `new-project.ps1`. Both scripts now exit at the workspace root, requiring users to manually `cd` into the project directory as documented in README.

## Problem

**Inconsistent Behavior:**
- `new-project.sh` exits at workspace root (`C:\git`)
- `new-project.ps1` exits at project directory (`C:\git\my-project`)

**Root Cause:**
- Bash: `cd` in scripts doesn't affect parent shell
- PowerShell: `Set-Location` in script affects current session

**Documentation Conflict:**
README.md instructs users to manually `cd` into the project directory:
```bash
# 2. Move into the newly created project folder
cd "my-project-name"
```

## Solution

**Modified `new-project.ps1`:**
1. Save original location before git operations: `$OriginalLocation = Get-Location`
2. Return to workspace root after all operations: `Set-Location $OriginalLocation`
3. Removed final `Set-Location $ProjectDir` that was auto-locating to project directory

**Changes:**
- Added `$OriginalLocation` capture before git init
- Added `Set-Location $OriginalLocation` after security bootstrap verification
- Removed auto-location to project directory at end of script

## Impact

✅ Both scripts now exit at workspace root (consistent behavior)
✅ Users must manually `cd` into project directory (as documented)
✅ Cross-platform consistency achieved
✅ Aligns with README Quick Start instructions

## Test Plan

- [ ] Run `pwsh scripts/new-project.ps1 "test-project"` on Windows
- [ ] Verify script exits at workspace root (not in project directory)
- [ ] Run `bash scripts/new-project.sh "test-project"` on Linux/Mac
- [ ] Verify both scripts have identical exit behavior
- [ ] Confirm README instructions match actual behavior

🤖 Generated with [Claude Code](https://claude.com/claude-code)