### PR TITLE
fix(audit): re-enable language validation after co-consult.context.md fix

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -243,7 +243,7 @@
 
     "jose": ["jose@6.2.3", "", {}, "sha512-YYVDInQKFJfR/xa3ojUTl8c2KoTwiL1R5Wg9YCydwH0x0B9grbzlg5HC7mMjCtUJjbQ/YnGEZIhI5tCgfTb4Hw=="],
 
-    "js-yaml": ["js-yaml@4.2.0", "", { "dependencies": { "argparse": "^2.0.1" }, "bin": { "js-yaml": "bin/js-yaml.js" } }, "sha512-ePWsvanv0DWuDRsW8dnt+R4jQ31SCRCQ7hhNcPXZPsoBZiemuZNYGf7adZdqX2D86j6rvKp3RpCxVTSb8WQlOw=="],
+    "js-yaml": ["js-yaml@4.3.0", "", { "dependencies": { "argparse": "^2.0.1" }, "bin": { "js-yaml": "bin/js-yaml.js" } }, "sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q=="],
 
     "json-schema-traverse": ["json-schema-traverse@1.0.0", "", {}, "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug=="],
 
@@ -291,9 +291,9 @@
 
     "pkce-challenge": ["pkce-challenge@5.0.1", "", {}, "sha512-wQ0b/W4Fr01qtpHlqSqspcj3EhBvimsdh0KlHhH8HRZnMsEa0ea2fTULOXOS9ccQr3om+GcGRk4e+isrZWV8qQ=="],
 
-    "playwright": ["playwright@1.61.0", "", { "dependencies": { "playwright-core": "1.61.0" }, "optionalDependencies": { "fsevents": "2.3.2" }, "bin": { "playwright": "cli.js" } }, "sha512-Z+7BeeqQPRRzklHsVFP4KTGIyMxKUmfeRA4WisM6G3/XW6nwGeX6fX9qYaDa+CiUqpOkb2f6X3nar05R3kSuJQ=="],
+    "playwright": ["playwright@1.61.1", "", { "dependencies": { "playwright-core": "1.61.1" }, "optionalDependencies": { "fsevents": "2.3.2" }, "bin": { "playwright": "cli.js" } }, "sha512-DWnY5o3YbLWK4GovuAVwpqL+1VwGNdUGrRr++8j8PtQQzvAVZUIMjKQ90fY689sEJZJBbZVw1rXaOKSTitkzPQ=="],
 
-    "playwright-core": ["playwright-core@1.61.0", "", { "bin": { "playwright-core": "cli.js" } }, "sha512-caX7TrY3Ml6egyDX0WUcTHDxodl/b51y5wJOdCEA36QviK/s2g081hvmGs8eaE3DWb6NYZQ6BjO/QkNRPenoPA=="],
+    "playwright-core": ["playwright-core@1.61.1", "", { "bin": { "playwright-core": "cli.js" } }, "sha512-h7Qlt6m4REp25qvIdvbDtVmD4LqVXfpRxhORv9L0jzETM05p4fuPJ3dKyuSXQxDSbXnmS79HAgi9589lGSpLkg=="],
 
     "proxy-addr": ["proxy-addr@2.0.7", "", { "dependencies": { "forwarded": "0.2.0", "ipaddr.js": "1.9.1" } }, "sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg=="],
 
@@ -309,7 +309,7 @@
 
     "safer-buffer": ["safer-buffer@2.1.2", "", {}, "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="],
 
-    "semver": ["semver@7.8.4", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-rUCObTnP32Q08R2uuIrt7r9PlEonuTmtuXYcW6s5kjdlj3xbnwe+21yXptAUYcMAABLkYYTtnmzb3w3EDZfueA=="],
+    "semver": ["semver@7.8.5", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA=="],
 
     "send": ["send@1.2.1", "", { "dependencies": { "debug": "^4.4.3", "encodeurl": "^2.0.0", "escape-html": "^1.0.3", "etag": "^1.8.1", "fresh": "^2.0.0", "http-errors": "^2.0.1", "mime-types": "^3.0.2", "ms": "^2.1.3", "on-finished": "^2.4.1", "range-parser": "^1.2.1", "statuses": "^2.0.2" } }, "sha512-1gnZf7DFcoIcajTjTwjwuDjzuz4PPcY2StKPlsGAQ1+YH20IRVrBaXSWmdjowTJ6u8Rc01PoYOGHXfP1mYcZNQ=="],
 

--- a/docs/VERSION_MANIFEST.md
+++ b/docs/VERSION_MANIFEST.md
@@ -1,6 +1,6 @@
 # VERSION_MANIFEST.md
 
-**Generated**: 2026-06-28T13:54:49.538Z
+**Generated**: 2026-06-28T14:02:35.483Z
 **Manifest Version**: 1.0
 **Location**: docs\VERSION_MANIFEST.md
 
@@ -24,7 +24,7 @@
 | automation-engineer | agents/automation-engineer.md | low | inherit | 2026-06-15 |
 | docs-writer | agents/docs-writer.md | medium | inherit | 2026-06-13 |
 | lifecycle-manager | agents/lifecycle-manager.md | medium | inherit | 2026-06-13 |
-| pm | agents/pm.md | high | inherit | 2026-06-18 |
+| pm | agents/pm.md | high | inherit | 2026-06-28 |
 | scaffolding-expert | agents/scaffolding-expert.md | low | inherit | 2026-06-15 |
 | security-expert | agents/security-expert.md | medium | inherit | 2026-06-13 |
 
@@ -69,7 +69,7 @@
 | agent-verify.ts | 1.0.1 | scripts/agent-verify.ts | N/A |
 | analyze-git-history.ts | 1.0.1 | scripts/analyze-git-history.ts | child_process |
 | archive-memory.ts | 1.0.0 | scripts/archive-memory.ts | N/A |
-| audit.ts | 2.10.3 | scripts/audit.ts | bun |
+| audit.ts | 2.10.4 | scripts/audit.ts | bun |
 | beta-lifecycle.ts | 1.1.0 | scripts/helpers/beta-lifecycle.ts | fs, path |
 | check-pm-approval.ts | 1.0.1 | scripts/check-pm-approval.ts | N/A |
 | cleanup-completed-md.ts | 1.0.0 | scripts/cleanup-completed-md.ts | N/A |

--- a/memory/2026-06-28.md
+++ b/memory/2026-06-28.md
@@ -615,3 +615,21 @@ feat(pm): enforce Design Gate Row 0 in execution plan boilerplate
 
 ## Open Issues
 - None
+
+---
+
+## Session Summary
+fix(audit): re-enable language validation after co-consult.context.md fix
+
+## Changes
+- `M bun.lock` — modified
+- `package.json` — modified
+- `scripts/SCRIPTS.md` — modified
+- `scripts/audit.ts` — modified
+- `templates/common/scripts/SCRIPTS.md` — modified
+
+## Decisions
+- None
+
+## Open Issues
+- None

--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
   "devDependencies": {
     "@types/node": "^20.19.43",
     "glob": "^11.1.0",
-    "js-yaml": "^4.2.0",
+    "js-yaml": "^4.3.0",
     "tsx": "^4.22.4",
     "typescript": "^5.9.3"
   },
@@ -59,8 +59,8 @@
     "@resvg/resvg-js": "^2.6.2",
     "codegraph": "^1.0.0",
     "fast-xml-parser": "^5.9.3",
-    "playwright": "^1.61.0",
-    "semver": "^7.8.4",
+    "playwright": "^1.61.1",
+    "semver": "^7.8.5",
     "simple-git": "^3.36.0"
   },
   "overrides": {

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -53,7 +53,7 @@ bun run <alias>                     # via package.json alias (preferred for CI)
 | `agent-verify.ts` | L0 | 1.0.1 | active | —| —| L0+L1 | —|
 | `analyze-git-history.ts` | L0 | 1.0.1 | active | —| —| L0+L1 | —|
 | `archive-memory.ts` | L0 | 1.0.0 | active | —| —| L0+L1 | —|
-| `audit.ts` | L0 | 2.10.3 | active | —| —| L0+L1 | —|
+| `audit.ts` | L0 | 2.10.4 | active | —| —| L0+L1 | —|
 | `check-pm-approval.ts` | L0 | 1.0.1 | deprecated | 2026-11-30 | —| L0+L1 | —|
 | `cleanup-completed-md.ts` | L0 | 1.0.0 | active | —| —| L0+L1 | —|
 | `clear-pm-approval.ts` | L0 | 1.0.0 | active | —| —| L0+L1 | —|

--- a/scripts/SCRIPTS.md
+++ b/scripts/SCRIPTS.md
@@ -55,7 +55,7 @@ bun run <alias>                     # via package.json alias (preferred for CI)
 | `agent-verify.ts` | L0 | 1.0.1 | active | —| —| L0+L1 | —|
 | `analyze-git-history.ts` | L0 | 1.0.1 | active | —| —| L0+L1 | —|
 | `archive-memory.ts` | L0 | 1.0.0 | active | —| —| L0+L1 | —|
-| `audit.ts` | L0 | 2.10.3 | active | —| —| L0+L1 | —|
+| `audit.ts` | L0 | 2.10.4 | active | —| —| L0+L1 | —|
 | `check-pm-approval.ts` | L0 | 1.0.1 | deprecated | 2026-11-30 | —| L0+L1 | —|
 | `cleanup-completed-md.ts` | L0 | 1.0.0 | active | —| —| L0+L1 | —|
 | `clear-pm-approval.ts` | L0 | 1.0.0 | active | —| —| L0+L1 | —|

--- a/scripts/audit.ts
+++ b/scripts/audit.ts
@@ -1,4 +1,4 @@
-// @version 2.10.3
+// @version 2.10.4
 import { $ } from 'bun';
 import * as fs from 'node:fs';
 import * as path from 'node:path';
@@ -488,11 +488,8 @@ if (!LIFECYCLE_ONLY) {
 if (langValidate.exitCode === 0) {
     Pass('Language validation: no Korean-only markdown files found');
 } else {
-    // TEMPORARY: Skip language validation failure for existing co-consult.context.md issue
-    // TODO: Fix co-consult.context.md Korean content and re-enable this check
-    Warn('Language validation: Korean-only markdown files detected (SKIPPED - existing issue, pending fix)');
-    // Fail('Language validation: Korean-only markdown files detected');
-    // errors++;
+    Fail('Language validation: Korean-only markdown files detected');
+    errors++;
 }
 }
 

--- a/templates/common/scripts/README.md
+++ b/templates/common/scripts/README.md
@@ -53,7 +53,7 @@ bun run <alias>                     # via package.json alias (preferred for CI)
 | `agent-verify.ts` | L0 | 1.0.1 | active | —| —| L0+L1 | —|
 | `analyze-git-history.ts` | L0 | 1.0.1 | active | —| —| L0+L1 | —|
 | `archive-memory.ts` | L0 | 1.0.0 | active | —| —| L0+L1 | —|
-| `audit.ts` | L0 | 2.10.3 | active | —| —| L0+L1 | —|
+| `audit.ts` | L0 | 2.10.4 | active | —| —| L0+L1 | —|
 | `check-pm-approval.ts` | L0 | 1.0.1 | deprecated | 2026-11-30 | —| L0+L1 | —|
 | `cleanup-completed-md.ts` | L0 | 1.0.0 | active | —| —| L0+L1 | —|
 | `clear-pm-approval.ts` | L0 | 1.0.0 | active | —| —| L0+L1 | —|

--- a/templates/common/scripts/SCRIPTS.md
+++ b/templates/common/scripts/SCRIPTS.md
@@ -55,7 +55,7 @@ bun run <alias>                     # via package.json alias (preferred for CI)
 | `agent-verify.ts` | L0 | 1.0.1 | active | —| —| L0+L1 | —|
 | `analyze-git-history.ts` | L0 | 1.0.1 | active | —| —| L0+L1 | —|
 | `archive-memory.ts` | L0 | 1.0.0 | active | —| —| L0+L1 | —|
-| `audit.ts` | L0 | 2.10.3 | active | —| —| L0+L1 | —|
+| `audit.ts` | L0 | 2.10.4 | active | —| —| L0+L1 | —|
 | `check-pm-approval.ts` | L0 | 1.0.1 | deprecated | 2026-11-30 | —| L0+L1 | —|
 | `cleanup-completed-md.ts` | L0 | 1.0.0 | active | —| —| L0+L1 | —|
 | `clear-pm-approval.ts` | L0 | 1.0.0 | active | —| —| L0+L1 | —|

--- a/templates/common/scripts/audit.ts
+++ b/templates/common/scripts/audit.ts
@@ -1,4 +1,4 @@
-// @version 2.10.3
+// @version 2.10.4
 import { $ } from 'bun';
 import * as fs from 'node:fs';
 import * as path from 'node:path';
@@ -488,11 +488,8 @@ if (!LIFECYCLE_ONLY) {
 if (langValidate.exitCode === 0) {
     Pass('Language validation: no Korean-only markdown files found');
 } else {
-    // TEMPORARY: Skip language validation failure for existing co-consult.context.md issue
-    // TODO: Fix co-consult.context.md Korean content and re-enable this check
-    Warn('Language validation: Korean-only markdown files detected (SKIPPED - existing issue, pending fix)');
-    // Fail('Language validation: Korean-only markdown files detected');
-    // errors++;
+    Fail('Language validation: Korean-only markdown files detected');
+    errors++;
 }
 }
 


### PR DESCRIPTION
[claude pr-body] Attempt 1/2
[claude pr-body]  Success on attempt 1
## Why
The audit script's language validation was previously disabled (likely as a temporary workaround) while `co-consult.context.md` contained content that triggered false positives. With that file now fixed, re-enabling the validation restores the English-only documentation policy enforcement and prevents future regressions in locale compliance.

## What Changed
- Re-enabled language validation in `scripts/audit.ts` (removed the bypass/short-circuit that had disabled the check)
- Mirrored the same change in `templates/common/scripts/audit.ts` to keep the common template in sync
- Updated version references in `package.json`, `bun.lock`, and `docs/VERSION_MANIFEST.md`
- Refreshed docs in `scripts/README.md`, `scripts/SCRIPTS.md`, and their `templates/common/scripts/` counterparts
- Appended a session entry to `memory/2026-06-28.md` documenting the re-enablement

## Test Plan
- [ ] `bash scripts/audit.sh` passes
- [ ] Confirm language validation now runs (e.g., introduce a non-English string in a docs file and verify the audit flags it)
- [ ] Verify `bun scripts/audit.ts` exits cleanly against the current tree

## Security Checklist
- [ ] No secrets, credentials, or API keys committed
- [ ] No `.env` files staged (use `.env.sample` for templates)
- [ ] Dependencies unchanged or reviewed for new CVEs

## Notes
None