### PR TITLE
chore: update

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -26,7 +26,7 @@ jobs:
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
 
       - name: Setup Bun
-        uses: oven-sh/setup-bun@4bc047ad317be86e772e62e09a80d557c476c58a # v2
+        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
         with:
           bun-version: latest
 

--- a/memory/2026-05-30.md
+++ b/memory/2026-05-30.md
@@ -809,3 +809,17 @@ chore: update
 
 ## Open Issues
 - None
+
+---
+
+## Session Summary
+chore: update
+
+## Changes
+- `M .github/workflows/test.yml` — modified
+
+## Decisions
+- None
+
+## Open Issues
+- None


### PR DESCRIPTION
Failed to authenticate. API Error: 401 Invalid bearer token