### PR TITLE
fix(scripts): add L0/L1 context guards to lifecycle audit and sync scripts

### DIFF
--- a/.claude/post-checkout.log
+++ b/.claude/post-checkout.log
@@ -1,1 +1,1 @@
-API Error: 529 [1305][The service may be temporarily overloaded, please try again later][20260626153920382f2c39255e48cd]. This is a server-side issue, usually temporary — try again in a moment. If it persists, check your inference gateway (api.z.ai).
+Ignoring 7 permissions.allow entries from .claude/settings.json: this workspace has not been trusted. Run Claude Code interactively here once and accept the trust dialog, or set projects["C:/git/ai_workspace"].hasTrustDialogAccepted: true in C:\Users\USER\.claude.json.

--- a/docs/constitution/06.5-script-lifecycle.md
+++ b/docs/constitution/06.5-script-lifecycle.md
@@ -121,3 +121,79 @@ Scripts with scope `L0` in SCRIPTS.md are excluded at the **L0→L1 propagation 
 To mark a script as workspace-only, set its scope to `L0` in SCRIPTS.md. No file-header annotation is required.
 
 **Current L0-only scripts (examples)**: `upgrade-project.ts`, `new-project.ts`, `propagate-to-templates.ts`
+
+#### L0+L1 Script Runtime Context Guard Convention
+
+Scripts with scope `L0+L1` exist in both the workspace root (`scripts/`) and `templates/common/scripts/`. When a new project is scaffolded, these scripts are copied into the L2 project. At that point, `CONSTITUTION.md` is **not** present — L2 projects use `docs/context.md` instead (see [CONSTITUTION.md §7.5](../../CONSTITUTION.md) — *CONSTITUTION.md Non-Propagation*).
+
+**All `L0+L1` scripts must gracefully handle L1/L2 context.** Follow this convention:
+
+##### 1. Canonical L0 Detection Pattern
+
+```typescript
+const CONSTITUTION_FILE = join(ROOT, 'CONSTITUTION.md');
+const IS_WORKSPACE_ROOT = existsSync(CONSTITUTION_FILE);
+```
+
+- **Always use `existsSync('CONSTITUTION.md')`** as the canonical L0 detection signal.
+- Do **not** use alternative heuristics (`existsSync('templates/common')`, file path checks, etc.) unless explicitly documented and justified.
+- Name the variable `IS_WORKSPACE_ROOT` for consistency across scripts.
+
+##### 2. Gate L0-Only Logic
+
+Any logic that requires workspace-root infrastructure (e.g., `AGENTS.md` registry, `scripts/SCRIPTS.md`, `templates/` hierarchy, L0→L1 publish) must be guarded:
+
+```typescript
+function runWorkspaceOnlyCheck(): Issue[] {
+  const issues: Issue[] = [];
+  if (!IS_WORKSPACE_ROOT) return issues;  // ← early return
+  // ... L0-only logic ...
+  return issues;
+}
+```
+
+**Examples of L0-only operations that require gating**:
+- Checking `AGENTS.md` registry consistency (no `AGENTS.md` in L2)
+- Comparing scripts/ against `SCRIPTS.md` (no `SCRIPTS.md` in L2)
+- Scanning `templates/common/` for sync drift (no `templates/` in L2)
+- L0→L1 publish (`propagate-to-templates.ts`)
+- L0-only content removal verification
+
+##### 3. Guard L0-Only Sub-Script Calls
+
+When an `L0+L1` script invokes another script that may only exist at L0, wrap the call with an `existsSync` guard:
+
+```typescript
+const auditTs = path.join('scripts', 'audit.ts');
+if (fs.existsSync(auditTs)) {
+  const result = await $`bun scripts/audit.ts`.nothrow();
+  // ... handle result ...
+}
+```
+
+**Scripts that may not exist in L2**: `audit.ts` (L0 workspace root), `sync-md.ts` (L0 workspace root), `propagate-to-templates.ts` (L0-only by scope).
+
+##### 4. Directory Scan Scope Limitation
+
+When scanning directories recursively at the project root, always restrict the scan to known subdirectories — do not recurse into arbitrary directories:
+
+```typescript
+// CORRECT: Always restrict root-level scan (L0 and L1/L2 alike)
+if (dir === ROOT) {
+  if (entry.name !== 'skills' && entry.name !== '.claude') continue;
+}
+```
+
+This prevents noise and false positives when the script runs in an L1/L2 project that may contain unrelated directories (`src/`, `docs/`, etc.).
+
+##### 5. Avoid Shadow Variables
+
+Do not introduce loop-local variables that reuse the name `isWorkspaceRoot` or `IS_WORKSPACE_ROOT` with different semantics. Use a distinct name (e.g., `isWorkspaceRootReadme`) that composes with the module-level `IS_WORKSPACE_ROOT`:
+
+```typescript
+// WRONG: shadow variable ignores IS_WORKSPACE_ROOT
+const isWorkspaceRoot = relPath === 'README.md';
+
+// CORRECT: composes with module-level detection
+const isWorkspaceRootReadme = IS_WORKSPACE_ROOT && relPath === 'README.md';
+```

--- a/templates/common/scripts/agent-lifecycle-audit.ts
+++ b/templates/common/scripts/agent-lifecycle-audit.ts
@@ -335,14 +335,17 @@ function auditAgents(jsonMode = false): AuditResult {
       });
     }
 
-    // Check 5: Agent not registered in AGENTS.md
+    // Check 5: Agent not registered in AGENTS.md (L0 workspace root — error;
+    // L1/L2 projects may not use AGENTS.md, so downgrade to informational)
     if (!registeredAgents.has(agentName) && frontmatter.status !== 'archived') {
-      warnings.push({
-        level: 'warning',
-        file: relPath,
-        message: `Agent not registered in AGENTS.md`,
-        fix: `Add to AGENTS.md agent roster table`,
-      });
+      if (IS_WORKSPACE_ROOT) {
+        warnings.push({
+          level: 'warning',
+          file: relPath,
+          message: `Agent not registered in AGENTS.md`,
+          fix: `Add to AGENTS.md agent roster table`,
+        });
+      }
     }
 
     // Check 6: Deprecated agents with active skill references
@@ -403,17 +406,19 @@ function auditAgents(jsonMode = false): AuditResult {
     }
   }
 
-  // Check 8: Agents registered in AGENTS.md but files don't exist
-  for (const agentName of registeredAgents) {
-    const agentPath1 = join(ROOT, 'agents', `${agentName}.md`);
-    const agentPath2 = join(ROOT, '.claude', 'agents', `${agentName}.md`);
-    if (!existsSync(agentPath1) && !existsSync(agentPath2)) {
-      errors.push({
-        level: 'error',
-        file: `agents/${agentName}.md`,
-        message: 'Registered in AGENTS.md but file not found',
-        fix: `Create agents/${agentName}.md or remove from AGENTS.md`,
-      });
+  // Check 8: Agents registered in AGENTS.md but files don't exist (L0 workspace root only)
+  if (IS_WORKSPACE_ROOT) {
+    for (const agentName of registeredAgents) {
+      const agentPath1 = join(ROOT, 'agents', `${agentName}.md`);
+      const agentPath2 = join(ROOT, '.claude', 'agents', `${agentName}.md`);
+      if (!existsSync(agentPath1) && !existsSync(agentPath2)) {
+        errors.push({
+          level: 'error',
+          file: `agents/${agentName}.md`,
+          message: 'Registered in AGENTS.md but file not found',
+          fix: `Create agents/${agentName}.md or remove from AGENTS.md`,
+        });
+      }
     }
   }
 

--- a/templates/common/scripts/dev-sync.ts
+++ b/templates/common/scripts/dev-sync.ts
@@ -11,6 +11,11 @@ const YELLOW = '\x1b[33m';
 const CYAN = '\x1b[36m';
 const RESET = '\x1b[0m';
 
+// Workspace Root Detection Convention:
+// All lifecycle/audit scripts MUST use the canonical pattern:
+//   const IS_WORKSPACE_ROOT = existsSync('CONSTITUTION.md');
+// dev-sync.ts additionally checks templates/common for L0→L1 publish eligibility.
+
 // Workspace root guard — dev-sync must run from the workspace root it belongs to.
 // Using import.meta.dir (script location) prevents CWD mismatches when two clones exist.
 const expectedRoot = resolve(import.meta.dir, '..');
@@ -66,8 +71,11 @@ ${fileLines}
 
 fs.appendFileSync(memoryFile, template, 'utf8');
 
-// 2. Update MEMORY.md index
-await $`bun run scripts/sync-md.ts ${date} "${msg}"`;
+// 2. Update MEMORY.md index (L0-only — sync-md.ts may not exist in L1/L2 projects)
+const syncMdTs = path.join('scripts', 'sync-md.ts');
+if (fs.existsSync(syncMdTs)) {
+    await $`bun run scripts/sync-md.ts ${date} "${msg}"`;
+}
 
 
 // 2.5 Generate scripts/README.md
@@ -138,12 +146,15 @@ if (fs.existsSync(specRegPath)) {
     await $`bun scripts/audit.ts --spec-check --lifecycle-only`.quiet().nothrow();
 }
 
-// 4. Audit gate — call audit.ts directly (platform-independent, no shell intermediary)
-const auditRes = await $`bun scripts/audit.ts`.nothrow();
+// 4. Audit gate — call audit.ts directly (L0-only — audit.ts may not exist in L1/L2 projects)
+const auditTs = path.join('scripts', 'audit.ts');
+if (fs.existsSync(auditTs)) {
+    const auditRes = await $`bun scripts/audit.ts`.nothrow();
 
-if (auditRes.exitCode !== 0) {
-    if (import.meta.main) {
-      process.exit(1);
+    if (auditRes.exitCode !== 0) {
+        if (import.meta.main) {
+          process.exit(1);
+        }
     }
 }
 
@@ -162,9 +173,10 @@ if (fs.existsSync(genManifestTs)) {
 }
 
 // 4.7 L0→L1 publish (workspace root only)
-const isWorkspaceRoot = fs.existsSync('templates/common') && fs.existsSync('scripts/propagation-map.json');
-// L0 context: CONSTITUTION.md exists at workspace root — publish failures are fatal here.
+// Canonical L0 detection: CONSTITUTION.md exists at workspace root.
+// isWorkspaceRoot adds templates/common + propagation-map.json checks for L0→L1 publish eligibility.
 const isL0Context = fs.existsSync('CONSTITUTION.md');
+const isWorkspaceRoot = isL0Context && fs.existsSync('templates/common') && fs.existsSync('scripts/propagation-map.json');
 if (isWorkspaceRoot) {
     console.log('\n📦 Publishing L0→L1 (scripts, skills, commands)...');
     try {

--- a/templates/common/scripts/lifecycle-sync-audit.ts
+++ b/templates/common/scripts/lifecycle-sync-audit.ts
@@ -169,6 +169,9 @@ function extractFileVersion(filePath: string): string | null {
 function runCheckA(): SyncIssue[] {
   const issues: SyncIssue[] = [];
 
+  // Check A is L0-only: verifies L0 scripts/SCRIPTS.md registry consistency
+  if (!IS_WORKSPACE_ROOT) return issues;
+
   if (!existsSync(SCRIPTS_MD)) {
     issues.push({
       level: 'error',

--- a/templates/common/scripts/readme-lifecycle-audit.ts
+++ b/templates/common/scripts/readme-lifecycle-audit.ts
@@ -242,21 +242,22 @@ function auditReadmes(jsonMode = false): AuditResult {
   for (const readmeFile of readmeFiles) {
     const relPath = relative(ROOT, readmeFile).replace(/\\/g, '/');
     const isKorean = readmeFile.endsWith('README_ko.md');
-    // Only the workspace-root EN README requires specific sections;
+    // Only the L0 workspace-root EN README requires specific sections;
     // KO variants are checked via i18n consistency, templates/README.md has its own structure.
-    const isWorkspaceRoot = relPath === 'README.md';
+    // In L1/L2 projects (no CONSTITUTION.md), all READMEs use project-level requirements.
+    const isWorkspaceRootReadme = IS_WORKSPACE_ROOT && relPath === 'README.md';
     const sections = parseSections(readmeFile);
 
     // Check required sections (EN workspace root only — skip KO and templates/README)
-    const requiredSections = isWorkspaceRoot ? REQUIRED_SECTIONS_ROOT : REQUIRED_SECTIONS_PROJECT;
+    const requiredSections = isWorkspaceRootReadme ? REQUIRED_SECTIONS_ROOT : REQUIRED_SECTIONS_PROJECT;
     for (const section of requiredSections) {
       if (!Array.from(sections.keys()).some(s => s.includes(section))) {
-        const level = isWorkspaceRoot ? 'error' : 'warning';
+        const level = isWorkspaceRootReadme ? 'error' : 'warning';
         const issue = {
           level: level as 'error' | 'warning',
           file: relPath,
           message: `Missing required section: ${section}`,
-          fix: isWorkspaceRoot ? `Add '${section}' section to README` : `Consider adding '${section}' section`,
+          fix: isWorkspaceRootReadme ? `Add '${section}' section to README` : `Consider adding '${section}' section`,
         };
         if (level === 'error') {
           errors.push(issue);

--- a/templates/common/scripts/skill-lifecycle-audit.ts
+++ b/templates/common/scripts/skill-lifecycle-audit.ts
@@ -149,8 +149,10 @@ function findSkillFiles(dir: string, baseDir: string = ROOT): string[] {
       // Skip agent directories (they don't contain skills)
       if (entry.name === 'agents') continue;
 
-      // At workspace root: only scan known subdirectories
-      if (IS_WORKSPACE_ROOT && dir === ROOT) {
+      // At project root: only scan known subdirectories (skills/ and .claude/)
+      // This applies at both L0 workspace root and L1/L2 projects to avoid scanning
+      // unrelated directories like docs/, src/, etc.
+      if (dir === ROOT) {
         // Only recurse into skills/ and .claude/ directories
         if (entry.name !== 'skills' && entry.name !== '.claude') continue;
       }


### PR DESCRIPTION
## Summary

L0+L1 스크립트가 L1/L2 프로젝트로 배포될 때 CONSTITUTION.md 미존재로 인해 오작동할 수 있는 7개 이슈를 수정하고, 스크립트 런타임 컨텍스트 가드 규약을 문서화합니다.

## Script Fixes (7 issues)

### 🔴 High
1. **readme-lifecycle-audit.ts** — Shadow variable `isWorkspaceRoot` causing false-positive errors for README.md section requirements in L2 projects
2. **skill-lifecycle-audit.ts** — Scan scope inversion: root-level directory scan now always restricted to `skills/` and `.claue/` (not only at L0)
3. **dev-sync.ts** — Added `existsSync` guards for `sync-md.ts` and `audit.ts` calls to prevent crashes in L2 projects

### 🟡 Medium
4. **lifecycle-sync-audit.ts** — Added `IS_WORKSPACE_ROOT` guard to Check A (consistent with Checks B/C/X/V)
5. **dev-sync.ts** — Unified workspace root detection to canonical `CONSTITUTION.md` pattern
6. **agent-lifecycle-audit.ts** — Gated AGENTS.md registry checks (Checks 5/8) on `IS_WORKSPACE_ROOT`

### 🟢 Low
7. **dev-sync.ts** — Added documentation comment for canonical workspace root detection convention

## Documentation

- **06.5-script-lifecycle.md**: Added "L0+L1 Script Runtime Context Guard Convention" section documenting:
  - Canonical L0 detection pattern (`existsSync('CONSTITUTION.md')`)
  - L0-only logic gating rules
  - Sub-script call guards
  - Directory scan scope limitation
  - Shadow variable avoidance

## Verification

- ✅ `audit.ts` L0 Leakage check: PASS
- ✅ Pre-push audit: all checks passed (FAIL: 0, WARN: 2 pre-existing)