### PR TITLE
fix: use Bun stdin stream for cross-platform tag push detection in pre-push hook

### DIFF
--- a/docs/VERSION_MANIFEST.md
+++ b/docs/VERSION_MANIFEST.md
@@ -1,6 +1,6 @@
 # VERSION_MANIFEST.md
 
-**Generated**: 2026-06-01T04:32:04.990Z
+**Generated**: 2026-06-01T04:34:27.859Z
 **Manifest Version**: 1.0
 **Location**: docs\VERSION_MANIFEST.md
 

--- a/memory/2026-06-01.md
+++ b/memory/2026-06-01.md
@@ -990,3 +990,20 @@ fix: allow tag pushes in pre-push hook + add list-template-versions.ps1
 
 ## Open Issues
 - None
+
+---
+
+## Session Summary
+fix: use Bun stdin stream for cross-platform tag push detection in pre-push hook
+
+## Changes
+- `M scripts/SCRIPTS.md` — modified
+- `scripts/hooks/pre-push.ts` — modified
+- `templates/common/scripts/SCRIPTS.md` — modified
+- `templates/common/scripts/hooks/pre-push.ts` — modified
+
+## Decisions
+- None
+
+## Open Issues
+- None

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -95,7 +95,7 @@ All scripts in this workspace follow a Hybrid Scripting Architecture divided int
 | `test-runner.ts` | L0 | 1.0.1 | active | — | — | common | — |
 | `validate-md-language.ts` | L0 | 1.0.1 | active | — | — | common | — |
 | `hooks/pre-commit.ts` | L0 | 1.2.0 | active | — | — | common | — |
-| `hooks/pre-push.ts` | L0 | 1.1.0 | active | — | — | common | — |
+| `hooks/pre-push.ts` | L0 | 1.2.0 | active | — | — | common | — |
 | `hooks/post-write-lifecycle-check.ts` | L0 | 1.0.0 | active | — | — | common | — |
 | `validate-model-registry.ts` | L0 | 1.0.1 | active | — | — | L0-only | workspace-only: references docs/workspace-schema.json |
 | `verify-platform-lifecycle.ts` | L0 | 1.0.0 | active | — | — | common | — |

--- a/scripts/SCRIPTS.md
+++ b/scripts/SCRIPTS.md
@@ -98,7 +98,7 @@ All scripts in this workspace follow a Hybrid Scripting Architecture divided int
 | `test-runner.ts` | L0 | 1.0.1 | active | — | — | common | — |
 | `validate-md-language.ts` | L0 | 1.0.1 | active | — | — | common | — |
 | `hooks/pre-commit.ts` | L0 | 1.2.0 | active | — | — | common | — |
-| `hooks/pre-push.ts` | L0 | 1.1.0 | active | — | — | common | — |
+| `hooks/pre-push.ts` | L0 | 1.2.0 | active | — | — | common | — |
 | `hooks/post-write-lifecycle-check.ts` | L0 | 1.0.0 | active | — | — | common | — |
 | `validate-model-registry.ts` | L0 | 1.0.1 | active | — | — | L0-only | workspace-only: references docs/workspace-schema.json |
 | `verify-platform-lifecycle.ts` | L0 | 1.0.0 | active | — | — | common | — |

--- a/scripts/hooks/pre-push.ts
+++ b/scripts/hooks/pre-push.ts
@@ -1,7 +1,7 @@
 #!/usr/bin/env bun
 /**
  * pre-push.ts — TS-based pre-push hook.
- * @version 1.1.0
+ * @version 1.2.0
  */
 
 import { $ } from "bun";
@@ -9,12 +9,16 @@ import { $ } from "bun";
 // Read stdin to determine what refs are being pushed.
 // Format per line: <local ref> <local sha1> <remote ref> <remote sha1>
 // Tag pushes have local ref like "refs/tags/..." — skip branch protection for those.
-function isTagOnlyPush(): boolean {
+async function isTagOnlyPush(): Promise<boolean> {
   try {
-    const stdin = require("fs").readFileSync("/dev/stdin", "utf8").trim();
+    const chunks: Buffer[] = [];
+    for await (const chunk of Bun.stdin.stream()) {
+      chunks.push(Buffer.from(chunk));
+    }
+    const stdin = Buffer.concat(chunks).toString("utf8").trim();
     if (!stdin) return false;
     const lines = stdin.split("\n").filter(Boolean);
-    return lines.length > 0 && lines.every(line => line.startsWith("refs/tags/") || line.split(" ")[0]?.startsWith("refs/tags/"));
+    return lines.length > 0 && lines.every(line => line.split(" ")[0]?.startsWith("refs/tags/"));
   } catch {
     return false;
   }
@@ -39,7 +43,7 @@ async function main() {
   }
 
   // Tag-only pushes bypass the branch protection check — tags are not commits to main.
-  if (isTagOnlyPush()) return;
+  if (await isTagOnlyPush()) return;
 
   const branch = await $`git rev-parse --abbrev-ref HEAD`.text();
   if (branch.trim() === "main" || branch.trim() === "master") {

--- a/templates/common/scripts/README.md
+++ b/templates/common/scripts/README.md
@@ -95,7 +95,7 @@ All scripts in this workspace follow a Hybrid Scripting Architecture divided int
 | `test-runner.ts` | L0 | 1.0.1 | active | — | — | common | — |
 | `validate-md-language.ts` | L0 | 1.0.1 | active | — | — | common | — |
 | `hooks/pre-commit.ts` | L0 | 1.2.0 | active | — | — | common | — |
-| `hooks/pre-push.ts` | L0 | 1.1.0 | active | — | — | common | — |
+| `hooks/pre-push.ts` | L0 | 1.2.0 | active | — | — | common | — |
 | `hooks/post-write-lifecycle-check.ts` | L0 | 1.0.0 | active | — | — | common | — |
 | `validate-model-registry.ts` | L0 | 1.0.1 | active | — | — | L0-only | workspace-only: references docs/workspace-schema.json |
 | `verify-platform-lifecycle.ts` | L0 | 1.0.0 | active | — | — | common | — |

--- a/templates/common/scripts/SCRIPTS.md
+++ b/templates/common/scripts/SCRIPTS.md
@@ -97,7 +97,7 @@ All scripts in this workspace follow a Hybrid Scripting Architecture divided int
 | `test-runner.ts` | L0 | 1.0.1 | active | — | — | common | — |
 | `validate-md-language.ts` | L0 | 1.0.1 | active | — | — | common | — |
 | `hooks/pre-commit.ts` | L0 | 1.2.0 | active | — | — | common | — |
-| `hooks/pre-push.ts` | L0 | 1.1.0 | active | — | — | common | — |
+| `hooks/pre-push.ts` | L0 | 1.2.0 | active | — | — | common | — |
 | `hooks/post-write-lifecycle-check.ts` | L0 | 1.0.0 | active | — | — | common | — |
 | `validate-model-registry.ts` | L0 | 1.0.1 | active | — | — | L0-only | workspace-only: references docs/workspace-schema.json |
 | `verify-platform-lifecycle.ts` | L0 | 1.0.0 | active | — | — | common | — |

--- a/templates/common/scripts/hooks/pre-push.ts
+++ b/templates/common/scripts/hooks/pre-push.ts
@@ -1,7 +1,7 @@
 #!/usr/bin/env bun
 /**
  * pre-push.ts — TS-based pre-push hook.
- * @version 1.1.0
+ * @version 1.2.0
  */
 
 import { $ } from "bun";
@@ -9,12 +9,16 @@ import { $ } from "bun";
 // Read stdin to determine what refs are being pushed.
 // Format per line: <local ref> <local sha1> <remote ref> <remote sha1>
 // Tag pushes have local ref like "refs/tags/..." — skip branch protection for those.
-function isTagOnlyPush(): boolean {
+async function isTagOnlyPush(): Promise<boolean> {
   try {
-    const stdin = require("fs").readFileSync("/dev/stdin", "utf8").trim();
+    const chunks: Buffer[] = [];
+    for await (const chunk of Bun.stdin.stream()) {
+      chunks.push(Buffer.from(chunk));
+    }
+    const stdin = Buffer.concat(chunks).toString("utf8").trim();
     if (!stdin) return false;
     const lines = stdin.split("\n").filter(Boolean);
-    return lines.length > 0 && lines.every(line => line.startsWith("refs/tags/") || line.split(" ")[0]?.startsWith("refs/tags/"));
+    return lines.length > 0 && lines.every(line => line.split(" ")[0]?.startsWith("refs/tags/"));
   } catch {
     return false;
   }
@@ -39,7 +43,7 @@ async function main() {
   }
 
   // Tag-only pushes bypass the branch protection check — tags are not commits to main.
-  if (isTagOnlyPush()) return;
+  if (await isTagOnlyPush()) return;
 
   const branch = await $`git rev-parse --abbrev-ref HEAD`.text();
   if (branch.trim() === "main" || branch.trim() === "master") {


### PR DESCRIPTION
Failed to authenticate. API Error: 401 Invalid bearer token