### PR TITLE
docs(agents): fix Model column in AGENTS.md §5.3 execution plan examples to use Claude Code short aliases instead of registry IDs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -448,13 +448,15 @@ When modifying files that affect both CLAUDE.md and GEMINI.md:
 
 #### Example 1: Multi-Agent Platform Parity Update
 
+> **Note**: The `Model` column below shows the Claude Code short alias (`sonnet`/`opus`/`haiku`/`fable`) actually passed to the `Agent()` tool's `model` parameter — not the registry ID (e.g. `claude-sonnet-4-6`). See [CLAUDE.md §6](CLAUDE.md#6-native-sub-agents-agent-tool) for the registry-ID → alias translation table. On Gemini/Antigravity, use the literal model ID instead (see GEMINI.md's equivalent example).
+
 | # | Task | Agent | Tier | Model | Spec |
 |---|------|-------|------|-------|------|
-| 1 | Update agents/pm.md | docs-writer | Medium | claude-sonnet-4-6 |
-| 2 | Update scripts/audit.ts | automation-engineer | Low | claude-haiku-4-5 |
-| 3 | Update CLAUDE.md §5 | docs-writer | Medium | claude-sonnet-4-6 |
-| 4 | Update GEMINI.md §5 | docs-writer | Medium | claude-sonnet-4-6 |
-| 5 | `/sync "docs(agents): update pm.md and platform dispatch rules"` | pm | Medium | claude-sonnet-4-6 |
+| 1 | Update agents/pm.md | docs-writer | Medium | sonnet | <spec-id> |
+| 2 | Update scripts/audit.ts | automation-engineer | Low | haiku | <spec-id> |
+| 3 | Update CLAUDE.md §5 | docs-writer | Medium | sonnet | <spec-id> |
+| 4 | Update GEMINI.md §5 | docs-writer | Medium | sonnet | <spec-id> |
+| 5 | `/sync "docs(agents): update pm.md and platform dispatch rules"` | pm | Medium | sonnet | |
 
 **Execution Order**: Sequential (platform parity requires CLAUDE.md and GEMINI.md updates together)
 
@@ -462,8 +464,8 @@ When modifying files that affect both CLAUDE.md and GEMINI.md:
 
 | # | Task | Agent | Tier | Model | Spec |
 |---|------|-------|------|-------|------|
-| 1 | Update project README introduction | docs-writer | Medium | claude-sonnet-4-6 |
-| 2 | `/sync "docs: update project README introduction"` | pm | Medium | claude-sonnet-4-6 |
+| 1 | Update project README introduction | docs-writer | Medium | sonnet | <spec-id> |
+| 2 | `/sync "docs: update project README introduction"` | pm | Medium | sonnet | |
 
 **Execution Order**: Sequential
 

--- a/docs/VERSION_MANIFEST.md
+++ b/docs/VERSION_MANIFEST.md
@@ -1,6 +1,6 @@
 # VERSION_MANIFEST.md
 
-**Generated**: 2026-07-05T04:53:47.039Z
+**Generated**: 2026-07-05T09:37:56.207Z
 **Manifest Version**: 1.0
 **Location**: docs\VERSION_MANIFEST.md
 

--- a/memory/2026-07-05.md
+++ b/memory/2026-07-05.md
@@ -308,3 +308,17 @@ fix(templates): add missing docs/workspace-schema.json to templates/common
 
 ## Open Issues
 - None
+
+---
+
+## Session Summary
+docs(agents): fix Model column in AGENTS.md §5.3 execution plan examples to use Claude Code short aliases instead of registry IDs
+
+## Changes
+- `M AGENTS.md` — modified
+
+## Decisions
+- None
+
+## Open Issues
+- None


### PR DESCRIPTION
[claude pr-body] Attempt 1/2
## Why
docs(agents): fix Model column in AGENTS.md §5.3 execution plan examples to use Claude Code short aliases instead of registry IDs

## What Changed
- AGENTS.md
- docs/VERSION_MANIFEST.md
- memory/2026-07-05.md

## Test Plan
- [ ] `bash scripts/audit.sh` passes
- [ ] CHANGELOG.md updated under `[Unreleased]`

## Security Checklist
- [ ] No secrets, credentials, or API keys committed
- [ ] No `.env` files staged (use `.env.sample` for templates)
- [ ] Dependencies unchanged or reviewed for new CVEs

## Notes
None

---