### PR TITLE
docs(governance): add CONSTITUTION.md non-propagation principle and fix L1 references

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,6 +1,7 @@
 # CLAUDE.md
 
 > **Shared workspace setup, session start checklist, project structure, and design standards live in [`CONSTITUTION.md`](CONSTITUTION.md) - read it first and the files listed in its `## Required Reading` block.**
+<!-- L0-ONLY: This instruction targets the workspace root (L0). L1/L2 projects must NOT reference CONSTITUTION.md — see CONSTITUTION.md §7.5 CONSTITUTION.md Non-Propagation. merge-frontmatter.ts strips CONSTITUTION.md lines from L2 output. -->
 
 ---
 

--- a/CONSTITUTION.md
+++ b/CONSTITUTION.md
@@ -410,6 +410,32 @@ This is intentional — see ADR-0039 (L0→L1→L2 Hierarchy) and ADR-0040
 
 **Current L1 agent**: Only `pm.md` (uses `extends: ../../../agents/pm.md`).
 
+#### CONSTITUTION.md Non-Propagation
+
+`CONSTITUTION.md` is the L0 workspace-root governance document. It must **never** be
+present in L1 (`templates/common/`) or L2 (variant projects), and L1/L2 `.md` files
+must **not** contain references to it.
+
+**Rules**:
+- `CONSTITUTION.md` is on the blocklist in
+  [`docs/governance/variant-contract.md`](docs/governance/variant-contract.md) —
+  `validate-templates.ts` Check 0 blocks any copy in `templates/common/`.
+- L1 and L2 documentation (`.md` files, agent definitions, skill specs, CLAUDE.md,
+  GEMINI.md) must **not** reference `CONSTITUTION.md` by file path, section anchor,
+  or markdown link.
+- **L2 substitute**: generated projects use `docs/context.md` and
+  `<variant>.context.md` instead.
+- The session-start directive in CLAUDE.md / GEMINI.md ("read CONSTITUTION.md first")
+  is L0-only; `merge-frontmatter.ts` strips CONSTITUTION.md references from L2
+  output during scaffolding.
+
+**Enforcement**:
+- `audit.ts` L0 Leakage check scans all `.md` files under `templates/` for
+  unauthorized `CONSTITUTION.md` or `docs/constitution/` references.
+- The `intentional-duplicate` HTML comment is the sole escape hatch — it exempts
+  the containing file from the L0 Leakage check. Use it **only** when the file is
+  verified to be L1-only (i.e., never copied into L2 variants).
+
 #### Adding a New Common Agent or Skill
 1. Add the file to `templates/common/agents/` or `templates/common/skills/`.
 2. Register it in `docs/templates/common-contract.json`.

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -1,6 +1,7 @@
 # GEMINI.md
 
 > **Shared workspace setup, session start checklist, project structure, and design standards live in [`CONSTITUTION.md`](CONSTITUTION.md) - read it first and the files listed in its `## Required Reading` block.**
+<!-- L0-ONLY: This instruction targets the workspace root (L0). L1/L2 projects must NOT reference CONSTITUTION.md — see CONSTITUTION.md §7.5 CONSTITUTION.md Non-Propagation. merge-frontmatter.ts strips CONSTITUTION.md lines from L2 output. -->
 
 ---
 

--- a/docs/governance/variant-contract.md
+++ b/docs/governance/variant-contract.md
@@ -106,7 +106,7 @@ The following files MUST NOT exist in `templates/common/`. If present, `validate
 
 | File | Reason |
 |------|--------|
-| `CONSTITUTION.md` | Workspace governance SSOT — projects reference via URL, not file copy |
+| `CONSTITUTION.md` | Workspace governance SSOT — never propagated to L1/L2. L1/L2 docs must NOT contain CONSTITUTION.md references (file path, section anchors, or markdown links). Use `docs/context.md` instead. |
 
 <!-- NOTE: CLAUDE.md and GEMINI.md are intentionally NOT on this blocklist.
      They are provided via the common layer (templates/common/) and inherited by all

--- a/templates/common/docs/_templates/variant-pm-spec.md
+++ b/templates/common/docs/_templates/variant-pm-spec.md
@@ -137,5 +137,4 @@ Extends chain validation enforces security constraints:
 - **ADR-0032**: Auto-Mode Deprecation rationale and implementation
 - **ADR-0033**: Complete L0→L1→L2 hierarchy specification
 - **ADR-0031**: L1-L2 Fork Model governance
-- **CONSTITUTION.md §5**: Multi-agent architecture rules
-<!-- intentional-duplicate: CONSTITUTION.md referenced as L0 governance source (this file is L1-only, never propagates to L2) -->
+- **Multi-agent architecture rules**: Defined in workspace governance docs/context.md §5


### PR DESCRIPTION
## Summary

L1/L2 템플릿에서 CONSTITUTION.md를 참조하지 않아야 하는 원칙을 명시적으로 문서화하고, 기존의 문제가 있던 참조를 수정합니다.

## Changes

### 1. CONSTITUTION.md §7.5 — `CONSTITUTION.md Non-Propagation` 섹션 추가
- L1/L2에서 CONSTITUTION.md 파일 복사 및 참조 금지 원칙을 명문화
- blocklist, L0 Leakage check, intentional-duplicate 예외 조건, L2 대체 파일 등 규칙 명시

### 2. `templates/common/docs/_templates/variant-pm-spec.md` — CONSTITUTION.md 직접 참조 제거
- `CONSTITUTION.md §5` 직접 참조를 `docs/context.md §5`로 교체
- `intentional-duplicate` HTML 주석 우회 제거 (해당 파일은 L1에 존재하므로 L2로 전파 가능)

### 3. `docs/governance/variant-contract.md` — Blocklist 설명 강화
- CONSTITUTION.md blocklist 이유를 단순 "projects reference via URL"에서
  명시적인 "L1/L2 docs must NOT contain CONSTITUTION.md references"로 강화

### 4. CLAUDE.md / GEMINI.md — L0-ONLY 가드 주석 추가
- 세션 시작 지시어("read CONSTITUTION.md first")에 L0 전용임을 명시하는 주석 추가
- `merge-frontmatter.ts`가 L2 생성 시 해당 줄을 자동 제거함

## Verification

- ✅ `audit.ts` L0 Leakage check: PASS (no unauthorized CONSTITUTION references in templates)
- ✅ Pre-push audit: all checks passed
- ✅ No FAIL items in full audit run