### PR TITLE
docs(constitution): document L0 agent non-propagation as intentional design

### DIFF
--- a/CONSTITUTION.md
+++ b/CONSTITUTION.md
@@ -370,7 +370,7 @@ The `templates/common/` directory is the shared foundation for all variant templ
 
 | Category | Condition | Examples |
 |----------|-----------|---------|
-| **Common agent** | Exists identically across all variants | `pm.md`, `automation-engineer.md` |
+| **Common agent** | Exists identically across all variants | `pm.md` |
 | **Common skill** | Used in all variants without modification | `project-review`, `meeting-facilitation`, `audit-workspace`, `security-scan`, `skill-lifecycle-manager`, `agent-lifecycle-manager` |
 | **Variant-specific** | Unique to one variant; not applicable elsewhere | Domain-expert agents, variant-only skills |
 
@@ -385,6 +385,30 @@ Additive overrides are concatenated with the common file during scaffolding. Rep
 
 #### Anti-Swelling Rule
 If **≥ 50 %** of variants declare an override for the same agent or skill, the common definition must be updated instead of accumulating per-variant overrides. `bun scripts/validate-templates.ts` enforces this threshold and will fail with an actionable error listing the affected files.
+
+#### L0 Agent Non-Propagation
+
+L0 specialist agents (`architect.md`, `auditor.md`, `automation-engineer.md`,
+`docs-writer.md`, `lifecycle-manager.md`, `scaffolding-expert.md`,
+`security-expert.md`) are **not** propagated to `templates/common/agents/`.
+This is intentional — see ADR-0039 (L0→L1→L2 Hierarchy) and ADR-0040
+(L0→L1 Deployment Strategy).
+
+**Rationale**:
+- **PM is the only agent with an L0→L1→L2 extends chain.** Specialist agents are
+  dispatched by PM and resolved at runtime by the AI platform — they do not
+  require a template-layer copy.
+- **Variant projects define their own specialist agents.** L2 variants declare
+  domain-specific agents in their `variant.json` `agent_roster`, which may
+  differ from the L0 roster (e.g., a co-security variant uses `red-team-lead`
+  instead of `architect`).
+- **Bottom-up promotion instead of top-down propagation.** If a specialist agent
+  becomes common across 3+ variants (Jaccard similarity ≥ 80%), it may be
+  promoted to L1 via the process described in ADR-0043 (L1 Agent Layer Hybrid
+  Override). This is a separate, intentional workflow distinct from L0→L1
+  propagation.
+
+**Current L1 agent**: Only `pm.md` (uses `extends: ../../../agents/pm.md`).
 
 #### Adding a New Common Agent or Skill
 1. Add the file to `templates/common/agents/` or `templates/common/skills/`.

--- a/scripts/propagation-map.json
+++ b/scripts/propagation-map.json
@@ -1,5 +1,5 @@
 {
-  "_comment": "Propagation map: L0 (workspace root) → L1 (templates/common/) for scripts/skills/commands; L1 (templates/common/) → L2 (templates/co-*/) for governance docs via marker-inject mode.",
+  "_comment": "Propagation map: L0 (workspace root) → L1 (templates/common/) for scripts/skills/commands; L1 (templates/common/) → L2 (templates/co-*/) for governance docs via marker-inject mode. Agents are intentionally excluded from L0→L1 propagation — only pm.md uses an explicit extends chain (ADR-0039, ADR-0040). Specialist agents are variant-defined (ADR-0043).",
   "version": "1.2.0",
   "domains": {
     "scripts": {

--- a/templates/common/agents/_COMMON.md
+++ b/templates/common/agents/_COMMON.md
@@ -19,6 +19,13 @@ See `common-contract.json` for:
 - Override type rules (additive vs. replacement)
 - Anti-swelling threshold (50% rule)
 
+## L0 Agent Non-Propagation
+
+Only `pm.md` exists in this directory. L0 specialist agents (architect, auditor,
+automation-engineer, docs-writer, lifecycle-manager, scaffolding-expert,
+security-expert) are intentionally **not** propagated here. Variant projects
+define their own specialist agents. See docs/context.md §7.5 and ADR-0043.
+
 ## Override Types
 
 | Type | Description | Approval |

--- a/templates/common/scripts/propagation-map.json
+++ b/templates/common/scripts/propagation-map.json
@@ -1,5 +1,5 @@
 {
-  "_comment": "Propagation map: L0 (workspace root) → L1 (templates/common/) for scripts/skills/commands; L1 (templates/common/) → L2 (templates/co-*/) for governance docs via marker-inject mode.",
+  "_comment": "Propagation map: L0 (workspace root) → L1 (templates/common/) for scripts/skills/commands; L1 (templates/common/) → L2 (templates/co-*/) for governance docs via marker-inject mode. Agents are intentionally excluded from L0→L1 propagation — only pm.md uses an explicit extends chain (ADR-0039, ADR-0040). Specialist agents are variant-defined (ADR-0043).",
   "version": "1.2.0",
   "domains": {
     "scripts": {


### PR DESCRIPTION
## Summary

Clarifies that L0 specialist agents (architect, auditor, automation-engineer, docs-writer, lifecycle-manager, scaffolding-expert, security-expert) are **intentionally not** propagated to L1 (`templates/common/agents/`). Only `pm.md` uses an explicit L0→L1→L2 extends chain.

## Changes

| File | Change |
|------|--------|
| `CONSTITUTION.md` §7.5 | Fix stale `automation-engineer.md` reference in Classification Criteria + add **L0 Agent Non-Propagation** subsection with rationale (ADR-0039, ADR-0040, ADR-0043) |
| `scripts/propagation-map.json` | Add agents exclusion note to `_comment` field |
| `templates/common/agents/_COMMON.md` | Add **L0 Agent Non-Propagation** section explaining why only `pm.md` exists in L1 |
| `templates/common/scripts/propagation-map.json` | Sync L1 copy with L0 |

## Rationale

- PM is the only agent with an L0→L1→L2 extends chain (ADR-0039)
- Specialist agents are dispatched by PM at runtime — no template-layer copy needed
- Variant projects define their own specialist agents in `variant.json` (ADR-0040)
- Bottom-up promotion via ADR-0043 if a specialist becomes common across 3+ variants