### PR TITLE
fix(co-deck): resolve Measure/PDF pipeline runtime errors

### DIFF
--- a/templates/co-deck/scripts/co-deck/download-font.ts
+++ b/templates/co-deck/scripts/co-deck/download-font.ts
@@ -7,8 +7,8 @@
 // Requires: fflate (bun install fflate)
 
 import { mkdirSync, writeFileSync, existsSync } from 'fs';
-import { join, resolve, homedir } from 'path';
-import { platform } from 'os';
+import { join, resolve } from 'path';
+import { platform, homedir } from 'os';
 import { unzipSync } from 'fflate';
 
 interface FontSpec {

--- a/templates/co-deck/scripts/co-deck/estimate-layout.ts
+++ b/templates/co-deck/scripts/co-deck/estimate-layout.ts
@@ -6,8 +6,8 @@
 // No Playwright dependency required.
 
 import { readFileSync, existsSync, mkdirSync, writeFileSync } from 'fs';
-import { join, resolve, dirname, homedir } from 'path';
-import { platform } from 'os';
+import { join, resolve, dirname } from 'path';
+import { platform, homedir } from 'os';
 
 // ── Types ────────────────────────────────────────────────────────────────────
 

--- a/templates/co-deck/scripts/co-deck/gen-slides-pdf.ts
+++ b/templates/co-deck/scripts/co-deck/gen-slides-pdf.ts
@@ -398,10 +398,26 @@ class Renderer {
     this.page.drawEllipse({ x: cx, y: cy, xScale: this.pt(diamMm / 2), yScale: this.pt(diamMm / 2), color });
   }
 
+  /**
+   * Detect actual image format from magic bytes, falling back to extension.
+   * Prevents "SOI not found in JPEG" errors when a PNG is saved with .jpg extension.
+   */
+  private detectImageFormat(data: Buffer): 'png' | 'jpeg' {
+    // PNG magic: 89 50 4E 47
+    if (data.length >= 4 && data[0] === 0x89 && data[1] === 0x50 && data[2] === 0x4E && data[3] === 0x47) {
+      return 'png';
+    }
+    // JPEG magic: FF D8 FF
+    if (data.length >= 3 && data[0] === 0xFF && data[1] === 0xD8 && data[2] === 0xFF) {
+      return 'jpeg';
+    }
+    return 'jpeg'; // fallback default
+  }
+
   async embedImg(doc: PDFDocument, imgPath: string) {
     const data = readFileSync(imgPath);
-    const ext  = imgPath.split('.').pop()?.toLowerCase();
-    return ext === 'png' ? await doc.embedPng(data) : await doc.embedJpg(data);
+    const format = this.detectImageFormat(data);
+    return format === 'png' ? await doc.embedPng(data) : await doc.embedJpg(data);
   }
 
   drawEmbeddedImage(img: any, xMm: number, yMm: number, wMm: number, hMm: number) {

--- a/templates/co-deck/scripts/co-deck/gen-slides-pdf.ts
+++ b/templates/co-deck/scripts/co-deck/gen-slides-pdf.ts
@@ -22,8 +22,8 @@ import { PDFDocument, PDFFont, PDFPage, rgb, RGB,
   pushGraphicsState, popGraphicsState, moveTo, lineTo, closePath, clip, endPath } from 'pdf-lib';
 import fontkit from '@pdf-lib/fontkit';
 import { readFileSync, writeFileSync, existsSync, statSync } from 'fs';
-import { join, resolve, dirname, homedir } from 'path';
-import { platform } from 'os';
+import { join, resolve, dirname } from 'path';
+import { platform, homedir } from 'os';
 
 // ── Constants ─────────────────────────────────────────────────────────────────
 


### PR DESCRIPTION
## Summary

Fixes two runtime errors that blocked the Measure (Stage 9-10) and PDF Export (Stage 11) stages of the co-deck 11-stage pipeline when running under Bun v1.3.14.

### Bug 1:  import from wrong module

 belongs to Node.js  module, not . Bun v1.3.14 enforces strict named exports, causing all three scripts to fail with:



**Fix**: Move  from  to  in:
-  (Measure stage)
-  (font acquisition for PDF)
-  (PDF export)

### Bug 2: Image format detection by extension only

The  method in  routed images to  vs  purely by file extension. When an image was actually a PNG but saved with a  extension, pdf-lib threw:



**Fix**: Add  that checks magic bytes:
- PNG: 
- JPEG: 

This is defense-in-depth — the PDF pipeline now handles mismatched extensions gracefully regardless of file naming.

### Context

These bugs were discovered during the ai-marketing-strategy presentation build pipeline (Stages 9-11). The homedir fix unblocked all three scripts; the magic bytes fix prevents SOI errors from misnamed image assets.

## Files Changed

| File | Change |
|------|--------|
|  | Fix  import |
|  | Fix  import |
|  | Fix  import + add magic bytes detection |

## Test Plan

- [x]  completes without import error
- [x]  completes without import error
- [x]  completes without import error
- [x]  correctly embeds PNG saved with  extension
- [x] Full 20-slide PDF generated successfully for ai-marketing-strategy