### PR TITLE
fix(co-deck): remove CSS ::before bullet markers from visual panel text in pitch/pitch-enhanced themes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - **[2026-06-22]**: feat(co-deck): add opt-in `--title-text-shadow` CSS variable to `styles/base.css` (defaults `none`; zero impact on classic/minimal/academic/visual-heavy) to express the premium-dark gold title glow within the CSS-variables-only style discipline
 
 ### Fixed
+- **[2026-06-26]**: fix(co-deck): remove CSS `::before` bullet markers from visual panel text in pitch/pitch-enhanced themes — visual panel text items (with embedded markers like →, ✓) displayed duplicate bullets due to CSS `::before` pseudo-elements; removed `.visual-item-check::before` rules from base.css, pitch/theme.css, pitch-enhanced/theme.css; aligned pitch/template.html `renderVisualDisplay()` class from `visual-item-check` to `visual-item` to match ppt-engine.js shared implementation
 - **[2026-06-26]**: fix(co-deck): vertical template.html `</div>` mismatched closing tag for `<ul class="toc-list">` — changed to `</ul>`
 - **[2026-06-26]**: fix(co-deck): visual-heavy style.css `:root {}` block premature closure orphaning 14 custom properties (section-label, divider, cover variables) — removed stray closing brace
 - **[2026-06-26]**: fix(co-deck): vertical theme sticky topbar scrolls away — `ppt-engine.css` sets `body { display: flex }` for PPT themes but vertical theme only overrode `overflow`; add `display: block !important; height: auto !important` to `vertical/theme.css` body rule to restore normal flow context enabling `position: sticky` on `.vertical-topbar`

--- a/memory/2026-06-26.md
+++ b/memory/2026-06-26.md
@@ -1,4 +1,47 @@
 ## Session Summary
+fix(co-deck): remove CSS ::before bullet markers from visual panel text in pitch/pitch-enhanced themes
+
+## Changes
+- `templates/co-deck/docs/html-themes/styles/base.css` — removed `.visual-item-check::before` rule that injected `▸` via CSS variable `--bullet-marker`
+- `templates/co-deck/docs/html-themes/themes/pitch-enhanced/theme.css` — removed `.slide-visual .visual-item-check::before` rule with hardcoded `content: '▸'`
+- `templates/co-deck/docs/html-themes/themes/pitch/theme.css` — removed `.slide-visual .visual-item-check::before` rule with hardcoded `content: '▸'`
+- `templates/co-deck/docs/html-themes/themes/pitch/template.html` — changed `'visual-item visual-item-check'` to `'visual-item'` in `renderVisualDisplay()` to match ppt-engine.js shared implementation
+- `CHANGELOG.md` — added entry for visual panel bullet fix
+
+## Decisions
+- Root cause: when no visualImage exists, `renderVisualDisplay()` parses visualDisplay text into `.visual-item` elements. Pitch theme's local implementation used `visual-item-check` class which triggered CSS `::before` adding `▸` on top of text-embedded markers (→, ✓, •). This created double markers.
+- Fix approach: remove all CSS `::before` rules for visual-item-check, and align the JS class to match ppt-engine.js (which already uses `visual-item` only, no `visual-item-check`). Text-embedded markers remain intact.
+- User selected "keep text markers, remove CSS ::before only" — preserving the visual content while eliminating the duplicate decoration
+
+## Open Issues
+- None
+
+---
+
+## Session Summary
+fix(co-deck): increase PDF body/bullet font sizes for readability
+
+## Changes
+- `templates/co-deck/docs/html-themes/themes/vertical/pdf_layout_spec.json` — bullet_pt 13→15, bullet_px 28→32, bullet_gap_px 16→18, div_desc_pt 13→15, div_desc_px 28.16→32
+- `templates/co-deck/docs/html-themes/themes/outline/pdf_layout_spec.json` — bullet_pt 13→15, bullet_px 28→32, bullet_gap_px 14→18
+- `templates/co-deck/docs/html-themes/themes/pitch/pdf_layout_spec.json` — bullet_pt 11→14, bullet_px 22→28, bullet_gap_px 12→16
+- `templates/co-deck/docs/html-themes/themes/pitch-enhanced/pdf_layout_spec.json` — bullet_pt 11→14, bullet_px 22→28, bullet_gap_px 12→16
+- `templates/co-deck/docs/html-themes/themes/zen/pdf_layout_spec.json` — bullet_pt 14→15, bullet_px 28→32, bullet_gap_px 16→18
+- `templates/co-deck/scripts/co-deck/gen-slides-pdf.ts` — v1.8.0: fallback T_BUL 12.5→14.0, FONT_PT_MULT 0.85→0.94, LINE_H_MULT 1.85→1.90
+- `CHANGELOG.md` — added entry for PDF font size fix
+
+## Decisions
+- Root cause: bullet_pt in pdf_layout_spec.json was too small for widescreen (338.7×190.5mm) presentation output. HTML CSS uses --font-size-body: 1rem = 16px which scales to ~15-16pt equivalent; PDF bullet_pt was 11-13pt
+- vertical/outline/zen (text-heavy themes): bumped to 15pt to match HTML readability
+- pitch/pitch-enhanced (visual-presentation themes): bumped to 14pt (still slightly smaller due to imagery-heavy slides)
+- bullet_px and bullet_gap_px increased proportionally to maintain comfortable line spacing
+
+## Open Issues
+- None
+
+---
+
+## Session Summary
 fix(co-deck): vertical theme sticky topbar fix + TOC drawer consistency across themes
 
 ## Changes
@@ -259,6 +302,50 @@ docs(co-deck): update session summary and visual-heavy style comment
 ## Changes
 - `memory/2026-06-26.md` — modified
 - `templates/co-deck/docs/html-themes/styles/visual-heavy/style.css` — modified
+
+## Decisions
+- None
+
+## Open Issues
+- None
+
+---
+
+## Session Summary
+--message fix(co-deck): increase PDF body/bullet font sizes for readability
+
+## Changes
+- `M .claude/post-checkout.log` — modified
+- `CHANGELOG.md` — modified
+- `memory/2026-06-26.md` — modified
+- `templates/co-deck/docs/html-themes/themes/outline/pdf_layout_spec.json` — modified
+- `templates/co-deck/docs/html-themes/themes/pitch-enhanced/pdf_layout_spec.json` — modified
+- `templates/co-deck/docs/html-themes/themes/pitch/pdf_layout_spec.json` — modified
+- `templates/co-deck/docs/html-themes/themes/vertical/pdf_layout_spec.json` — modified
+- `templates/co-deck/docs/html-themes/themes/zen/pdf_layout_spec.json` — modified
+- `templates/co-deck/scripts/co-deck/gen-slides-pdf.ts` — modified
+
+## Decisions
+- None
+
+## Open Issues
+- None
+
+---
+
+## Session Summary
+--message fix(co-deck): increase PDF body/bullet font sizes for readability
+
+## Changes
+- `M .claude/post-checkout.log` — modified
+- `CHANGELOG.md` — modified
+- `memory/2026-06-26.md` — modified
+- `templates/co-deck/docs/html-themes/themes/outline/pdf_layout_spec.json` — modified
+- `templates/co-deck/docs/html-themes/themes/pitch-enhanced/pdf_layout_spec.json` — modified
+- `templates/co-deck/docs/html-themes/themes/pitch/pdf_layout_spec.json` — modified
+- `templates/co-deck/docs/html-themes/themes/vertical/pdf_layout_spec.json` — modified
+- `templates/co-deck/docs/html-themes/themes/zen/pdf_layout_spec.json` — modified
+- `templates/co-deck/scripts/co-deck/gen-slides-pdf.ts` — modified
 
 ## Decisions
 - None

--- a/templates/co-deck/docs/html-themes/styles/base.css
+++ b/templates/co-deck/docs/html-themes/styles/base.css
@@ -352,13 +352,6 @@ html, body {
   padding: 0.15rem 0;
 }
 
-.visual-item-check::before {
-  content: var(--bullet-marker, "▸");
-  color: var(--accent, var(--accent-color, #4a90d9));
-  flex-shrink: 0;
-  margin-top: 0.05em;
-}
-
 .visual-paragraph {
   font-size: var(--font-size-body, 1rem);
   line-height: 1.6;

--- a/templates/co-deck/docs/html-themes/themes/pitch-enhanced/theme.css
+++ b/templates/co-deck/docs/html-themes/themes/pitch-enhanced/theme.css
@@ -355,13 +355,6 @@
   padding: 0.12rem 0;
 }
 
-.slide-visual .visual-item-check::before {
-  content: '▸';
-  color: var(--accent-color, #D97706);
-  flex-shrink: 0;
-  margin-top: 0.05em;
-}
-
 .slide-visual .visual-paragraph {
   font-size: 0.92rem;
   line-height: 1.6;

--- a/templates/co-deck/docs/html-themes/themes/pitch/template.html
+++ b/templates/co-deck/docs/html-themes/themes/pitch/template.html
@@ -171,7 +171,7 @@
           return;
         }
         if (/^[✓✗✔✘→►•▪▫▸❯]\s*/.test(trimmed)) {
-          parent.appendChild(el('div', 'visual-item visual-item-check', trimmed));
+          parent.appendChild(el('div', 'visual-item', trimmed));
           return;
         }
         parent.appendChild(el('div', 'visual-paragraph', trimmed));

--- a/templates/co-deck/docs/html-themes/themes/pitch/theme.css
+++ b/templates/co-deck/docs/html-themes/themes/pitch/theme.css
@@ -375,13 +375,6 @@ body {
   padding: 0.12rem 0;
 }
 
-.slide-visual .visual-item-check::before {
-  content: '▸';
-  color: var(--accent-color, #D97706);
-  flex-shrink: 0;
-  margin-top: 0.05em;
-}
-
 .slide-visual .visual-paragraph {
   font-size: 0.92rem;
   line-height: 1.6;


### PR DESCRIPTION
## Summary

Visual panel text items in pitch and pitch-enhanced themes displayed duplicate bullet markers. When no  exists,  parses  text into  elements with embedded markers (→, ✓, •). The pitch theme's local implementation used the  class which triggered CSS  pseudo-elements that injected an additional  marker on top of the text-embedded one.

## Changes

| File | Change |
|------|--------|
|  | Removed  rule (CSS variable  injection) |
|  | Removed  rule (hardcoded ) |
|  | Removed  rule (hardcoded ) |
|  | Changed  class to  in  to match ppt-engine.js shared implementation |
|  | Added fix entry |
|  | Added session log |

## Root Cause

- ppt-engine.js shared  correctly uses  class only
- Pitch theme's local  used  — the extra class triggered CSS  rules in 3 locations
- Text-embedded markers (→, ✓) remain intact; only the duplicate CSS decoration is removed

## Verification

- All pre-push audit checks passed (gitleaks, workspace audit, lifecycle sync, i18n, variant integrity)