### PR TITLE
feat(co-consult): add Phase 1.5 Cross-Validation for research deliverables

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
 
+- **[2026-06-28]**: feat(co-consult): Phase 1.5 Cross-Validation — validator agents cross-check Phase 1 research deliverables for consistency before insight-synthesis; cross-validation matrix, checklist, and re-execution triggers added to engagement-orchestration.md
+
 ### Added
 - **[2026-06-28]**: docs(co-consult): update md-to-report design spec v1.1 (Korean default + DOCX-first PDF) and co-consult.context.md v2.2 (Korean default language convention + `_ko.md` suffix for deliverables)
 - **[2026-06-28]**: feat(co-deck): preview Tier 1 — FullscreenManager + @media print — (1) ppt-engine.js: `FullscreenManager` object (F key toggle + footer button ⤢/⤡, fullscreenchange event listener, Escape exits fullscreen first); (2) ppt-engine.css: `#fullscreen-btn.active` accent color + `@media print` block (one slide per page in landscape, all UI chrome hidden, block flow with page-break-after); (3) base.css: `@media print` block for pitch theme fallback; (4) all 5 template.html: fullscreen button added (outline/pitch-enhanced/zen: footer-right; vertical: topbar-right; pitch: inline onclick); (5) THEMES.md: FullscreenManager + @media print + F key in feature table; (6) co-deck.context.md v4.2: updated PPT-Engine feature list; (7) co-deck1: all changes propagated

--- a/docs/VERSION_MANIFEST.md
+++ b/docs/VERSION_MANIFEST.md
@@ -1,6 +1,6 @@
 # VERSION_MANIFEST.md
 
-**Generated**: 2026-06-28T14:42:50.680Z
+**Generated**: 2026-06-28T14:47:32.419Z
 **Manifest Version**: 1.0
 **Location**: docs\VERSION_MANIFEST.md
 

--- a/docs/VERSION_MANIFEST.md
+++ b/docs/VERSION_MANIFEST.md
@@ -1,6 +1,6 @@
 # VERSION_MANIFEST.md
 
-**Generated**: 2026-06-28T14:02:35.483Z
+**Generated**: 2026-06-28T14:42:50.680Z
 **Manifest Version**: 1.0
 **Location**: docs\VERSION_MANIFEST.md
 

--- a/memory/2026-06-28.md
+++ b/memory/2026-06-28.md
@@ -633,3 +633,55 @@ fix(audit): re-enable language validation after co-consult.context.md fix
 
 ## Open Issues
 - None
+
+---
+
+## Session Summary
+feat(co-consult): add Phase 1.5 Cross-Validation for research deliverables
+
+## Changes
+- `M templates/co-consult/docs/co-consult.context.md` — modified
+- `templates/co-consult/docs/engagement-orchestration.md` — modified
+- `templates/co-consult/docs/team-configuration-guide.md` — modified
+
+## Decisions
+- None
+
+## Open Issues
+- None
+
+---
+
+## Session Summary
+feat(co-consult): add Phase 1.5 Cross-Validation for research deliverables
+
+## Changes
+- `CHANGELOG.md` — modified
+- `memory/2026-06-28.md` — modified
+- `templates/co-consult/docs/co-consult.context.md` — modified
+- `templates/co-consult/docs/engagement-orchestration.md` — modified
+- `templates/co-consult/docs/team-configuration-guide.md` — modified
+
+## Decisions
+- None
+
+## Open Issues
+- None
+
+---
+
+## Session Summary
+feat(co-consult): add Phase 1.5 Cross-Validation for research deliverables
+
+## Changes
+- `CHANGELOG.md` — modified
+- `memory/2026-06-28.md` — modified
+- `templates/co-consult/docs/co-consult.context.md` — modified
+- `templates/co-consult/docs/engagement-orchestration.md` — modified
+- `templates/co-consult/docs/team-configuration-guide.md` — modified
+
+## Decisions
+- None
+
+## Open Issues
+- None

--- a/memory/2026-06-28.md
+++ b/memory/2026-06-28.md
@@ -685,3 +685,17 @@ feat(co-consult): add Phase 1.5 Cross-Validation for research deliverables
 
 ## Open Issues
 - None
+
+---
+
+## Session Summary
+feat(co-consult): add Phase 1.5 Cross-Validation for research deliverables
+
+## Changes
+- N/A
+
+## Decisions
+- None
+
+## Open Issues
+- None

--- a/templates/co-consult/docs/co-consult.context.md
+++ b/templates/co-consult/docs/co-consult.context.md
@@ -159,6 +159,7 @@ Engagement Leader
 |-------|------|--------------|---------------|
 | 0 | Engagement Initiation | Engagement Leader defines scope, assembles team, confirms client objectives | Engagement Leader |
 | 1 | Research & Data Gathering | Strategy Analyst conducts market/competitive research; Change Management Partner assesses org readiness | Strategy Analyst, Change Management Partner |
+| 1.5 | Cross-Validation | Validator agents cross-check Phase 1 deliverables for consistency before synthesis | PM (dispatches validators) |
 | 2 | Design Review & Approval | Proposed approach presented to client/user; **approval gate** — no execution without sign-off | Engagement Leader |
 | 3 | Content Creation | Communications Lead drafts client deliverables; Solutions Architect designs technical solutions (parallel) | Communications Lead, Solutions Architect |
 | 4 | Platform Delivery | Delivery Manager coordinates stakeholder reviews; Technology Specialist implements M365 workflows | Delivery Manager, Technology Specialist |
@@ -271,7 +272,8 @@ Each agent must save its deliverables to the designated folder with the specifie
 6. All agent-produced deliverables MUST be saved to their designated output folder per the **Output Destination Mapping** table above. Agents MUST read this table before saving any file. Do not hard-code output paths in agent or skill definitions — this table is the single source of truth. Create the destination folder if it does not exist.
 7. **Default deliverable language is Korean**. Unless the client explicitly requests another language, all deliverables MUST be written in Korean and saved with the `_ko.md` file suffix (e.g., `semiconductor-trends-2026-06-28_ko.md`). English-language deliverables use `.md` without suffix only when requested.
 8. Markdown deliverables in `deliverables/` can be converted to client-ready DOCX reports using `bun scripts/co-consult/md-to-report.ts <file.md>`. Output is saved alongside the source file (e.g., `report_ko.md` → `report_ko.docx`). Requires project dependency (`docx`) installed via `bun install`. PDF conversion is out of scope for this script — convert DOCX to PDF manually via Word or any office application.
+9. Phase 1 research deliverables MUST pass cross-validation before entering `insight-synthesis`. PM dispatches validator agents per the Cross-Validation Matrix in [`engagement-orchestration.md`](engagement-orchestration.md). See Phase 1.5 Cross-Validation section for checklist and re-execution triggers.
 
 ---
 
-*co-consult.context.md version: 2.2 — Korean default language, DOCX-only report generation*
+*co-consult.context.md version: 2.3 — Phase 1.5 Cross-Validation*

--- a/templates/co-consult/docs/engagement-orchestration.md
+++ b/templates/co-consult/docs/engagement-orchestration.md
@@ -9,14 +9,22 @@
 ```
 Phase 1 ─────────────────────────────────────────────────────────────
   competitive-intelligence  ──┐
-  org-readiness-assessment  ──┤──► insight-synthesis ──► Phase 2 Gate
+  org-readiness-assessment  ──┤──► insight-synthesis
   technical-feasibility (draft)┘
-
-Phase 1-2 Iteration Loop (max 2x) ───────────────────────────────────
+         │
+         ▼
+Phase 1.5 Cross-Validation ─────────────────────────────────────────
+  [PM dispatches validator agents per Cross-Validation Matrix]
+  → Validators review Phase 1 deliverables (read-only findings)
+  → PM synthesizes findings, requests fixes if needed
+  (max 1 revision cycle per deliverable)
+         │
+         ▼
+Phase 1-2 Iteration Loop (max 2x) ─────────────────────────────────
   technical-feasibility ◄──► financial-modeling
   Exit: cost fits budget | Engagement Leader escalates
 
-Phase 2 Gate ────────────────────────────────────────────────────────
+Phase 2 Gate ──────────────────────────────────────────────────────
   insight-synthesis output + financial-modeling output
   → Engagement Leader presents → Client/User approval required
 
@@ -64,6 +72,50 @@ When iteration limits are reached without resolution:
 
 ---
 
+## Phase 1.5 Cross-Validation
+
+After all Phase 1 research deliverables are complete and before `insight-synthesis`, the PM dispatches validator agents to cross-check deliverable consistency. This step catches contradictions, unsupported claims, and feasibility gaps before synthesis.
+
+### Cross-Validation Matrix
+
+| Validator | Validates | Check Focus |
+|-----------|-----------|-------------|
+| Strategy Analyst | Industry Expert | Strategic plausibility of industry trends, competitive dynamics, and market sizing |
+| Industry Expert | Strategy Analyst | Sector-specific validity of market analysis, competitive assessments, and strategic options |
+| SME | Industry Expert | Functional feasibility of sector-specific recommendations and implementation viability |
+| Data Analyst | Strategy Analyst | Statistical rigor of data-driven claims, methodology soundness, and evidence quality |
+| Change Management Partner | SME | Organizational readiness implications of functional solutions and change impact assessment |
+
+### Validation Principles
+
+1. **Read-only**: Validators review and report findings only — they do NOT modify the original deliverable.
+2. **PM orchestrates**: PM dispatches validators, collects findings, and decides whether fixes are needed.
+3. **Timing**: Cross-validation runs after all Phase 1 deliverables are marked complete, before `insight-synthesis` begins.
+4. **Scope**: Only Phase 1 research deliverables (`deliverables/research/`) are in scope.
+
+### Cross-Validation Checklist
+
+Validators check each deliverable against the following criteria:
+
+| # | Check Item | Severity | Example |
+|---|-----------|----------|---------|
+| C1 | Key claims do not contradict findings in other agents' deliverables | Critical | Strategy says "market growing 15%" but Industry Expert data shows "mature market, 3% growth" |
+| C2 | Data/statistical citations have documented sources and sound methodology | High | Financial model uses unverified growth assumptions |
+| C3 | Industry/function recommendations are practically implementable | High | Industry Expert recommends full digital transformation but SME's org readiness assessment shows low digital maturity |
+| C4 | Common terminology and definitions are used consistently across agents | Moderate | "Digital transformation" defined differently by Strategy Analyst vs SME |
+| C5 | Analysis scope stays within the defined project boundaries | Moderate | SME analysis covers out-of-scope organizational functions |
+
+### Cross-Validation Re-execution Triggers
+
+| Trigger Event | Action | Authorized By |
+|---------------|--------|---------------|
+| Cross-validation finds Critical (C1) contradiction | Original author revises deliverable → validator re-checks (max 1x) | PM |
+| Cross-validation finds High-severity (C2/C3) gap | Original author addresses gap or documents accepted rationale | PM |
+| Moderate (C4/C5) finding | Logged as advisory — no mandatory fix; PM may request if pattern detected across multiple agents | PM |
+| Max revision cycle exhausted without resolution | PM documents as accepted risk in `memory/YYYY-MM-DD.md`, proceeds to Phase 2 | PM |
+
+---
+
 ## Prerequisites Enforcement
 
 Skills with declared prerequisites must not be invoked until all prerequisites are complete. The Engagement Leader is responsible for gate-keeping:
@@ -79,4 +131,4 @@ Skills with declared prerequisites must not be invoked until all prerequisites a
 
 ---
 
-*engagement-orchestration.md version: 1.0 — created 2026-06-03*
+*engagement-orchestration.md version: 1.1 — added Phase 1.5 Cross-Validation*

--- a/templates/co-consult/docs/team-configuration-guide.md
+++ b/templates/co-consult/docs/team-configuration-guide.md
@@ -182,6 +182,7 @@ Match agent tier to task complexity:
 ### 5. Governance Checkpoints
 Regardless of scenario size, always include:
 - **Phase 0**: Scope alignment and team confirmation with client
+- **Phase 1.5**: Cross-validation of Phase 1 deliverables before synthesis (see [`engagement-orchestration.md`](engagement-orchestration.md))
 - **Phase 2**: Design review and user/client approval gate before execution
 - **Phase 5-6**: QA gate and formal handoff
 


### PR DESCRIPTION
[claude pr-body] Attempt 1/2
[claude pr-body]  Success on attempt 1
## Why
Phase 1 research deliverables in the co-consult template are produced independently by multiple agents (Strategy Analyst, Industry Expert, SME, etc.), so contradictions, unsupported claims, and feasibility gaps only surface late — during or after `insight-synthesis`. This inserts a cross-validation gate before synthesis so those issues are caught while they are still cheap to fix.

## What Changed
- **`engagement-orchestration.md` (v1.0 → v1.1)**: Added a new **Phase 1.5 Cross-Validation** section, including a Cross-Validation Matrix (5 validator/validatee pairs), four validation principles (read-only, PM-orchestrated, post-Phase-1 timing, research-only scope), a 5-item checklist (C1–C5 with severity levels), and a re-execution triggers table (max 1 revision cycle).
- Updated the Phase 1 flow diagram to insert the Phase 1.5 cross-validation step between `insight-synthesis` and the Phase 1–2 iteration loop.
- **`co-consult.context.md` (v2.2 → v2.3)**: Inserted the **Phase 1.5 Cross-Validation** row into the engagement phase table and added rule #9 requiring Phase 1 research deliverables to pass cross-validation before entering `insight-synthesis`.
- **`team-configuration-guide.md`**: Added Phase 1.5 to the mandatory Governance Checkpoints list (cross-ref to `engagement-orchestration.md`).
- **`CHANGELOG.md`**: Added `[Unreleased]` entry for the feature.
- **`memory/2026-06-28.md`**: Appended session summary. **`docs/VERSION_MANIFEST.md`**: Regenerated timestamp.

## Test Plan
- [ ] `bun scripts/audit.ts` passes (project audit gate — runs via bun, not `audit.sh`)
- [ ] Verify Phase 1.5 row renders correctly in the engagement phase table of `co-consult.context.md`
- [ ] Confirm Cross-Validation Matrix and Checklist tables render in `engagement-orchestration.md`
- [ ] Cross-check that the rule numbers (C1–C5), severities, and re-execution triggers are internally consistent across the three updated docs

## Security Checklist
- [x] No secrets, credentials, or API keys committed
- [x] No `.env` files staged (use `.env.sample` for templates)
- [x] Dependencies unchanged or reviewed for new CVEs

## Notes
None — documentation-only change to the `co-consult` template; no runtime code, dependencies, or behavior affected. No deployment steps required.