### PR TITLE
fix: remove Administrators and Users group grants from Bash script permission cleanup to resolve Windows deletion issues

### DIFF
--- a/docs/VERSION_MANIFEST.md
+++ b/docs/VERSION_MANIFEST.md
@@ -1,6 +1,6 @@
 # VERSION_MANIFEST.md
 
-**Generated**: 2026-06-08T22:30:11.404Z
+**Generated**: 2026-06-08T22:51:02.122Z
 **Manifest Version**: 1.0
 **Location**: docs\VERSION_MANIFEST.md
 

--- a/memory/2026-06-08.md
+++ b/memory/2026-06-08.md
@@ -900,3 +900,18 @@ chore: update
 
 ## Open Issues
 - None
+
+---
+
+## Session Summary
+fix: remove Administrators and Users group grants from Bash script permission cleanup to resolve Windows deletion issues
+
+## Changes
+- `M scripts/new-project.sh` — modified
+- `templates/common/scripts/new-project.sh` — modified
+
+## Decisions
+- None
+
+## Open Issues
+- None

--- a/scripts/new-project.sh
+++ b/scripts/new-project.sh
@@ -750,27 +750,17 @@ if [ "$IS_WINDOWS" = true ]; then
   icacls "$PROJECT_DIR" /inheritance:r 2>&1 | grep -i "processed" || true
   echo "  [OK] ACL inheritance disabled"
 
-  echo "  [Step 3/7] Granting full control to current user..."
+  echo "  [Step 3/5] Granting full control to current user..."
   # Grant full control to current user
   icacls "$PROJECT_DIR" /grant "${CURRENT_USER}:(OI)(CI)F" /T /C /Q 2>&1 | grep -i "processed" || true
   echo "  [OK] Current user full control granted"
 
-  echo "  [Step 4/7] Granting full control to Administrators group..."
-  # Grant Administrators group full control
-  icacls "$PROJECT_DIR" /grant "Administrators:(OI)(CI)F" /T /C /Q 2>&1 | grep -i "processed" || true
-  echo "  [OK] Administrators full control granted"
-
-  echo "  [Step 5/7] Re-enabling inheritance..."
+  echo "  [Step 4/5] Re-enabling inheritance..."
   # Re-enable inheritance
   icacls "$PROJECT_DIR" /inheritance:e 2>&1 | grep -i "processed" || true
   echo "  [OK] Inheritance re-enabled"
 
-  echo "  [Step 6/7] Granting Users group read/execute..."
-  # Grant Users group read/execute
-  icacls "$PROJECT_DIR" /grant "Users:(OI)(CI)RX" /T /C /Q 2>&1 | grep -i "processed" || true
-  echo "  [OK] Users group read/execute granted"
-
-  echo "  [Step 7/7] Verifying permissions..."
+  echo "  [Step 5/5] Verifying permissions..."
   # Count access rules (approximate verification)
   echo "  [OK] Permission cleanup complete"
 

--- a/templates/common/scripts/new-project.sh
+++ b/templates/common/scripts/new-project.sh
@@ -750,27 +750,17 @@ if [ "$IS_WINDOWS" = true ]; then
   icacls "$PROJECT_DIR" /inheritance:r 2>&1 | grep -i "processed" || true
   echo "  [OK] ACL inheritance disabled"
 
-  echo "  [Step 3/7] Granting full control to current user..."
+  echo "  [Step 3/5] Granting full control to current user..."
   # Grant full control to current user
   icacls "$PROJECT_DIR" /grant "${CURRENT_USER}:(OI)(CI)F" /T /C /Q 2>&1 | grep -i "processed" || true
   echo "  [OK] Current user full control granted"
 
-  echo "  [Step 4/7] Granting full control to Administrators group..."
-  # Grant Administrators group full control
-  icacls "$PROJECT_DIR" /grant "Administrators:(OI)(CI)F" /T /C /Q 2>&1 | grep -i "processed" || true
-  echo "  [OK] Administrators full control granted"
-
-  echo "  [Step 5/7] Re-enabling inheritance..."
+  echo "  [Step 4/5] Re-enabling inheritance..."
   # Re-enable inheritance
   icacls "$PROJECT_DIR" /inheritance:e 2>&1 | grep -i "processed" || true
   echo "  [OK] Inheritance re-enabled"
 
-  echo "  [Step 6/7] Granting Users group read/execute..."
-  # Grant Users group read/execute
-  icacls "$PROJECT_DIR" /grant "Users:(OI)(CI)RX" /T /C /Q 2>&1 | grep -i "processed" || true
-  echo "  [OK] Users group read/execute granted"
-
-  echo "  [Step 7/7] Verifying permissions..."
+  echo "  [Step 5/5] Verifying permissions..."
   # Count access rules (approximate verification)
   echo "  [OK] Permission cleanup complete"
 


### PR DESCRIPTION
[claude pr-body] Attempt 1/2
[claude pr-body]  Success on attempt 1
## Why
Windows file deletion was failing due to overly restrictive permission grants in the Bash permission cleanup script. The Administrators and Users group grants were causing permission conflicts on Windows systems, preventing proper cleanup and deletion of project directories.

## What Changed
- Removed `Administrators` group grant from permission cleanup in `scripts/new-project.sh`
- Removed `Users` group grant from permission cleanup in `scripts/new-project.sh`
- Applied identical changes to `templates/common/scripts/new-project.sh`
- Updated VERSION_MANIFEST.md to reflect the change
- Added memory log entry documenting the Windows deletion issue resolution

## Test Plan
- [ ] `bash scripts/audit.sh` passes
- [ ] Verify project deletion works on Windows after permission cleanup
- [ ] Confirm no permission-related errors when running `new-project.sh` on Windows

## Security Checklist
- [ ] No secrets, credentials, or API keys committed
- [ ] No `.env` files staged (use `.env.sample` for templates)
- [ ] Dependencies unchanged or reviewed for new CVEs

## Notes
This change addresses a Windows-specific permission issue where granting permissions to Administrators and Users groups in the cleanup phase caused subsequent deletion operations to fail. The permission grants have been removed entirely while maintaining the core permission cleanup functionality for the project owner.

---