### PR TITLE
feat: portable workspace root detection for new-project.ps1

### DIFF
--- a/scripts/new-project.ps1
+++ b/scripts/new-project.ps1
@@ -105,7 +105,39 @@ if ($Platform -notin @("claude", "antigravity", "both")) {
     exit 1
 }
 
-$WorkspaceRoot = Split-Path $PSScriptRoot -Parent
+# ── Workspace Root Resolution ──────────────────────────────────────────────────────  # TEST: none
+# Priority 1: Environment variable (for portable deployment)
+if ($env:WORKSPACE_ROOT -and (Test-Path $env:WORKSPACE_ROOT)) {
+    $WorkspaceRoot = $env:WORKSPACE_ROOT
+    Write-Verbose "Using workspace root from environment: $WorkspaceRoot"
+}
+# Priority 2: Auto-detect by searching for templates/ folder
+else {
+    $CurrentDir = $PSScriptRoot
+    while ($CurrentDir -ne [System.IO.Path]::GetPathRoot($CurrentDir)) {
+        $TemplatesPath = Join-Path $CurrentDir "templates"
+        if ((Test-Path $TemplatesPath) -and (Test-Path (Join-Path $TemplatesPath "common"))) {
+            $WorkspaceRoot = $CurrentDir
+            Write-Verbose "Auto-detected workspace root: $WorkspaceRoot"
+            break
+        }
+        $CurrentDir = Split-Path $CurrentDir -Parent
+    }
+
+    # Priority 3: Fallback to script's parent directory
+    if (-not $WorkspaceRoot) {
+        $WorkspaceRoot = Split-Path $PSScriptRoot -Parent
+        Write-Verbose "Using fallback workspace root: $WorkspaceRoot"
+    }
+}
+
+# Verify workspace root is valid
+if (-not (Test-Path (Join-Path $WorkspaceRoot "templates/common"))) {
+    Write-Host "❌ Cannot find workspace templates folder." -ForegroundColor Red
+    Write-Host "   Set WORKSPACE_ROOT environment variable or run from workspace directory." -ForegroundColor Yellow
+    Write-Host "   Example: `$env:WORKSPACE_ROOT = 'C:\git'" -ForegroundColor Yellow
+    exit 1
+}
 $ProjectDir    = Join-Path $WorkspaceRoot $ProjectName
 $TemplatesDir  = Join-Path (Join-Path $WorkspaceRoot "templates") $Variant
 $CommonDir     = Join-Path (Join-Path $WorkspaceRoot "templates") "common"

--- a/scripts/new-project.ps1
+++ b/scripts/new-project.ps1
@@ -623,7 +623,7 @@ if ($LASTEXITCODE -eq 0 -and $hooksPath -match '\.githooks') {
 if (-not $SecurityOk) {
     Write-Host ""
     Write-Host "❌ Security bootstrap check FAILED. Fix the issues above before using this project." -ForegroundColor Red
-    Write-Host "   Run 'bun audit.ts' after fixing to verify." -ForegroundColor Yellow
+    Write-Host "   Run 'bun scripts/audit.ts' from workspace root after fixing to verify." -ForegroundColor Yellow
     exit 1
 }
 Write-Host "  ✅ All security bootstrap checks passed" -ForegroundColor Green
@@ -634,7 +634,7 @@ Set-Location $OriginalLocation
 # ── 7. Post-scaffold audit ────────────────────────────────────────────────────  # TEST: none
 Write-Host ""
 Write-Host "Running post-scaffold audit..." -ForegroundColor Cyan
-bun audit.ts
+& bun "$WorkspaceRoot/scripts/audit.ts"
 if ($LASTEXITCODE -eq 0) {
     Write-Host ""
     Write-Host "✅ Project '$ProjectName' scaffolded and verified at: $ProjectDir" -ForegroundColor Green


### PR DESCRIPTION
## Summary

Added flexible workspace root resolution to support running `new-project.ps1` from any location, not just from workspace root directory.

## Problem

Previously, the script assumed workspace root was always the parent directory of the script:
```powershell
$WorkspaceRoot = Split-Path $PSScriptRoot -Parent
```

This caused failures when:
- Running script from different directories: `C:\demo> C:\git\scripts\new-project.ps1 "name"`
- Copying script to other locations for portable use
- Workspace folder structure different from expected

## Solution

Implemented 3-tier workspace root detection:

**Priority 1: Environment Variable** (for portable deployment)
```powershell
$env:WORKSPACE_ROOT = "C:\git"
C:\demo\scripts\new-project.ps1 "my-project"
```

**Priority 2: Auto-detection** (searches for templates/common folder)
```powershell
# Automatically walks up directory tree until finding workspace
```

**Priority 3: Fallback** (original behavior)
```powershell
# Uses script's parent directory if detection fails
```

## Changes

- Added workspace root resolution logic with 3-tier priority system
- Added validation to verify workspace root is valid
- Provides clear error message with help when workspace cannot be found

## Test plan

- [x] Run from workspace root: `.\scripts\new-project.ps1 "test"` → ✅ Works
- [x] Run from different directory: `C:\demo> C:\git\scripts\new-project.ps1 "test"` → ✅ Works
- [x] With environment variable: `$env:WORKSPACE_ROOT = "C:\git"; .\scripts\new-project.ps1 "test"` → ✅ Works
- [x] Validates workspace root with clear error messages
- [x] Pre-commit hooks pass
- [x] Integration tests pass

## Usage Examples

**From workspace root:**
```powershell
PS C:\git> .\scripts\new-project.ps1 "my-project"
```

**From any directory:**
```powershell
PS C:\demo> C:\git\scripts\new-project.ps1 "my-project"
```

**With portable deployment:**
```powershell
PS C:\anywhere> $env:WORKSPACE_ROOT = "C:\git"
PS C:\anywhere> .\scripts\new-project.ps1 "my-project"
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)