### PR TITLE
fix: resolve script paths relative to __dirname, not cwd

### DIFF
--- a/scripts/SCRIPTS.md
+++ b/scripts/SCRIPTS.md
@@ -71,7 +71,8 @@ All scripts in this workspace follow a Hybrid Scripting Architecture divided int
 | `retry-handler.ts` | L0 | 1.0.0 | active | — | — | — | — |
 | `sync-agent-status.ts` | L0 | 1.0.0 | active | — | — | — | — |
 | `sync-skill-status.ts` | L0 | 1.0.0 | active | — | — | — | — |
-| `validate-templates.ts` | L1 | 1.0.0 | active | — | — | — | — |
+| `validate-templates.ts` | L1 | 1.0.1 | active | — | — | — | — |
+| `helpers/lifecycle-governance.ts` | L0 | 1.0.1 | active | — | — | — | — |
 | `verify-readme-sync.ts` | L1 | 1.0.1 | active | — | — | — | — |
 | `translate-readme.ts` | L0 | 1.0.0 | active | — | — | — | — |
 | `verify-agent-deliverables.ts` | L0 | 1.0.0 | active | — | — | — | — |

--- a/scripts/helpers/lifecycle-governance.ts
+++ b/scripts/helpers/lifecycle-governance.ts
@@ -9,9 +9,11 @@
  */
 
 import { readFileSync } from 'node:fs';
-import { join } from 'node:path';
+import { join, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
 
-const governancePath = join(process.cwd(), 'templates', 'common', 'lifecycle-governance.json');
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const governancePath = join(__dirname, '..', '..', 'templates', 'common', 'lifecycle-governance.json');
 
 try {
   const content = readFileSync(governancePath, 'utf-8');

--- a/scripts/validate-templates.ts
+++ b/scripts/validate-templates.ts
@@ -13,7 +13,7 @@
 
 import { readFileSync, writeFileSync, existsSync, readdirSync, statSync } from 'node:fs';
 import { join, dirname, resolve } from 'node:path';
-import { cwd } from 'node:process';
+import { fileURLToPath } from 'node:url';
 import { load } from 'js-yaml';
 
 interface VariantManifest {
@@ -54,15 +54,12 @@ const colors = {
   dim: '\x1b[2m',
 };
 
-const ROOT = cwd();
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const ROOT = resolve(__dirname, '..');
 const TEMPLATES_DIR = join(ROOT, 'templates');
 
-// Guard: must be run from workspace root (where templates/ directory exists)
 if (!existsSync(TEMPLATES_DIR)) {
-  console.error(`\x1b[31m[ERROR] validate-templates.ts must be run from the workspace root.\x1b[0m`);
-  console.error(`        Current directory: ${ROOT}`);
-  console.error(`        Expected: a directory containing templates/`);
-  console.error(`        Usage: cd <workspace-root> && bun scripts/validate-templates.ts`);
+  console.error(`\x1b[31m[ERROR] templates/ directory not found at: ${TEMPLATES_DIR}\x1b[0m`);
   process.exit(1);
 }
 


### PR DESCRIPTION
## Summary

- `scripts/helpers/lifecycle-governance.ts` and `scripts/validate-templates.ts` used `process.cwd()` to resolve the `templates/` directory path
- When `new-project.sh` invokes these scripts from outside the workspace root (e.g. `/mnt/c/demo`), `bun` could not find `package.json` / `node_modules` and hung indefinitely
- Fixed by replacing `process.cwd()` with `import.meta.url`-based `__dirname` so paths are always resolved relative to the script file itself

## Test plan

- [ ] Run `bash scripts/new-project.sh "test-project" --variant co-design` from a directory other than workspace root — should no longer hang
- [ ] Run `bun scripts/validate-templates.ts` from workspace root — existing behavior unchanged
- [ ] Run `bun scripts/helpers/lifecycle-governance.ts` from any directory — outputs `variant,agent,skill`

🤖 Generated with [Claude Code](https://claude.com/claude-code)