### PR TITLE
fix(co-deck): resolve nested HTML comment parser bug

### DIFF
--- a/docs/VERSION_MANIFEST.md
+++ b/docs/VERSION_MANIFEST.md
@@ -1,6 +1,6 @@
 # VERSION_MANIFEST.md
 
-**Generated**: 2026-06-26T23:04:12.537Z
+**Generated**: 2026-06-26T23:36:34.950Z
 **Manifest Version**: 1.0
 **Location**: docs\VERSION_MANIFEST.md
 

--- a/memory/2026-06-26.md
+++ b/memory/2026-06-26.md
@@ -456,3 +456,21 @@ fix(co-deck): remove thumbnail-panel remnant, fix title slide grid layout in pit
 
 ## Open Issues
 - None
+
+---
+
+## Session Summary
+fix(co-deck): resolve nested HTML comment parser bug
+
+## Changes
+- `M templates/co-deck/docs/html-themes/themes/outline/template.html` — modified
+- `templates/co-deck/docs/html-themes/themes/pitch-enhanced/template.html` — modified
+- `templates/co-deck/docs/html-themes/themes/pitch/template.html` — modified
+- `templates/co-deck/docs/html-themes/themes/vertical/template.html` — modified
+- `templates/co-deck/docs/html-themes/themes/zen/template.html` — modified
+
+## Decisions
+- None
+
+## Open Issues
+- None

--- a/templates/co-deck/docs/html-themes/themes/outline/template.html
+++ b/templates/co-deck/docs/html-themes/themes/outline/template.html
@@ -9,9 +9,9 @@
   HOW TO USE:
     html-build reads this template and:
     1. Injects <html data-theme="outline" data-style="<style>"> attributes
-    2. Replaces <!-- INJECT:CSS --> with base.css + ppt-engine.css + theme.css + style.css links
-    3. Replaces <!-- INJECT:slideData --> with: const slideData = [...];
-    4. <!-- INJECT:slides --> is satisfied at RUNTIME by renderSlide()/initSlides()
+    2. Replaces [INJECT:CSS] with base.css + ppt-engine.css + theme.css + style.css links
+    3. Replaces [INJECT:slideData] with: const slideData = [...];
+    4. [INJECT:slides] is satisfied at RUNTIME by renderSlide()/initSlides()
 
   CONTENT RULES (from theme.json):
     - max 6 bullets per slide, max 35 chars in title

--- a/templates/co-deck/docs/html-themes/themes/pitch-enhanced/template.html
+++ b/templates/co-deck/docs/html-themes/themes/pitch-enhanced/template.html
@@ -10,9 +10,9 @@
   HOW TO USE:
     html-build reads this template and:
     1. Injects <html data-theme="pitch-enhanced" data-style="<style>"> attributes
-    2. Replaces <!-- INJECT:CSS --> with base.css + ppt-engine.css + theme.css + style.css links
-    3. Replaces <!-- INJECT:slideData --> with: const slideData = [...];
-    4. <!-- INJECT:slides --> is satisfied at RUNTIME by renderSlide()/initSlides()
+    2. Replaces [INJECT:CSS] with base.css + ppt-engine.css + theme.css + style.css links
+    3. Replaces [INJECT:slideData] with: const slideData = [...];
+    4. [INJECT:slides] is satisfied at RUNTIME by renderSlide()/initSlides()
 
   CONTENT RULES (from theme.json):
     - max 4 bullets per slide, max 28 chars in title

--- a/templates/co-deck/docs/html-themes/themes/pitch/template.html
+++ b/templates/co-deck/docs/html-themes/themes/pitch/template.html
@@ -9,9 +9,9 @@
   HOW TO USE:
     html-build reads this template and:
     1. Injects <html data-theme="pitch" data-style="<style>"> attributes
-    2. Replaces <!-- INJECT:CSS --> with base.css + theme.css + style.css <link> tags
-    3. Replaces <!-- INJECT:slideData --> with: const slideData = [...];
-    4. <!-- INJECT:slides --> is satisfied at RUNTIME by renderSlide()/initSlides()
+    2. Replaces [INJECT:CSS] with base.css + theme.css + style.css <link> tags
+    3. Replaces [INJECT:slideData] with: const slideData = [...];
+    4. [INJECT:slides] is satisfied at RUNTIME by renderSlide()/initSlides()
        defined in this template's <script>. html-build injects slideData only and
        MUST NOT hand-author .slide divs — leave the presentation container empty.
 

--- a/templates/co-deck/docs/html-themes/themes/vertical/template.html
+++ b/templates/co-deck/docs/html-themes/themes/vertical/template.html
@@ -9,9 +9,9 @@
   HOW TO USE:
     html-build reads this template and:
     1. Injects <html data-theme="vertical" data-style="<style>"> attributes
-    2. Replaces <!-- INJECT:CSS --> with base.css + ppt-engine.css + theme.css + style.css links
-    3. Replaces <!-- INJECT:slideData --> with: const slideData = [...];
-    4. <!-- INJECT:slides --> is satisfied at RUNTIME by renderSlide()/initSlides()
+    2. Replaces [INJECT:CSS] with base.css + ppt-engine.css + theme.css + style.css links
+    3. Replaces [INJECT:slideData] with: const slideData = [...];
+    4. [INJECT:slides] is satisfied at RUNTIME by renderSlide()/initSlides()
 
   CONTENT RULES (from theme.json):
     - max 5 bullets per slide, max 28 chars in title

--- a/templates/co-deck/docs/html-themes/themes/zen/template.html
+++ b/templates/co-deck/docs/html-themes/themes/zen/template.html
@@ -9,9 +9,9 @@
   HOW TO USE:
     html-build reads this template and:
     1. Injects <html data-theme="zen" data-style="<style>"> attributes
-    2. Replaces <!-- INJECT:CSS --> with base.css + ppt-engine.css + theme.css + style.css links
-    3. Replaces <!-- INJECT:slideData --> with: const slideData = [...];
-    4. <!-- INJECT:slides --> is satisfied at RUNTIME by renderSlide()/initSlides()
+    2. Replaces [INJECT:CSS] with base.css + ppt-engine.css + theme.css + style.css links
+    3. Replaces [INJECT:slideData] with: const slideData = [...];
+    4. [INJECT:slides] is satisfied at RUNTIME by renderSlide()/initSlides()
 
   CONTENT RULES (from theme.json):
     - max 3 bullets per slide, max 30 chars in title


### PR DESCRIPTION
[claude pr-body] Attempt 1/2
[claude pr-body]  Success on attempt 1
## Why
The header documentation block in every co-deck theme template is wrapped in a single `<!-- ... -->` HTML comment, but the inline examples (`<!-- INJECT:CSS -->`) contained their own `-->`, which prematurely closed the outer comment and broke the parser. This replaces the nested-comment notation with bracket placeholders so the documentation comment parses cleanly.

## What Changed
- Replaced `<!-- INJECT:CSS -->`, `<!-- INJECT:slideData -->`, and `<!-- INJECT:slides -->` in the header doc-comment with `[INJECT:CSS]`, `[INJECT:slideData]`, and `[INJECT:slides]` across all five affected themes:
  - `outline/template.html`
  - `pitch/template.html`
  - `pitch-enhanced/template.html`
  - `vertical/template.html`
  - `zen/template.html`
- Bumped `docs/VERSION_MANIFEST.md` (lifecycle sync).
- Appended session entry to `memory/2026-06-26.md`.
- No functional/runtime injection behavior changed — the substitution targets in the live template body are untouched; only the documentation examples were rephrased.

## Test Plan
- [ ] `bash scripts/audit.sh` passes
- [ ] Open each updated `template.html` and confirm the top documentation comment now closes correctly (no premature termination after the `[INJECT:...]` lines)
- [ ] Run the co-deck `html-build` step against a sample deck and verify CSS, `slideData`, and slide injection still resolve at the correct placeholders
- [ ] Diff the rendered output of each theme against the pre-fix build to confirm no visual/structural regression

## Security Checklist
- [ ] No secrets, credentials, or API keys committed
- [ ] No `.env` files staged (use `.env.sample` for templates)
- [ ] Dependencies unchanged or reviewed for new CVEs

## Notes
Documentation-only fix inside template header comments. No runtime injection logic, build pipeline, or public API is affected, so no deployment steps or breaking changes. Reviewers should focus on confirming the placeholder notation change is consistent across all five themes and that the `[INJECT:...]` tokens remain purely illustrative in the comment block (the actual injection points in the template body are unchanged).