### PR TITLE
docs: Sync memory log before PR merge

### DIFF
--- a/docs/VERSION_MANIFEST.md
+++ b/docs/VERSION_MANIFEST.md
@@ -1,6 +1,6 @@
 # VERSION_MANIFEST.md
 
-**Generated**: 2026-06-01T22:19:19.877Z
+**Generated**: 2026-06-01T22:20:26.926Z
 **Manifest Version**: 1.0
 **Location**: docs\VERSION_MANIFEST.md
 

--- a/memory/2026-06-01.md
+++ b/memory/2026-06-01.md
@@ -1926,3 +1926,17 @@ chore: Lifecycle bump for script modifications
 
 ## Open Issues
 - None
+
+---
+
+## Session Summary
+docs: Sync memory log before PR merge
+
+## Changes
+- `M memory/2026-06-02.md` — modified
+
+## Decisions
+- None
+
+## Open Issues
+- None

--- a/memory/2026-06-02.md
+++ b/memory/2026-06-02.md
@@ -123,3 +123,25 @@ chore: update
 
 ## Open Issues
 - None
+
+---
+
+## Session Summary
+chore: Lifecycle bump for script modifications
+
+## Changes
+- `docs/VERSION_MANIFEST.md`
+- `scripts/README.md`
+- `scripts/SCRIPTS.md`
+- `scripts/propagate-to-templates.ts`
+- `scripts/verify-platform-lifecycle.ts`
+- `templates/common/scripts/README.md`
+- `templates/common/scripts/SCRIPTS.md`
+- `templates/common/scripts/propagate-to-templates.ts`
+- `templates/common/scripts/verify-platform-lifecycle.ts`
+
+## Decisions
+- None
+
+## Open Issues
+- None


### PR DESCRIPTION
## Why
Synchronizing version manifest and memory logs before merging the PR to ensure documentation reflects the latest project state and daily activity records are current.

## What Changed
- Updated `docs/VERSION_MANIFEST.md` (1 deletion, 1 insertion)
- Added 14 lines to `memory/2026-06-01.md` with daily activity log
- Added 22 lines to `memory/2026-06-02.md` with daily activity log

## Test Plan
- [ ] `bash scripts/audit.sh` passes
- [ ] Memory log files formatted correctly per daily log structure

## Security Checklist
- [ ] No secrets, credentials, or API keys committed
- [ ] No `.env` files staged (use `.env.sample` for templates)
- [ ] Dependencies unchanged or reviewed for new CVEs

## Notes
None.