### PR TITLE
/sync

### DIFF
--- a/docs/VERSION_MANIFEST.md
+++ b/docs/VERSION_MANIFEST.md
@@ -1,6 +1,6 @@
 # VERSION_MANIFEST.md
 
-**Generated**: 2026-06-26T22:54:27.890Z
+**Generated**: 2026-06-26T23:04:12.537Z
 **Manifest Version**: 1.0
 **Location**: docs\VERSION_MANIFEST.md
 

--- a/memory/2026-06-26.md
+++ b/memory/2026-06-26.md
@@ -441,3 +441,18 @@ fix(co-deck): remove thumbnail-panel remnant, fix title slide grid layout in pit
 
 ## Open Issues
 - None
+
+---
+
+## Session Summary
+/sync
+
+## Changes
+- `M templates/co-deck/docs/html-themes/themes/pitch-enhanced/theme.css` — modified
+- `templates/co-deck/docs/lecture-profile.md` — modified
+
+## Decisions
+- None
+
+## Open Issues
+- None

--- a/templates/co-deck/docs/html-themes/themes/pitch-enhanced/theme.css
+++ b/templates/co-deck/docs/html-themes/themes/pitch-enhanced/theme.css
@@ -81,6 +81,19 @@
   display: block;
 }
 
+/* When title slide has no image, center the content */
+.slide[data-type="title"]:not(:has(.right-panel)) .slide-content {
+  grid-template-columns: 1fr;
+  text-align: center;
+  justify-items: center;
+}
+
+.slide[data-type="title"]:not(:has(.right-panel)) .slide-left {
+  align-items: center;
+  max-width: 800px;
+  margin: 0 auto;
+}
+
 .slide[data-type="title"] .slide-eyebrow {
   font-size: 0.8rem;
   font-weight: 600;
@@ -233,6 +246,21 @@
    Only display:block is needed to cancel the base.css flex default. */
 .slide[data-type="contact"] {
   display: block;
+}
+
+/* When contact slide has no image, center the content */
+.slide[data-type="contact"]:not(:has(.right-panel)) .slide-content {
+  grid-template-columns: 1fr;
+  text-align: center;
+  justify-items: center;
+}
+
+.slide[data-type="contact"]:not(:has(.right-panel)) .slide-left {
+  align-items: center;
+}
+
+.slide[data-type="contact"]:not(:has(.right-panel)) .contact-info {
+  align-items: center;
 }
 
 .slide[data-type="contact"] .contact-title {

--- a/templates/co-deck/docs/lecture-profile.md
+++ b/templates/co-deck/docs/lecture-profile.md
@@ -140,8 +140,9 @@ narration:
   autoAdvance: false
   # Interval for auto-advance when narration is NOT playing (seconds)
   # When narration IS playing, slides advance after narration ends (~800ms).
-  # Options: integer (default: 5)
-  autoAdvanceInterval: 5
+  # Options: integer (default: 8)
+  #   Note: default bumped to 8 per user request
+  autoAdvanceInterval: 8
   # Languages for which to generate translated narration scripts.
   # The primary language (from `language` field) always gets a `script` field.
   # Additional languages generate `scriptEn`, `scriptJa`, etc.


### PR DESCRIPTION
[claude pr-body] Attempt 1/2
[claude pr-body]  Success on attempt 1
## Why
The `pitch-enhanced` HTML theme left title and contact slides left-aligned when they had no image, and the default narration auto-advance interval was too short for the user's presentation pacing. Both are small UX polish fixes in the co-deck template.

## What Changed
- `theme.css` (`pitch-enhanced`): added `:not(:has(.right-panel))` rules so title and contact slides collapse to a single centered column (centered text, `justify-items: center`, max-width 800px on title) when no image/right-panel is present.
- `lecture-profile.md`: bumped `autoAdvanceInterval` default from `5` to `8` seconds per user request, with an inline note documenting the change.

## Test Plan
- [ ] `bun scripts/audit.ts` passes
- [ ] Render a `pitch-enhanced` title slide and contact slide without a `right-panel` image — content is centered, not left-aligned
- [ ] Render title/contact slides *with* an image — layout is unchanged (two-column grid still applies)
- [ ] Confirm auto-advance advances at ~8s when narration is not playing

## Security Checklist
- [ ] No secrets, credentials, or API keys committed
- [ ] No `.env` files staged (use `.env.sample` for templates)
- [ ] Dependencies unchanged or reviewed for new CVEs

## Notes
Template-scoped changes only (`templates/co-deck/`). `docs/VERSION_MANIFEST.md` is an auto-generated timestamp bump and `memory/2026-06-26.md` is the session log entry; neither affects runtime behavior.