### PR TITLE
docs(gemini): resolve 3-tier model registry drift and lifecycle mismatches

### DIFF
--- a/GEMINI.md
+++ b/GEMINI.md
@@ -145,8 +145,8 @@ See [AGENTS.md - Subagent Roster](AGENTS.md#subagent-roster) for the complete ag
 #### Cost Optimization (3-Tier Model Strategy)
 **Model Selection Overrides** (overridden per subagent invocation when appropriate):
 - **High-tier (Design/Planning)** — `gemini-3.1-pro` (Parameter: `thinking_level="medium"`): Complex reasoning, architectural design, planning, and PM orchestration.
-- **Medium-tier (Review/QA)** — `gemini-3.5-flash` (Parameter: `thinking_level="medium"`): Code review, testing, PR review, and quality gates (`verification-before-completion`). Supervises the Low-tier.
-- **Low-tier (Execution/Coding)** — `gemini-3.5-flash` (Parameter: `thinking_level="low"`): Fast, repetitive coding, boilerplate generation, or strictly scoped sub-agent tasks.
+- **Medium-tier (Review/QA)** — `gemini-3.5-flash` (no thinking parameter): Code review, testing, PR review, and quality gates (`verification-before-completion`). Supervises the Low-tier.
+- **Low-tier (Execution/Coding)** — `gemini-3.5-flash` (no thinking parameter): Fast, repetitive coding, boilerplate generation, or strictly scoped sub-agent tasks.
 
 ---
 
@@ -192,9 +192,9 @@ Every execution plan MUST start with Row 0 (Design Gate — architect creates/up
 
 | # | Task | Agent | Tier | Model | Spec |
 |---|------|-------|------|-------|------|
-| 0 | Create/update design doc → `docs/designs/<spec-id>-design.md` | architect | High | [model] | NEW |
+| 0 | Create/update design doc → `docs/designs/<spec-id>-design.md` | architect | High | gemini-3.1-pro | NEW |
 | 1 | [task description] | [specialist] | High/Medium/Low | [model] | <spec-id> |
-| N | `/sync "type(scope): message"` — lifecycle + audit + commit + push + PR | pm | Medium | [model] | |
+| N | `/sync "type(scope): message"` — lifecycle + audit + commit + push + PR | pm | Medium | gemini-3.5-flash | |
 
 **Exempt tasks** (E1–E5): Replace Row 0 with `── EXEMPT: <category> ──`. See [AGENTS.md §5.1.1](AGENTS.md#511-design-gate-exemptions).
 
@@ -301,7 +301,7 @@ Antigravity does not have `CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS` or `teammateMod
 
 ---
 
-*Last Updated: 2026-06-28 — added §5 Skill Resolution Priority; added §6 CLAUDE.md/GEMINI.md lifecycle row; added lifecycle-manager and auditor sequence to boilerplate; removed obsolete physical pm approval hooks*
+*Last Updated: 2026-07-05 — added §5 Skill Resolution Priority; added §6 CLAUDE.md/GEMINI.md lifecycle row; added lifecycle-manager and auditor sequence to boilerplate; removed obsolete physical pm approval hooks*
 
 
 

--- a/docs/VERSION_MANIFEST.md
+++ b/docs/VERSION_MANIFEST.md
@@ -1,6 +1,6 @@
 # VERSION_MANIFEST.md
 
-**Generated**: 2026-07-05T03:59:27.696Z
+**Generated**: 2026-07-05T04:12:07.081Z
 **Manifest Version**: 1.0
 **Location**: docs\VERSION_MANIFEST.md
 

--- a/docs/lifecycle/agents/architect.md
+++ b/docs/lifecycle/agents/architect.md
@@ -43,7 +43,7 @@
 
 **Can Lead Phases**: [2]
 **Can Support In**: [0, 6]
-**Tier**: medium
+**Tier**: high
 **Communication Style**: sync (requires user approval before implementation)
 
 ## Design Deliverables

--- a/docs/lifecycle/agents/docs-writer.md
+++ b/docs/lifecycle/agents/docs-writer.md
@@ -15,7 +15,7 @@
 ### Production Phase
 
 - [x] Agent role clearly defined: Documentation specialist
-- [x] Tier assignment: Low-tier (claude-haiku-4-5) for documentation tasks
+- [x] Tier assignment: Medium-tier (claude-sonnet-4-6) for documentation tasks
 - [x] Documentation responsibilities specified: Markdown standardization, translations
 - [x] Successfully validated in documentation workflows
 
@@ -41,7 +41,7 @@
 
 **Can Lead Phases**: [4]
 **Can Support In**: [0, 2, 6]
-**Tier**: low (for documentation tasks)
+**Tier**: medium (for documentation tasks)
 **Communication Style**: async (can work independently on documentation)
 
 ## Documentation Types

--- a/memory/2026-07-05.md
+++ b/memory/2026-07-05.md
@@ -263,3 +263,20 @@ fix(deps): complete codegraph cleanup in gitignored scaffold AGENTS.md
 
 ## Open Issues
 - None
+
+---
+
+## Session Summary
+docs(gemini): resolve 3-tier model registry drift and lifecycle mismatches
+
+## Changes
+- `M GEMINI.md` — modified
+- `docs/lifecycle/agents/architect.md` — modified
+- `docs/lifecycle/agents/docs-writer.md` — modified
+- `templates/common/GEMINI.md` — modified
+
+## Decisions
+- None
+
+## Open Issues
+- None

--- a/templates/common/GEMINI.md
+++ b/templates/common/GEMINI.md
@@ -144,8 +144,8 @@ See [AGENTS.md - Subagent Roster](AGENTS.md#subagent-roster) for the complete ag
 #### Cost Optimization (3-Tier Model Strategy)
 **Model Selection Overrides** (overridden per subagent invocation when appropriate):
 - **High-tier (Design/Planning)** — `gemini-3.1-pro` (Parameter: `thinking_level="medium"`): Complex reasoning, architectural design, planning, and PM orchestration.
-- **Medium-tier (Review/QA)** — `gemini-3.5-flash` (Parameter: `thinking_level="medium"`): Code review, testing, PR review, and quality gates (`verification-before-completion`). Supervises the Low-tier.
-- **Low-tier (Execution/Coding)** — `gemini-3.5-flash` (Parameter: `thinking_level="low"`): Fast, repetitive coding, boilerplate generation, or strictly scoped sub-agent tasks.
+- **Medium-tier (Review/QA)** — `gemini-3.5-flash` (no thinking parameter): Code review, testing, PR review, and quality gates (`verification-before-completion`). Supervises the Low-tier.
+- **Low-tier (Execution/Coding)** — `gemini-3.5-flash` (no thinking parameter): Fast, repetitive coding, boilerplate generation, or strictly scoped sub-agent tasks.
 
 ---
 
@@ -191,9 +191,9 @@ Every execution plan MUST start with Row 0 (Design Gate — architect creates/up
 
 | # | Task | Agent | Tier | Model | Spec |
 |---|------|-------|------|-------|------|
-| 0 | Create/update design doc → `docs/designs/<spec-id>-design.md` | architect | High | [model] | NEW |
+| 0 | Create/update design doc → `docs/designs/<spec-id>-design.md` | architect | High | gemini-3.1-pro | NEW |
 | 1 | [task description] | [specialist] | High/Medium/Low | [model] | <spec-id> |
-| N | `/sync "type(scope): message"` — lifecycle + audit + commit + push + PR | pm | Medium | [model] | |
+| N | `/sync "type(scope): message"` — lifecycle + audit + commit + push + PR | pm | Medium | gemini-3.5-flash | |
 
 **Exempt tasks** (E1–E5): Replace Row 0 with `── EXEMPT: <category> ──`. See [AGENTS.md §5.1.1](AGENTS.md#511-design-gate-exemptions).
 
@@ -300,7 +300,7 @@ Antigravity does not have `CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS` or `teammateMod
 
 ---
 
-*Last Updated: 2026-06-28 — added §5 Skill Resolution Priority; added §6 CLAUDE.md/GEMINI.md lifecycle row; added lifecycle-manager and auditor sequence to boilerplate; removed obsolete physical pm approval hooks*
+*Last Updated: 2026-07-05 — added §5 Skill Resolution Priority; added §6 CLAUDE.md/GEMINI.md lifecycle row; added lifecycle-manager and auditor sequence to boilerplate; removed obsolete physical pm approval hooks*
 
 
 


### PR DESCRIPTION
[claude pr-body] Attempt 1/2
[claude pr-body]  Success on attempt 1
## Why
The Gemini platform docs and agent lifecycle files had drifted from the canonical 3-tier model registry: `gemini-3.5-flash` still carried invalid `thinking_level` parameters, execution-plan boilerplate left `[model]` placeholders unfilled, and `architect`/`docs-writer` lifecycle tiers contradicted their declared registry tiers. This aligns Gemini documentation with the resolved registry (per #371) so dispatch guidance is consistent and accurate.

## What Changed
- **GEMINI.md & templates/common/GEMINI.md** (3-tier strategy): removed the unsupported `thinking_level="medium"/"low"` parameters from the Medium- and Low-tier `gemini-3.5-flash` entries (now "no thinking parameter").
- **GEMINI.md & templates/common/GEMINI.md** (execution-plan boilerplate): replaced `[model]` placeholders with concrete models — `gemini-3.1-pro` for the architect (Row 0, High) and `gemini-3.5-flash` for the pm `/sync` (Row N, Medium).
- **GEMINI.md & templates/common/GEMINI.md**: bumped "Last Updated" from 2026-06-28 to 2026-07-05.
- **docs/lifecycle/agents/architect.md**: corrected tier `medium` → `high` to match its High-tier (gemini-3.1-pro) registry assignment.
- **docs/lifecycle/agents/docs-writer.md**: corrected tier `low` → `medium` (claude-sonnet-4-6), reflecting the 2026-05-28 docs-writer tier upgrade.
- **docs/VERSION_MANIFEST.md**: regenerated timestamp.
- **memory/2026-07-05.md**: appended session log entry for this change.

## Test Plan
- [ ] `bash scripts/audit.sh` passes
- [ ] Confirm `architect`/`docs-writer` tiers in `docs/lifecycle/agents/` now match the registry in `AGENTS.md` / `CLAUDE.md`
- [ ] Verify no remaining `[model]` placeholders or `thinking_level` references for `gemini-3.5-flash` in GEMINI.md (root and template)

## Security Checklist
- [ ] No secrets, credentials, or API keys committed
- [ ] No `.env` files staged (use `.env.sample` for templates)
- [ ] Dependencies unchanged or reviewed for new CVEs

## Notes
Documentation-only change — no runtime behavior, no breaking changes. Root `GEMINI.md` and `templates/common/GEMINI.md` were updated in parallel to keep the L1 template and L0 workspace variant in sync; downstream L2 variants should re-derive if they fork this section.