### PR TITLE
refactor: use current directory as workspace root

### DIFF
--- a/scripts/new-project.ps1
+++ b/scripts/new-project.ps1
@@ -105,7 +105,39 @@ if ($Platform -notin @("claude", "antigravity", "both")) {
     exit 1
 }
 
-$WorkspaceRoot = Split-Path $PSScriptRoot -Parent
+# ── Workspace Root Resolution ──────────────────────────────────────────────────────  # TEST: none
+# Priority 1: Environment variable (for portable deployment)
+if ($env:WORKSPACE_ROOT -and (Test-Path $env:WORKSPACE_ROOT)) {
+    $WorkspaceRoot = $env:WORKSPACE_ROOT
+    Write-Verbose "Using workspace root from environment: $WorkspaceRoot"
+}
+# Priority 2: Auto-detect by searching for templates/ folder
+else {
+    $CurrentDir = $PSScriptRoot
+    while ($CurrentDir -ne [System.IO.Path]::GetPathRoot($CurrentDir)) {
+        $TemplatesPath = Join-Path $CurrentDir "templates"
+        if ((Test-Path $TemplatesPath) -and (Test-Path (Join-Path $TemplatesPath "common"))) {
+            $WorkspaceRoot = $CurrentDir
+            Write-Verbose "Auto-detected workspace root: $WorkspaceRoot"
+            break
+        }
+        $CurrentDir = Split-Path $CurrentDir -Parent
+    }
+
+    # Priority 3: Fallback to script's parent directory
+    if (-not $WorkspaceRoot) {
+        $WorkspaceRoot = Split-Path $PSScriptRoot -Parent
+        Write-Verbose "Using fallback workspace root: $WorkspaceRoot"
+    }
+}
+
+# Verify workspace root is valid
+if (-not (Test-Path (Join-Path $WorkspaceRoot "templates/common"))) {
+    Write-Host "❌ Cannot find workspace templates folder." -ForegroundColor Red
+    Write-Host "   Set WORKSPACE_ROOT environment variable or run from workspace directory." -ForegroundColor Yellow
+    Write-Host "   Example: `$env:WORKSPACE_ROOT = 'C:\git'" -ForegroundColor Yellow
+    exit 1
+}
 $ProjectDir    = Join-Path $WorkspaceRoot $ProjectName
 $TemplatesDir  = Join-Path (Join-Path $WorkspaceRoot "templates") $Variant
 $CommonDir     = Join-Path (Join-Path $WorkspaceRoot "templates") "common"

--- a/scripts/new-project.ps1
+++ b/scripts/new-project.ps1
@@ -623,7 +623,7 @@ if ($LASTEXITCODE -eq 0 -and $hooksPath -match '\.githooks') {
 if (-not $SecurityOk) {
     Write-Host ""
     Write-Host "❌ Security bootstrap check FAILED. Fix the issues above before using this project." -ForegroundColor Red
-    Write-Host "   Run 'bun audit.ts' after fixing to verify." -ForegroundColor Yellow
+    Write-Host "   Run 'bun scripts/audit.ts' from workspace root after fixing to verify." -ForegroundColor Yellow
     exit 1
 }
 Write-Host "  ✅ All security bootstrap checks passed" -ForegroundColor Green
@@ -634,7 +634,7 @@ Set-Location $OriginalLocation
 # ── 7. Post-scaffold audit ────────────────────────────────────────────────────  # TEST: none
 Write-Host ""
 Write-Host "Running post-scaffold audit..." -ForegroundColor Cyan
-bun audit.ts
+& bun "$WorkspaceRoot/scripts/audit.ts"
 if ($LASTEXITCODE -eq 0) {
     Write-Host ""
     Write-Host "✅ Project '$ProjectName' scaffolded and verified at: $ProjectDir" -ForegroundColor Green

--- a/scripts/new-project.ps1
+++ b/scripts/new-project.ps1
@@ -106,38 +106,9 @@ if ($Platform -notin @("claude", "antigravity", "both")) {
 }
 
 # ── Workspace Root Resolution ──────────────────────────────────────────────────────  # TEST: none
-# Priority 1: Environment variable (for portable deployment)
-if ($env:WORKSPACE_ROOT -and (Test-Path $env:WORKSPACE_ROOT)) {
-    $WorkspaceRoot = $env:WORKSPACE_ROOT
-    Write-Verbose "Using workspace root from environment: $WorkspaceRoot"
-}
-# Priority 2: Auto-detect by searching for templates/ folder
-else {
-    $CurrentDir = $PSScriptRoot
-    while ($CurrentDir -ne [System.IO.Path]::GetPathRoot($CurrentDir)) {
-        $TemplatesPath = Join-Path $CurrentDir "templates"
-        if ((Test-Path $TemplatesPath) -and (Test-Path (Join-Path $TemplatesPath "common"))) {
-            $WorkspaceRoot = $CurrentDir
-            Write-Verbose "Auto-detected workspace root: $WorkspaceRoot"
-            break
-        }
-        $CurrentDir = Split-Path $CurrentDir -Parent
-    }
-
-    # Priority 3: Fallback to script's parent directory
-    if (-not $WorkspaceRoot) {
-        $WorkspaceRoot = Split-Path $PSScriptRoot -Parent
-        Write-Verbose "Using fallback workspace root: $WorkspaceRoot"
-    }
-}
-
-# Verify workspace root is valid
-if (-not (Test-Path (Join-Path $WorkspaceRoot "templates/common"))) {
-    Write-Host "❌ Cannot find workspace templates folder." -ForegroundColor Red
-    Write-Host "   Set WORKSPACE_ROOT environment variable or run from workspace directory." -ForegroundColor Yellow
-    Write-Host "   Example: `$env:WORKSPACE_ROOT = 'C:\git'" -ForegroundColor Yellow
-    exit 1
-}
+# Use current working directory as workspace root (portable deployment)
+$WorkspaceRoot = $PWD
+Write-Verbose "Using current directory as workspace root: $WorkspaceRoot"
 $ProjectDir    = Join-Path $WorkspaceRoot $ProjectName
 $TemplatesDir  = Join-Path (Join-Path $WorkspaceRoot "templates") $Variant
 $CommonDir     = Join-Path (Join-Path $WorkspaceRoot "templates") "common"


### PR DESCRIPTION
## Summary

Simplified workspace root resolution to always use current working directory (`$PWD`), enabling true portable deployment.

## Problem

Previous implementation had complex 3-tier workspace detection logic:
1. Environment variable
2. Auto-detect by searching for templates/ folder  
3. Fallback to script's parent directory

This was over-engineered for the actual use case.

## Solution

**Always use current working directory as workspace root:**
```powershell
$WorkspaceRoot = $PWD
```

**Benefits:**
- Simple and predictable behavior
- True portability: copy entire workspace anywhere
- No environment variables needed
- No complex directory traversal

## Changes

- Removed 32 lines of complex detection logic
- Replaced with single line: `$WorkspaceRoot = $PWD`
- Reduces from 3-tier priority to simple rule: "where you run = workspace root"

## Usage

**From workspace root:**
```powershell
PS C:\workspace> .\scripts\new-project.ps1 "my-project"
```

**From copied workspace (portable deployment):**
```powershell
PS C:\demo> .\scripts\new-project.ps1 "my-project"
```

**Requirements for portable deployment:**
All workspace files must be copied:
- `templates/` folder
- `scripts/*.ts` files (dependencies)
- `workspace-schema.json`
- `.githooks/` (if using git hooks)

## Test plan

- [x] Run from workspace root: Works
- [x] Simple implementation: Reduced from 32 lines to 3 lines
- [x] Pre-commit hooks pass
- [x] Integration tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)