### PR TITLE
feat: improve template flexibility with {{PROJECT_NAME}} placeholder

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,6 +58,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Fixed
 - **[2026-05-30]**: Language policy violation — resolved `scripts/TRANSLATOR_GUIDE.md` Korean documentation by integrating into `skills/translate/SKILL.md` with English primary + Korean section
 - **[2026-05-30]**: Agent "report forgery" incident — `translate-readme.ts` reported as complete but file not created; implemented verification to prevent recurrence via Tier 2 Sentinel
+- **[2026-05-31]**: Template README titles — replaced hardcoded titles in co-develop, co-security, co-work README.md with {{PROJECT_NAME}} placeholder for better template flexibility
+- **[2026-05-31]**: Documentation — added meeting transcript for PR sync conflict resolution (finishing-a-development-branch vs /sync workflow)
 
 ### Added
 - **[2026-05-30]**: feat: implement TS-based hooks and template synchronization

--- a/CHANGELOG_ENTRY.md
+++ b/CHANGELOG_ENTRY.md
@@ -1,0 +1,4 @@
+### Fixed
+
+- **Templates**: Replace hardcoded titles in co-develop, co-security, co-work README.md with {{PROJECT_NAME}} placeholder for better template flexibility
+- **Documentation**: Add meeting transcript for PR sync conflict resolution (finishing-a-development-branch vs /sync workflow)

--- a/memory/2026-05-31.md
+++ b/memory/2026-05-31.md
@@ -1378,3 +1378,22 @@ fix(lifecycle): stabilize new-project tests and sync templates
 
 ## Open Issues
 - None
+
+---
+
+## Session Summary
+feat: improve template flexibility with {{PROJECT_NAME}} placeholder
+
+## Changes
+- `M CHANGELOG.md` — modified
+- `memory/meeting-2026-05-31-pr-sync-conflict.md` — modified
+- `templates/co-develop/README.md` — modified
+- `templates/co-security/README.md` — modified
+- `templates/co-work/README.md` — modified
+- `CHANGELOG_ENTRY.md` — modified
+
+## Decisions
+- None
+
+## Open Issues
+- None

--- a/memory/meeting-2026-05-31-pr-sync-conflict.md
+++ b/memory/meeting-2026-05-31-pr-sync-conflict.md
@@ -1,0 +1,41 @@
+# Meeting Transcript
+**Date**: 2026-05-31
+**Topic**: Resolve conflict between finishing-a-development-branch skill and /sync command
+**Participants**: architect, auditor, lifecycle-manager
+**Rounds**: 2
+**Language**: English (transcript always saved in English)
+**Status**: Complete
+
+---
+
+## Transcript
+
+**[architect]**: (Round 1)
+The issue we're seeing is that we have two mechanisms handling the end of a development lifecycle. `finishing-a-development-branch` prompts the agent to push and create a PR via `gh pr create`. At the same time, our pre-commit hook enforces the use of `/sync` (which runs `dev-sync.ts`), and that script itself creates a PR and pushes changes. Having both creates a race condition and duplicates effort, as we saw when the hook rejected manual commits. I propose we deprecate PR creation from `finishing-a-development-branch` and delegate all commit/push/PR responsibilities to `dev-sync.ts`.
+
+**[auditor]**: (Round 1)
+I agree with architect. From a compliance perspective, `dev-sync.ts` guarantees that `audit.ts` runs, that session logs are appended, and that the pre-commit hook checks for English-only Markdown. If agents bypass `/sync` and use `finishing-a-development-branch` to push directly, they might bypass these critical workspace audits. Therefore, `finishing-a-development-branch` should only handle the local environment cleanup (e.g., merging locally, discarding worktrees) or simply instruct the user to run `/sync` for pushing and PR creation.
+
+**[lifecycle-manager]**: (Round 1)
+Building on both of your points, the `/sync` workflow is fundamental to our artifact lifecycle. If we remove Option 2 (Create PR) from `finishing-a-development-branch`, we need to replace it with clear instructions to use `/sync`. Option 1 (Merge locally) and Option 4 (Discard) are still valid for local branch management. We should update the skill `SKILL.md` to remove `gh pr create` and explicitly state that PRs and remote syncing must be handled strictly by `/sync`.
+
+**[architect]**: (Round 2)
+Yes, specifically, we should modify Step 4 and Step 5 of `finishing-a-development-branch`. 
+- Option 2 becomes: "Stage changes and run /sync to create a PR".
+- Step 5 for Option 2 should remove the `git push` and `gh pr create` bash commands, and instead just guide the agent to use the `/sync` slash command. This streamlines the architecture and centralizes version control operations into a single robust pipeline.
+
+**[auditor]**: (Round 2)
+We also need to update `.gemini/commands/sync.md` and `.claude/commands/sync.md` if necessary, just to explicitly state that it is the *exclusive* method for creating PRs. However, just patching the skill is the most direct fix to the conflict. We should update `templates/common/skills/finishing-a-development-branch/SKILL.md`.
+
+**[lifecycle-manager]**: (Round 2)
+I will ensure that after we modify `finishing-a-development-branch/SKILL.md`, the version is bumped, and the registry `SCRIPTS.md` (or in this case, `skills/` README) is updated as per our lifecycle rules. 
+
+**[auditor]**: (Synthesis)
+Points of Agreement:
+- There is a functional overlap and compliance risk with two separate PR creation methods.
+- `dev-sync.ts` (via `/sync`) is the authoritative pipeline because it enforces audits and memory tracking.
+- `finishing-a-development-branch` should not directly execute `git push` or `gh pr create`.
+
+Next Action Items:
+1. **Architect**: Modify `finishing-a-development-branch/SKILL.md` to replace the direct PR creation logic with instructions to use `/sync`. (High)
+2. **Lifecycle-Manager**: Update the lifecycle metadata for the modified skill. (Medium)

--- a/templates/co-develop/README.md
+++ b/templates/co-develop/README.md
@@ -3,7 +3,7 @@ content_hash: PLACEHOLDER
 sync_version: 1
 ---
 
-# Co-Develop Template
+# {{PROJECT_NAME}}
 
 AI-assisted software development workspace template. Optimized for collaborative coding with Claude and Gemini AI assistants using a multi-agent architecture.
 

--- a/templates/co-security/README.md
+++ b/templates/co-security/README.md
@@ -3,7 +3,7 @@ content_hash: PLACEHOLDER
 sync_version: 1
 ---
 
-# Co-Security Template
+# {{PROJECT_NAME}}
 
 AI-assisted security engagement workspace template. Optimized for Red Team operations, threat modeling, and cross-platform patch automation with a structured multi-agent architecture.
 

--- a/templates/co-work/README.md
+++ b/templates/co-work/README.md
@@ -3,7 +3,7 @@ content_hash: PLACEHOLDER
 sync_version: 1
 ---
 
-# co-work variant
+# {{PROJECT_NAME}}
 
 > **Status**: Stable — v1.0.0
 


### PR DESCRIPTION
## Why
Templates previously used hardcoded project names, making them less reusable across different project types. This change introduces a `{{PROJECT_NAME}}` placeholder variable that gets dynamically replaced during project scaffolding, improving template flexibility and maintainability.

## What Changed
- Introduced `{{PROJECT_NAME}}` placeholder in template README files
- Updated `templates/co-develop/README.md`, `templates/co-security/README.md`, and `templates/co-work/README.md` to use the placeholder
- Added changelog entry documenting the improvement
- Recorded implementation notes in daily memory log

## Test Plan
- [ ] `bash scripts/audit.sh` passes
- [ ] Manual test: Create a new project using each affected template (co-develop, co-security, co-work) and verify `{{PROJECT_NAME}}` is correctly replaced in generated README

## Security Checklist
- [ ] No secrets, credentials, or API keys committed
- [ ] No `.env` files staged (use `.env.sample` for templates)
- [ ] Dependencies unchanged or reviewed for new CVEs

## Notes
None