### PR TITLE
fix: correct L0/L1 script copying logic and terminology

### DIFF
--- a/docs/VERSION_MANIFEST.md
+++ b/docs/VERSION_MANIFEST.md
@@ -1,6 +1,6 @@
 # VERSION_MANIFEST.md
 
-**Generated**: 2026-06-02T11:56:57.283Z
+**Generated**: 2026-06-02T12:10:19.974Z
 **Manifest Version**: 1.0
 **Location**: docs\VERSION_MANIFEST.md
 
@@ -93,7 +93,7 @@
 | post-write-lifecycle-check.ts | N/A | scripts/hooks/post-write-lifecycle-check.ts | bun |
 | pre-commit.ts | N/A | scripts/hooks/pre-commit.ts | bun |
 | pre-push.ts | N/A | scripts/hooks/pre-push.ts | bun |
-| publish-to-template.ts | 1.3.0 | scripts/publish-to-template.ts | N/A |
+| publish-to-template.ts | 1.3.1 | scripts/publish-to-template.ts | N/A |
 | qa-gate.ts | N/A | scripts/qa-gate.ts | bun |
 | readme-lifecycle-audit.ts | N/A | scripts/readme-lifecycle-audit.ts | N/A |
 | retry-handler.ts | N/A | scripts/retry-handler.ts | N/A |

--- a/memory/2026-06-02.md
+++ b/memory/2026-06-02.md
@@ -3000,3 +3000,25 @@ docs: add CHANGELOG entries, session memlog, and ADR-0021/0022/0023 for platform
 
 ## Open Issues
 - None
+
+---
+
+## Session Summary
+fix: correct L0/L1 script copying logic and terminology
+
+## Changes
+- `M scripts/SCRIPTS.md` — modified
+- `scripts/publish-to-template.ts` — modified
+- `scripts/validate-templates.ts` — modified
+- `templates/co-design/scripts/publish-to-template.ts` — modified
+- `templates/co-develop/scripts/publish-to-template.ts` — modified
+- `templates/co-security/scripts/publish-to-template.ts` — modified
+- `templates/co-work/scripts/publish-to-template.ts` — modified
+- `templates/common/scripts/SCRIPTS.md` — modified
+- `templates/common/scripts/publish-to-template.ts` — modified
+
+## Decisions
+- None
+
+## Open Issues
+- None

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -54,7 +54,7 @@ All scripts in this workspace follow a Hybrid Scripting Architecture divided int
 | `sync-md.ts` | L0 | 1.2.0 | active | — | — | common | — |
 | `gen-pr-body.ts` | L0 | 1.0.0 | active | — | — | common | — |
 | `sync-skills.ts` | L0 | 1.1.0 | active | — | — | common | — |
-| `publish-to-template.ts` | L0 | 1.3.0 | active | — | — | common | — |
+| `publish-to-template.ts` | L0 | 1.3.1 | active | — | — | common | — |
 | `list-template-versions.ts` | L0 | 1.0.0 | active | — | — | common | — |
 | `qa-gate.ts` | L0 | 1.0.2 | active | — | — | common | — |
 | `agent-create.ts` | L0 | 1.0.0 | active | — | — | common | — |
@@ -75,7 +75,7 @@ All scripts in this workspace follow a Hybrid Scripting Architecture divided int
 | `retry-handler.ts` | L0 | 1.0.0 | active | — | — | common | — |
 | `sync-agent-status.ts` | L0 | 1.0.0 | active | — | — | common | — |
 | `sync-skill-status.ts` | L0 | 1.0.0 | active | — | — | common | — |
-| `validate-templates.ts` | L1 | 1.4.2 | active | — | — | L0-only | workspace-only: references docs/workspace-schema.json |
+| `validate-templates.ts` | L0 | 1.4.3 | active | — | — | L0-only | workspace-only: references docs/workspace-schema.json |
 | `helpers/lifecycle-governance.ts` | L0 | 1.0.1 | active | — | — | common | — |
 | `helpers/template-validation.ts` | L0 | 1.1.0 | active | — | — | common | — |
 | `helpers/inject-global-plugins.ts` | L0 | 1.0.0 | active | — | — | L0-only | — |
@@ -86,10 +86,10 @@ All scripts in this workspace follow a Hybrid Scripting Architecture divided int
 | `helpers/update-variant-lifecycle.ts` | L0 | 1.0.0 | active | — | — | L0-only | — |
 | `helpers/validate-output.ts` | L0 | 1.0.0 | active | — | — | L0-only | — |
 | `helpers/write-scripts-snapshot.ts` | L0 | 1.0.0 | active | — | — | L0-only | — |
-| `verify-readme-sync.ts` | L1 | 1.1.0 | active | — | — | common | — |
+| `verify-readme-sync.ts` | L0 | 1.1.0 | active | — | — | common | — |
 | `translate-readme.ts` | L0 | 1.0.0 | active | — | — | common | — |
 | `verify-agent-deliverables.ts` | L0 | 1.0.0 | active | — | — | common | — |
-| `verify-scripts.ts` | L1 | 1.0.0 | active | — | — | common | — |
+| `verify-scripts.ts` | L0 | 1.0.0 | active | — | — | common | — |
 | `test-new-project.ts` | L0 | 1.0.3 | active | — | — | common | — |
 | `check-pm-approval.ts` | L0 | 1.0.0 | deprecated | 2026-11-30 | — | common | — |
 | `verify-new-project-tests.ts` | L0 | 1.0.2 | active | — | — | common | — |

--- a/scripts/SCRIPTS.md
+++ b/scripts/SCRIPTS.md
@@ -56,7 +56,7 @@ All scripts in this workspace follow a Hybrid Scripting Architecture divided int
 | `sync-md.ts` | L0 | 1.2.0 | active | — | — | common | — |
 | `gen-pr-body.ts` | L0 | 1.0.0 | active | — | — | common | — |
 | `sync-skills.ts` | L0 | 1.1.0 | active | — | — | common | — |
-| `publish-to-template.ts` | L0 | 1.3.0 | active | — | — | common | — |
+| `publish-to-template.ts` | L0 | 1.3.1 | active | — | — | common | — |
 | `list-template-versions.ts` | L0 | 1.0.0 | active | — | — | common | — |
 | `qa-gate.ts` | L0 | 1.0.2 | active | — | — | common | — |
 | `agent-create.ts` | L0 | 1.0.0 | active | — | — | common | — |
@@ -77,7 +77,7 @@ All scripts in this workspace follow a Hybrid Scripting Architecture divided int
 | `retry-handler.ts` | L0 | 1.0.0 | active | — | — | common | — |
 | `sync-agent-status.ts` | L0 | 1.0.0 | active | — | — | common | — |
 | `sync-skill-status.ts` | L0 | 1.0.0 | active | — | — | common | — |
-| `validate-templates.ts` | L1 | 1.4.2 | active | — | — | L0-only | workspace-only: references docs/workspace-schema.json |
+| `validate-templates.ts` | L0 | 1.4.3 | active | — | — | L0-only | workspace-only: references docs/workspace-schema.json |
 | `helpers/lifecycle-governance.ts` | L0 | 1.0.1 | active | — | — | common | — |
 | `helpers/template-validation.ts` | L0 | 1.1.0 | active | — | — | common | — |
 | `helpers/inject-global-plugins.ts` | L0 | 1.0.0 | active | — | — | L0-only | — |
@@ -88,10 +88,10 @@ All scripts in this workspace follow a Hybrid Scripting Architecture divided int
 | `helpers/update-variant-lifecycle.ts` | L0 | 1.0.0 | active | — | — | L0-only | — |
 | `helpers/validate-output.ts` | L0 | 1.0.0 | active | — | — | L0-only | — |
 | `helpers/write-scripts-snapshot.ts` | L0 | 1.0.0 | active | — | — | L0-only | — |
-| `verify-readme-sync.ts` | L1 | 1.1.0 | active | — | — | common | — |
+| `verify-readme-sync.ts` | L0 | 1.1.0 | active | — | — | common | — |
 | `translate-readme.ts` | L0 | 1.0.0 | active | — | — | common | — |
 | `verify-agent-deliverables.ts` | L0 | 1.0.0 | active | — | — | common | — |
-| `verify-scripts.ts` | L1 | 1.0.0 | active | — | — | common | — |
+| `verify-scripts.ts` | L0 | 1.0.0 | active | — | — | common | — |
 | `test-new-project.ts` | L0 | 1.0.3 | active | — | — | common | — |
 | `check-pm-approval.ts` | L0 | 1.0.0 | deprecated | 2026-11-30 | — | common | — |
 | `verify-new-project-tests.ts` | L0 | 1.0.2 | active | — | — | common | — |

--- a/scripts/publish-to-template.ts
+++ b/scripts/publish-to-template.ts
@@ -1,7 +1,7 @@
 #!/usr/bin/env bun
 // publish-to-template.ts — Publishes L0 scripts and skills to L1 (templates/common) and propagates to L2 (templates/co-*)
 // Usage: bun run scripts/publish-to-template.ts [--dry-run] [--domain <name>] [--docs]
-// @version 1.3.0
+// @version 1.3.1
 
 import * as fs from 'node:fs';
 import * as path from 'node:path';
@@ -92,9 +92,9 @@ for (const line of registryLines) {
   if (cols.length < 4) continue;
   const script = cols[1].trim().replace(/`/g, '');
   const source = cols[2].trim();
-  const drift  = cols.length >= 8 ? cols[7].trim() : '—';
+  const layer  = cols.length >= 8 ? cols[7].trim() : '—';
   if (source !== 'L0') continue;
-  if (drift === 'intentional') continue;
+  if (layer.includes('L0-only')) continue;
   if (!script) continue;
   const src = path.join(l0Dir, script);
   const dst = path.join(l1Dir, script);

--- a/scripts/validate-templates.ts
+++ b/scripts/validate-templates.ts
@@ -1,7 +1,7 @@
 #!/usr/bin/env bun
 /**
  * Template Lifecycle Validation Script
- * @version 1.4.2
+ * @version 1.4.3
  *
  * Validates template variants for structural integrity.
  * Follows the same pattern as agent-lifecycle-audit.ts
@@ -755,8 +755,8 @@ function checkContextSync(variant: string): void {
 
 // Check 10: Root vs Template Alignment (L0 vs L1 Sync)
 function checkL0L1ScriptParity() {
-  const L1_SCRIPTS = join(ROOT, 'scripts');
-  const L0_SCRIPTS = join(ROOT, 'templates', 'common', 'scripts');
+  const L0_SCRIPTS = join(ROOT, 'scripts');
+  const L1_SCRIPTS = join(ROOT, 'templates', 'common', 'scripts');
 
   if (!existsSync(L1_SCRIPTS) || !existsSync(L0_SCRIPTS)) return;
 
@@ -816,7 +816,7 @@ function checkL0L1ScriptParity() {
       const l0Content = readFileSync(l0Path, 'utf-8');
 
       if (l1Content !== l0Content) {
-        fail('common', 'l0-l1-script-parity', `Script ${script} differs between L1 (root) and L0 (templates/common).`, `Backport L1 changes to L0 or update L1 to match L0.`);
+        fail('common', 'l0-l1-script-parity', `Script ${script} differs between L0 (root) and L1 (templates/common).`, `Backport L0 changes to L1 or update L0 to match L1.`);
       } else {
         pass(`Script ${script} is in sync between L0 and L1`);
       }

--- a/templates/co-design/scripts/publish-to-template.ts
+++ b/templates/co-design/scripts/publish-to-template.ts
@@ -1,7 +1,7 @@
 #!/usr/bin/env bun
 // publish-to-template.ts — Publishes L0 scripts and skills to L1 (templates/common) and propagates to L2 (templates/co-*)
 // Usage: bun run scripts/publish-to-template.ts [--dry-run] [--domain <name>] [--docs]
-// @version 1.3.0
+// @version 1.3.1
 
 import * as fs from 'node:fs';
 import * as path from 'node:path';
@@ -92,9 +92,9 @@ for (const line of registryLines) {
   if (cols.length < 4) continue;
   const script = cols[1].trim().replace(/`/g, '');
   const source = cols[2].trim();
-  const drift  = cols.length >= 8 ? cols[7].trim() : '—';
+  const layer  = cols.length >= 8 ? cols[7].trim() : '—';
   if (source !== 'L0') continue;
-  if (drift === 'intentional') continue;
+  if (layer.includes('L0-only')) continue;
   if (!script) continue;
   const src = path.join(l0Dir, script);
   const dst = path.join(l1Dir, script);

--- a/templates/co-develop/scripts/publish-to-template.ts
+++ b/templates/co-develop/scripts/publish-to-template.ts
@@ -1,7 +1,7 @@
 #!/usr/bin/env bun
 // publish-to-template.ts — Publishes L0 scripts and skills to L1 (templates/common) and propagates to L2 (templates/co-*)
 // Usage: bun run scripts/publish-to-template.ts [--dry-run] [--domain <name>] [--docs]
-// @version 1.3.0
+// @version 1.3.1
 
 import * as fs from 'node:fs';
 import * as path from 'node:path';
@@ -92,9 +92,9 @@ for (const line of registryLines) {
   if (cols.length < 4) continue;
   const script = cols[1].trim().replace(/`/g, '');
   const source = cols[2].trim();
-  const drift  = cols.length >= 8 ? cols[7].trim() : '—';
+  const layer  = cols.length >= 8 ? cols[7].trim() : '—';
   if (source !== 'L0') continue;
-  if (drift === 'intentional') continue;
+  if (layer.includes('L0-only')) continue;
   if (!script) continue;
   const src = path.join(l0Dir, script);
   const dst = path.join(l1Dir, script);

--- a/templates/co-security/scripts/publish-to-template.ts
+++ b/templates/co-security/scripts/publish-to-template.ts
@@ -1,7 +1,7 @@
 #!/usr/bin/env bun
 // publish-to-template.ts — Publishes L0 scripts and skills to L1 (templates/common) and propagates to L2 (templates/co-*)
 // Usage: bun run scripts/publish-to-template.ts [--dry-run] [--domain <name>] [--docs]
-// @version 1.3.0
+// @version 1.3.1
 
 import * as fs from 'node:fs';
 import * as path from 'node:path';
@@ -92,9 +92,9 @@ for (const line of registryLines) {
   if (cols.length < 4) continue;
   const script = cols[1].trim().replace(/`/g, '');
   const source = cols[2].trim();
-  const drift  = cols.length >= 8 ? cols[7].trim() : '—';
+  const layer  = cols.length >= 8 ? cols[7].trim() : '—';
   if (source !== 'L0') continue;
-  if (drift === 'intentional') continue;
+  if (layer.includes('L0-only')) continue;
   if (!script) continue;
   const src = path.join(l0Dir, script);
   const dst = path.join(l1Dir, script);

--- a/templates/co-work/scripts/publish-to-template.ts
+++ b/templates/co-work/scripts/publish-to-template.ts
@@ -1,7 +1,7 @@
 #!/usr/bin/env bun
 // publish-to-template.ts — Publishes L0 scripts and skills to L1 (templates/common) and propagates to L2 (templates/co-*)
 // Usage: bun run scripts/publish-to-template.ts [--dry-run] [--domain <name>] [--docs]
-// @version 1.3.0
+// @version 1.3.1
 
 import * as fs from 'node:fs';
 import * as path from 'node:path';
@@ -92,9 +92,9 @@ for (const line of registryLines) {
   if (cols.length < 4) continue;
   const script = cols[1].trim().replace(/`/g, '');
   const source = cols[2].trim();
-  const drift  = cols.length >= 8 ? cols[7].trim() : '—';
+  const layer  = cols.length >= 8 ? cols[7].trim() : '—';
   if (source !== 'L0') continue;
-  if (drift === 'intentional') continue;
+  if (layer.includes('L0-only')) continue;
   if (!script) continue;
   const src = path.join(l0Dir, script);
   const dst = path.join(l1Dir, script);

--- a/templates/common/scripts/README.md
+++ b/templates/common/scripts/README.md
@@ -54,7 +54,7 @@ All scripts in this workspace follow a Hybrid Scripting Architecture divided int
 | `sync-md.ts` | L0 | 1.2.0 | active | — | — | common | — |
 | `gen-pr-body.ts` | L0 | 1.0.0 | active | — | — | common | — |
 | `sync-skills.ts` | L0 | 1.1.0 | active | — | — | common | — |
-| `publish-to-template.ts` | L0 | 1.3.0 | active | — | — | common | — |
+| `publish-to-template.ts` | L0 | 1.3.1 | active | — | — | common | — |
 | `list-template-versions.ts` | L0 | 1.0.0 | active | — | — | common | — |
 | `qa-gate.ts` | L0 | 1.0.2 | active | — | — | common | — |
 | `agent-create.ts` | L0 | 1.0.0 | active | — | — | common | — |
@@ -75,7 +75,7 @@ All scripts in this workspace follow a Hybrid Scripting Architecture divided int
 | `retry-handler.ts` | L0 | 1.0.0 | active | — | — | common | — |
 | `sync-agent-status.ts` | L0 | 1.0.0 | active | — | — | common | — |
 | `sync-skill-status.ts` | L0 | 1.0.0 | active | — | — | common | — |
-| `validate-templates.ts` | L1 | 1.4.2 | active | — | — | L0-only | workspace-only: references docs/workspace-schema.json |
+| `validate-templates.ts` | L0 | 1.4.3 | active | — | — | L0-only | workspace-only: references docs/workspace-schema.json |
 | `helpers/lifecycle-governance.ts` | L0 | 1.0.1 | active | — | — | common | — |
 | `helpers/template-validation.ts` | L0 | 1.1.0 | active | — | — | common | — |
 | `helpers/inject-global-plugins.ts` | L0 | 1.0.0 | active | — | — | L0-only | — |
@@ -86,10 +86,10 @@ All scripts in this workspace follow a Hybrid Scripting Architecture divided int
 | `helpers/update-variant-lifecycle.ts` | L0 | 1.0.0 | active | — | — | L0-only | — |
 | `helpers/validate-output.ts` | L0 | 1.0.0 | active | — | — | L0-only | — |
 | `helpers/write-scripts-snapshot.ts` | L0 | 1.0.0 | active | — | — | L0-only | — |
-| `verify-readme-sync.ts` | L1 | 1.1.0 | active | — | — | common | — |
+| `verify-readme-sync.ts` | L0 | 1.1.0 | active | — | — | common | — |
 | `translate-readme.ts` | L0 | 1.0.0 | active | — | — | common | — |
 | `verify-agent-deliverables.ts` | L0 | 1.0.0 | active | — | — | common | — |
-| `verify-scripts.ts` | L1 | 1.0.0 | active | — | — | common | — |
+| `verify-scripts.ts` | L0 | 1.0.0 | active | — | — | common | — |
 | `test-new-project.ts` | L0 | 1.0.3 | active | — | — | common | — |
 | `check-pm-approval.ts` | L0 | 1.0.0 | deprecated | 2026-11-30 | — | common | — |
 | `verify-new-project-tests.ts` | L0 | 1.0.2 | active | — | — | common | — |

--- a/templates/common/scripts/SCRIPTS.md
+++ b/templates/common/scripts/SCRIPTS.md
@@ -56,7 +56,7 @@ All scripts in this workspace follow a Hybrid Scripting Architecture divided int
 | `sync-md.ts` | L0 | 1.2.0 | active | — | — | common | — |
 | `gen-pr-body.ts` | L0 | 1.0.0 | active | — | — | common | — |
 | `sync-skills.ts` | L0 | 1.1.0 | active | — | — | common | — |
-| `publish-to-template.ts` | L0 | 1.3.0 | active | — | — | common | — |
+| `publish-to-template.ts` | L0 | 1.3.1 | active | — | — | common | — |
 | `list-template-versions.ts` | L0 | 1.0.0 | active | — | — | common | — |
 | `qa-gate.ts` | L0 | 1.0.2 | active | — | — | common | — |
 | `agent-create.ts` | L0 | 1.0.0 | active | — | — | common | — |
@@ -77,7 +77,7 @@ All scripts in this workspace follow a Hybrid Scripting Architecture divided int
 | `retry-handler.ts` | L0 | 1.0.0 | active | — | — | common | — |
 | `sync-agent-status.ts` | L0 | 1.0.0 | active | — | — | common | — |
 | `sync-skill-status.ts` | L0 | 1.0.0 | active | — | — | common | — |
-| `validate-templates.ts` | L1 | 1.4.2 | active | — | — | L0-only | workspace-only: references docs/workspace-schema.json |
+| `validate-templates.ts` | L0 | 1.4.3 | active | — | — | L0-only | workspace-only: references docs/workspace-schema.json |
 | `helpers/lifecycle-governance.ts` | L0 | 1.0.1 | active | — | — | common | — |
 | `helpers/template-validation.ts` | L0 | 1.1.0 | active | — | — | common | — |
 | `helpers/inject-global-plugins.ts` | L0 | 1.0.0 | active | — | — | L0-only | — |
@@ -88,10 +88,10 @@ All scripts in this workspace follow a Hybrid Scripting Architecture divided int
 | `helpers/update-variant-lifecycle.ts` | L0 | 1.0.0 | active | — | — | L0-only | — |
 | `helpers/validate-output.ts` | L0 | 1.0.0 | active | — | — | L0-only | — |
 | `helpers/write-scripts-snapshot.ts` | L0 | 1.0.0 | active | — | — | L0-only | — |
-| `verify-readme-sync.ts` | L1 | 1.1.0 | active | — | — | common | — |
+| `verify-readme-sync.ts` | L0 | 1.1.0 | active | — | — | common | — |
 | `translate-readme.ts` | L0 | 1.0.0 | active | — | — | common | — |
 | `verify-agent-deliverables.ts` | L0 | 1.0.0 | active | — | — | common | — |
-| `verify-scripts.ts` | L1 | 1.0.0 | active | — | — | common | — |
+| `verify-scripts.ts` | L0 | 1.0.0 | active | — | — | common | — |
 | `test-new-project.ts` | L0 | 1.0.3 | active | — | — | common | — |
 | `check-pm-approval.ts` | L0 | 1.0.0 | deprecated | 2026-11-30 | — | common | — |
 | `verify-new-project-tests.ts` | L0 | 1.0.2 | active | — | — | common | — |

--- a/templates/common/scripts/publish-to-template.ts
+++ b/templates/common/scripts/publish-to-template.ts
@@ -1,7 +1,7 @@
 #!/usr/bin/env bun
 // publish-to-template.ts — Publishes L0 scripts and skills to L1 (templates/common) and propagates to L2 (templates/co-*)
 // Usage: bun run scripts/publish-to-template.ts [--dry-run] [--domain <name>] [--docs]
-// @version 1.3.0
+// @version 1.3.1
 
 import * as fs from 'node:fs';
 import * as path from 'node:path';
@@ -92,9 +92,9 @@ for (const line of registryLines) {
   if (cols.length < 4) continue;
   const script = cols[1].trim().replace(/`/g, '');
   const source = cols[2].trim();
-  const drift  = cols.length >= 8 ? cols[7].trim() : '—';
+  const layer  = cols.length >= 8 ? cols[7].trim() : '—';
   if (source !== 'L0') continue;
-  if (drift === 'intentional') continue;
+  if (layer.includes('L0-only')) continue;
   if (!script) continue;
   const src = path.join(l0Dir, script);
   const dst = path.join(l1Dir, script);


### PR DESCRIPTION
[claude pr-body] Attempt 1/2
[claude pr-body]  Success on attempt 1
## Why
Fixed incorrect script copying logic and terminology between workspace root (L0) and template level (L1) to prevent propagation errors and ensure consistent documentation across all variants.

## What Changed
- Corrected `publish-to-template.ts` script copying logic to properly handle L0 → L1 → L2 propagation chain
- Updated terminology in `SCRIPTS.md` and `README.md` to accurately describe the three-tier template architecture
- Fixed `validate-templates.ts` validation checks for correct script version alignment
- Propagated all fixes to all 4 variant templates (co-design, co-develop, co-security, co-work)
- Updated VERSION_MANIFEST.md and added session entry to memory log

## Test Plan
- [ ] `bash scripts/audit.sh` passes
- [ ] Manual verification: `bun scripts/publish-to-template.ts` correctly copies scripts to all template levels
- [ ] `bun scripts/validate-templates.ts` confirms version alignment across all tiers

## Security Checklist
- [ ] No secrets, credentials, or API keys committed
- [ ] No `.env` files staged (use `.env.sample` for templates)
- [ ] Dependencies unchanged or reviewed for new CVEs

## Notes
None.