### PR TITLE
chore: update

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -448,13 +448,15 @@ When modifying files that affect both CLAUDE.md and GEMINI.md:
 
 #### Example 1: Multi-Agent Platform Parity Update
 
+> **Note**: The `Model` column below shows the Claude Code short alias (`sonnet`/`opus`/`haiku`/`fable`) actually passed to the `Agent()` tool's `model` parameter — not the registry ID (e.g. `claude-sonnet-4-6`). See [CLAUDE.md §6](CLAUDE.md#6-native-sub-agents-agent-tool) for the registry-ID → alias translation table. On Gemini/Antigravity, use the literal model ID instead (see GEMINI.md's equivalent example).
+
 | # | Task | Agent | Tier | Model | Spec |
 |---|------|-------|------|-------|------|
-| 1 | Update agents/pm.md | docs-writer | Medium | claude-sonnet-4-6 |
-| 2 | Update scripts/audit.ts | automation-engineer | Low | claude-haiku-4-5 |
-| 3 | Update CLAUDE.md §5 | docs-writer | Medium | claude-sonnet-4-6 |
-| 4 | Update GEMINI.md §5 | docs-writer | Medium | claude-sonnet-4-6 |
-| 5 | `/sync "docs(agents): update pm.md and platform dispatch rules"` | pm | Medium | claude-sonnet-4-6 |
+| 1 | Update agents/pm.md | docs-writer | Medium | sonnet | <spec-id> |
+| 2 | Update scripts/audit.ts | automation-engineer | Low | haiku | <spec-id> |
+| 3 | Update CLAUDE.md §5 | docs-writer | Medium | sonnet | <spec-id> |
+| 4 | Update GEMINI.md §5 | docs-writer | Medium | sonnet | <spec-id> |
+| 5 | `/sync "docs(agents): update pm.md and platform dispatch rules"` | pm | Medium | sonnet | |
 
 **Execution Order**: Sequential (platform parity requires CLAUDE.md and GEMINI.md updates together)
 
@@ -462,8 +464,8 @@ When modifying files that affect both CLAUDE.md and GEMINI.md:
 
 | # | Task | Agent | Tier | Model | Spec |
 |---|------|-------|------|-------|------|
-| 1 | Update project README introduction | docs-writer | Medium | claude-sonnet-4-6 |
-| 2 | `/sync "docs: update project README introduction"` | pm | Medium | claude-sonnet-4-6 |
+| 1 | Update project README introduction | docs-writer | Medium | sonnet | <spec-id> |
+| 2 | `/sync "docs: update project README introduction"` | pm | Medium | sonnet | |
 
 **Execution Order**: Sequential
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -204,11 +204,13 @@ For execution plan format, mandatory criteria, and templates, see **[AGENTS.md �
 
 Every execution plan MUST start with Row 0 (Design Gate — architect creates/updates design doc) and end with `/sync`. Between Row 0 and `/sync`, list implementation tasks.
 
+> **Note**: The `Model` column below shows the Claude Code short alias (`sonnet`/`opus`/`haiku`/`fable`) actually passed to the `Agent()` tool's `model` parameter — not the registry ID (e.g. `claude-sonnet-4-6`). See §6 (Native Sub-agents) for the registry-ID → alias translation table. On Gemini/Antigravity, use the literal model ID instead (see GEMINI.md's equivalent example).
+
 | # | Task | Agent | Tier | Model | Spec |
 |---|------|-------|------|-------|------|
-| 0 | Create/update design doc → `docs/designs/<spec-id>-design.md` | architect | High | claude-opus-4-7 | NEW |
+| 0 | Create/update design doc → `docs/designs/<spec-id>-design.md` | architect | High | opus | NEW |
 | 1 | [task description] | [specialist] | High/Medium/Low | [model] | <spec-id> |
-| N | `/sync "type(scope): message"` — lifecycle + audit + commit + push + PR | pm | Medium | claude-sonnet-4-6 | |
+| N | `/sync "type(scope): message"` — lifecycle + audit + commit + push + PR | pm | Medium | sonnet | |
 
 **Exempt tasks** (E1–E5): Replace Row 0 with `── EXEMPT: <category> ──`. See [AGENTS.md §5.1.1](AGENTS.md#511-design-gate-exemptions).
 

--- a/docs/VERSION_MANIFEST.md
+++ b/docs/VERSION_MANIFEST.md
@@ -1,6 +1,6 @@
 # VERSION_MANIFEST.md
 
-**Generated**: 2026-07-05T04:53:47.039Z
+**Generated**: 2026-07-05T09:37:56.207Z
 **Manifest Version**: 1.0
 **Location**: docs\VERSION_MANIFEST.md
 

--- a/docs/VERSION_MANIFEST.md
+++ b/docs/VERSION_MANIFEST.md
@@ -1,6 +1,6 @@
 # VERSION_MANIFEST.md
 
-**Generated**: 2026-07-05T09:37:56.207Z
+**Generated**: 2026-07-05T09:50:57.229Z
 **Manifest Version**: 1.0
 **Location**: docs\VERSION_MANIFEST.md
 

--- a/docs/constitution/05-multi-agent-architecture.md
+++ b/docs/constitution/05-multi-agent-architecture.md
@@ -122,8 +122,10 @@ All PM execution plans MUST use the following table format (enforced in `CLAUDE.
 ```
 | # | Task | Agent | Tier | Model | Spec |
 |---|------|-------|------|-------|------|
-| 1 | ... | ... | Medium | claude-sonnet-4-6 | 2026-06-24-topic-slug |
+| 1 | ... | ... | Medium | sonnet | 2026-06-24-topic-slug |
 ```
+
+> **Note**: `Model` holds the Claude Code short alias (`sonnet`/`opus`/`haiku`/`fable`) passed to the `Agent()` tool's `model` parameter — not the registry ID (e.g. `claude-sonnet-4-6`). See [CLAUDE.md §6](../../CLAUDE.md#6-native-sub-agents-agent-tool) for the registry-ID → alias translation table.
 
 - **Spec column**: References the spec ID from `docs/specs/registry.json`. A plan without a spec ID generates a PM Gateway warning (non-blocking). Spec IDs follow the format `YYYY-MM-DD-<topic-slug>`.
 - See [§9.7 Spec Registry](09-operations-workflow.md#97-spec-registry--design-gate) for the full spec lifecycle.

--- a/memory/2026-07-05.md
+++ b/memory/2026-07-05.md
@@ -322,3 +322,26 @@ docs(agents): fix Model column in AGENTS.md §5.3 execution plan examples to use
 
 ## Open Issues
 - None
+
+---
+
+## Session Summary
+chore: update
+
+## Changes
+- `M CLAUDE.md` — modified
+- `docs/constitution/05-multi-agent-architecture.md` — modified
+- `templates/co-consult/AGENTS.md` — modified
+- `templates/co-deck/AGENTS.md` — modified
+- `templates/co-design/AGENTS.md` — modified
+- `templates/co-develop/AGENTS.md` — modified
+- `templates/co-security/AGENTS.md` — modified
+- `templates/co-work/AGENTS.md` — modified
+- `templates/common/AGENTS.md` — modified
+- `templates/common/CLAUDE.md` — modified
+
+## Decisions
+- None
+
+## Open Issues
+- None

--- a/memory/2026-07-05.md
+++ b/memory/2026-07-05.md
@@ -308,3 +308,17 @@ fix(templates): add missing docs/workspace-schema.json to templates/common
 
 ## Open Issues
 - None
+
+---
+
+## Session Summary
+docs(agents): fix Model column in AGENTS.md §5.3 execution plan examples to use Claude Code short aliases instead of registry IDs
+
+## Changes
+- `M AGENTS.md` — modified
+
+## Decisions
+- None
+
+## Open Issues
+- None

--- a/templates/co-consult/AGENTS.md
+++ b/templates/co-consult/AGENTS.md
@@ -496,13 +496,15 @@ When modifying files that affect both CLAUDE.md and GEMINI.md:
 
 #### Example 1: Multi-Agent Platform Parity Update
 
+> **Note**: The `Model` column below shows the Claude Code short alias (`sonnet`/`opus`/`haiku`/`fable`) actually passed to the `Agent()` tool's `model` parameter — not the registry ID (e.g. `claude-sonnet-4-6`). See [CLAUDE.md §6](CLAUDE.md#6-native-sub-agents-agent-tool) for the registry-ID → alias translation table. On Gemini/Antigravity, use the literal model ID instead (see GEMINI.md's equivalent example).
+
 | # | Task | Agent | Tier | Model |
 |---|------|-------|------|-------|
-| 1 | Update agents/pm.md | `[docs specialist]` | Medium | claude-sonnet-4-6 |
-| 2 | Update scripts/audit.ts | `[implementation specialist]` | Low | claude-haiku-4-5 |
-| 3 | Update CLAUDE.md §5 | `[docs specialist]` | Medium | claude-sonnet-4-6 |
-| 4 | Update GEMINI.md §5 | `[docs specialist]` | Medium | claude-sonnet-4-6 |
-| 5 | `/sync "type(scope): message"` — lifecycle + audit + commit + push + PR | pm | Medium | claude-sonnet-4-6 |
+| 1 | Update agents/pm.md | `[docs specialist]` | Medium | sonnet |
+| 2 | Update scripts/audit.ts | `[implementation specialist]` | Low | haiku |
+| 3 | Update CLAUDE.md §5 | `[docs specialist]` | Medium | sonnet |
+| 4 | Update GEMINI.md §5 | `[docs specialist]` | Medium | sonnet |
+| 5 | `/sync "type(scope): message"` — lifecycle + audit + commit + push + PR | pm | Medium | sonnet |
 
 **Execution Order**: Sequential (platform parity requires CLAUDE.md and GEMINI.md updates together)
 
@@ -510,8 +512,8 @@ When modifying files that affect both CLAUDE.md and GEMINI.md:
 
 | # | Task | Agent | Tier | Model |
 |---|------|-------|------|-------|
-| 1 | Update project README introduction | `[docs specialist]` | Medium | claude-sonnet-4-6 |
-| 2 | `/sync "type(scope): message"` — lifecycle + audit + commit + push + PR | pm | Medium | claude-sonnet-4-6 |
+| 1 | Update project README introduction | `[docs specialist]` | Medium | sonnet |
+| 2 | `/sync "type(scope): message"` — lifecycle + audit + commit + push + PR | pm | Medium | sonnet |
 
 **Execution Order**: Sequential
 

--- a/templates/co-deck/AGENTS.md
+++ b/templates/co-deck/AGENTS.md
@@ -564,13 +564,15 @@ When modifying files that affect both CLAUDE.md and GEMINI.md:
 
 #### Example 1: Multi-Agent Platform Parity Update
 
+> **Note**: The `Model` column below shows the Claude Code short alias (`sonnet`/`opus`/`haiku`/`fable`) actually passed to the `Agent()` tool's `model` parameter — not the registry ID (e.g. `claude-sonnet-4-6`). See [CLAUDE.md §6](CLAUDE.md#6-native-sub-agents-agent-tool) for the registry-ID → alias translation table. On Gemini/Antigravity, use the literal model ID instead (see GEMINI.md's equivalent example).
+
 | # | Task | Agent | Tier | Model |
 |---|------|-------|------|-------|
-| 1 | Update agents/pm.md | `[docs specialist]` | Medium | claude-sonnet-4-6 |
-| 2 | Update scripts/audit.ts | `[implementation specialist]` | Low | claude-haiku-4-5 |
-| 3 | Update CLAUDE.md §5 | `[docs specialist]` | Medium | claude-sonnet-4-6 |
-| 4 | Update GEMINI.md §5 | `[docs specialist]` | Medium | claude-sonnet-4-6 |
-| 5 | `/sync "type(scope): message"` — lifecycle + audit + commit + push + PR | pm | Medium | claude-sonnet-4-6 |
+| 1 | Update agents/pm.md | `[docs specialist]` | Medium | sonnet |
+| 2 | Update scripts/audit.ts | `[implementation specialist]` | Low | haiku |
+| 3 | Update CLAUDE.md §5 | `[docs specialist]` | Medium | sonnet |
+| 4 | Update GEMINI.md §5 | `[docs specialist]` | Medium | sonnet |
+| 5 | `/sync "type(scope): message"` — lifecycle + audit + commit + push + PR | pm | Medium | sonnet |
 
 **Execution Order**: Sequential (platform parity requires CLAUDE.md and GEMINI.md updates together)
 
@@ -578,8 +580,8 @@ When modifying files that affect both CLAUDE.md and GEMINI.md:
 
 | # | Task | Agent | Tier | Model |
 |---|------|-------|------|-------|
-| 1 | Update project README introduction | `[docs specialist]` | Medium | claude-sonnet-4-6 |
-| 2 | `/sync "type(scope): message"` — lifecycle + audit + commit + push + PR | pm | Medium | claude-sonnet-4-6 |
+| 1 | Update project README introduction | `[docs specialist]` | Medium | sonnet |
+| 2 | `/sync "type(scope): message"` — lifecycle + audit + commit + push + PR | pm | Medium | sonnet |
 
 **Execution Order**: Sequential
 

--- a/templates/co-design/AGENTS.md
+++ b/templates/co-design/AGENTS.md
@@ -454,13 +454,15 @@ When modifying files that affect both CLAUDE.md and GEMINI.md:
 
 #### Example 1: Multi-Agent Platform Parity Update
 
+> **Note**: The `Model` column below shows the Claude Code short alias (`sonnet`/`opus`/`haiku`/`fable`) actually passed to the `Agent()` tool's `model` parameter — not the registry ID (e.g. `claude-sonnet-4-6`). See [CLAUDE.md §6](CLAUDE.md#6-native-sub-agents-agent-tool) for the registry-ID → alias translation table. On Gemini/Antigravity, use the literal model ID instead (see GEMINI.md's equivalent example).
+
 | # | Task | Agent | Tier | Model |
 |---|------|-------|------|-------|
-| 1 | Update agents/pm.md | `[docs specialist]` | Medium | claude-sonnet-4-6 |
-| 2 | Update scripts/audit.ts | `[implementation specialist]` | Low | claude-haiku-4-5 |
-| 3 | Update CLAUDE.md §5 | `[docs specialist]` | Medium | claude-sonnet-4-6 |
-| 4 | Update GEMINI.md §5 | `[docs specialist]` | Medium | claude-sonnet-4-6 |
-| 5 | `/sync "type(scope): message"` — lifecycle + audit + commit + push + PR | pm | Medium | claude-sonnet-4-6 |
+| 1 | Update agents/pm.md | `[docs specialist]` | Medium | sonnet |
+| 2 | Update scripts/audit.ts | `[implementation specialist]` | Low | haiku |
+| 3 | Update CLAUDE.md §5 | `[docs specialist]` | Medium | sonnet |
+| 4 | Update GEMINI.md §5 | `[docs specialist]` | Medium | sonnet |
+| 5 | `/sync "type(scope): message"` — lifecycle + audit + commit + push + PR | pm | Medium | sonnet |
 
 **Execution Order**: Sequential (platform parity requires CLAUDE.md and GEMINI.md updates together)
 
@@ -468,8 +470,8 @@ When modifying files that affect both CLAUDE.md and GEMINI.md:
 
 | # | Task | Agent | Tier | Model |
 |---|------|-------|------|-------|
-| 1 | Update project README introduction | `[docs specialist]` | Medium | claude-sonnet-4-6 |
-| 2 | `/sync "type(scope): message"` — lifecycle + audit + commit + push + PR | pm | Medium | claude-sonnet-4-6 |
+| 1 | Update project README introduction | `[docs specialist]` | Medium | sonnet |
+| 2 | `/sync "type(scope): message"` — lifecycle + audit + commit + push + PR | pm | Medium | sonnet |
 
 **Execution Order**: Sequential
 

--- a/templates/co-develop/AGENTS.md
+++ b/templates/co-develop/AGENTS.md
@@ -443,13 +443,15 @@ When modifying files that affect both CLAUDE.md and GEMINI.md:
 
 #### Example 1: Multi-Agent Platform Parity Update
 
+> **Note**: The `Model` column below shows the Claude Code short alias (`sonnet`/`opus`/`haiku`/`fable`) actually passed to the `Agent()` tool's `model` parameter — not the registry ID (e.g. `claude-sonnet-4-6`). See [CLAUDE.md §6](CLAUDE.md#6-native-sub-agents-agent-tool) for the registry-ID → alias translation table. On Gemini/Antigravity, use the literal model ID instead (see GEMINI.md's equivalent example).
+
 | # | Task | Agent | Tier | Model |
 |---|------|-------|------|-------|
-| 1 | Update agents/pm.md | `[docs specialist]` | Medium | claude-sonnet-4-6 |
-| 2 | Update scripts/audit.ts | `[implementation specialist]` | Low | claude-haiku-4-5 |
-| 3 | Update CLAUDE.md §5 | `[docs specialist]` | Medium | claude-sonnet-4-6 |
-| 4 | Update GEMINI.md §5 | `[docs specialist]` | Medium | claude-sonnet-4-6 |
-| 5 | `/sync "type(scope): message"` — lifecycle + audit + commit + push + PR | pm | Medium | claude-sonnet-4-6 |
+| 1 | Update agents/pm.md | `[docs specialist]` | Medium | sonnet |
+| 2 | Update scripts/audit.ts | `[implementation specialist]` | Low | haiku |
+| 3 | Update CLAUDE.md §5 | `[docs specialist]` | Medium | sonnet |
+| 4 | Update GEMINI.md §5 | `[docs specialist]` | Medium | sonnet |
+| 5 | `/sync "type(scope): message"` — lifecycle + audit + commit + push + PR | pm | Medium | sonnet |
 
 **Execution Order**: Sequential (platform parity requires CLAUDE.md and GEMINI.md updates together)
 
@@ -457,8 +459,8 @@ When modifying files that affect both CLAUDE.md and GEMINI.md:
 
 | # | Task | Agent | Tier | Model |
 |---|------|-------|------|-------|
-| 1 | Update project README introduction | `[docs specialist]` | Medium | claude-sonnet-4-6 |
-| 2 | `/sync "type(scope): message"` — lifecycle + audit + commit + push + PR | pm | Medium | claude-sonnet-4-6 |
+| 1 | Update project README introduction | `[docs specialist]` | Medium | sonnet |
+| 2 | `/sync "type(scope): message"` — lifecycle + audit + commit + push + PR | pm | Medium | sonnet |
 
 **Execution Order**: Sequential
 

--- a/templates/co-security/AGENTS.md
+++ b/templates/co-security/AGENTS.md
@@ -426,13 +426,15 @@ When modifying files that affect both CLAUDE.md and GEMINI.md:
 
 #### Example 1: Multi-Agent Platform Parity Update
 
+> **Note**: The `Model` column below shows the Claude Code short alias (`sonnet`/`opus`/`haiku`/`fable`) actually passed to the `Agent()` tool's `model` parameter — not the registry ID (e.g. `claude-sonnet-4-6`). See [CLAUDE.md §6](CLAUDE.md#6-native-sub-agents-agent-tool) for the registry-ID → alias translation table. On Gemini/Antigravity, use the literal model ID instead (see GEMINI.md's equivalent example).
+
 | # | Task | Agent | Tier | Model |
 |---|------|-------|------|-------|
-| 1 | Update agents/pm.md | `[docs specialist]` | Medium | claude-sonnet-4-6 |
-| 2 | Update scripts/audit.ts | `[implementation specialist]` | Low | claude-haiku-4-5 |
-| 3 | Update CLAUDE.md §5 | `[docs specialist]` | Medium | claude-sonnet-4-6 |
-| 4 | Update GEMINI.md §5 | `[docs specialist]` | Medium | claude-sonnet-4-6 |
-| 5 | `/sync "type(scope): message"` — lifecycle + audit + commit + push + PR | pm | Medium | claude-sonnet-4-6 |
+| 1 | Update agents/pm.md | `[docs specialist]` | Medium | sonnet |
+| 2 | Update scripts/audit.ts | `[implementation specialist]` | Low | haiku |
+| 3 | Update CLAUDE.md §5 | `[docs specialist]` | Medium | sonnet |
+| 4 | Update GEMINI.md §5 | `[docs specialist]` | Medium | sonnet |
+| 5 | `/sync "type(scope): message"` — lifecycle + audit + commit + push + PR | pm | Medium | sonnet |
 
 **Execution Order**: Sequential (platform parity requires CLAUDE.md and GEMINI.md updates together)
 
@@ -440,8 +442,8 @@ When modifying files that affect both CLAUDE.md and GEMINI.md:
 
 | # | Task | Agent | Tier | Model |
 |---|------|-------|------|-------|
-| 1 | Update project README introduction | `[docs specialist]` | Medium | claude-sonnet-4-6 |
-| 2 | `/sync "type(scope): message"` — lifecycle + audit + commit + push + PR | pm | Medium | claude-sonnet-4-6 |
+| 1 | Update project README introduction | `[docs specialist]` | Medium | sonnet |
+| 2 | `/sync "type(scope): message"` — lifecycle + audit + commit + push + PR | pm | Medium | sonnet |
 
 **Execution Order**: Sequential
 

--- a/templates/co-work/AGENTS.md
+++ b/templates/co-work/AGENTS.md
@@ -440,13 +440,15 @@ When modifying files that affect both CLAUDE.md and GEMINI.md:
 
 #### Example 1: Multi-Agent Platform Parity Update
 
+> **Note**: The `Model` column below shows the Claude Code short alias (`sonnet`/`opus`/`haiku`/`fable`) actually passed to the `Agent()` tool's `model` parameter — not the registry ID (e.g. `claude-sonnet-4-6`). See [CLAUDE.md §6](CLAUDE.md#6-native-sub-agents-agent-tool) for the registry-ID → alias translation table. On Gemini/Antigravity, use the literal model ID instead (see GEMINI.md's equivalent example).
+
 | # | Task | Agent | Tier | Model |
 |---|------|-------|------|-------|
-| 1 | Update agents/pm.md | `[docs specialist]` | Medium | claude-sonnet-4-6 |
-| 2 | Update scripts/audit.ts | `[implementation specialist]` | Low | claude-haiku-4-5 |
-| 3 | Update CLAUDE.md §5 | `[docs specialist]` | Medium | claude-sonnet-4-6 |
-| 4 | Update GEMINI.md §5 | `[docs specialist]` | Medium | claude-sonnet-4-6 |
-| 5 | `/sync "type(scope): message"` — lifecycle + audit + commit + push + PR | pm | Medium | claude-sonnet-4-6 |
+| 1 | Update agents/pm.md | `[docs specialist]` | Medium | sonnet |
+| 2 | Update scripts/audit.ts | `[implementation specialist]` | Low | haiku |
+| 3 | Update CLAUDE.md §5 | `[docs specialist]` | Medium | sonnet |
+| 4 | Update GEMINI.md §5 | `[docs specialist]` | Medium | sonnet |
+| 5 | `/sync "type(scope): message"` — lifecycle + audit + commit + push + PR | pm | Medium | sonnet |
 
 **Execution Order**: Sequential (platform parity requires CLAUDE.md and GEMINI.md updates together)
 
@@ -454,8 +456,8 @@ When modifying files that affect both CLAUDE.md and GEMINI.md:
 
 | # | Task | Agent | Tier | Model |
 |---|------|-------|------|-------|
-| 1 | Update project README introduction | `[docs specialist]` | Medium | claude-sonnet-4-6 |
-| 2 | `/sync "type(scope): message"` — lifecycle + audit + commit + push + PR | pm | Medium | claude-sonnet-4-6 |
+| 1 | Update project README introduction | `[docs specialist]` | Medium | sonnet |
+| 2 | `/sync "type(scope): message"` — lifecycle + audit + commit + push + PR | pm | Medium | sonnet |
 
 **Execution Order**: Sequential
 

--- a/templates/common/AGENTS.md
+++ b/templates/common/AGENTS.md
@@ -373,13 +373,15 @@ When modifying files that affect both CLAUDE.md and GEMINI.md:
 
 #### Example 1: Multi-Agent Platform Parity Update
 
+> **Note**: The `Model` column below shows the Claude Code short alias (`sonnet`/`opus`/`haiku`/`fable`) actually passed to the `Agent()` tool's `model` parameter — not the registry ID (e.g. `claude-sonnet-4-6`). See [CLAUDE.md §6](CLAUDE.md#6-native-sub-agents-agent-tool) for the registry-ID → alias translation table. On Gemini/Antigravity, use the literal model ID instead (see GEMINI.md's equivalent example).
+
 | # | Task | Agent | Tier | Model |
 |---|------|-------|------|-------|
-| 1 | Update agents/pm.md | `[docs specialist]` | Medium | claude-sonnet-4-6 |
-| 2 | Update scripts/audit.ts | `[implementation specialist]` | Low | claude-haiku-4-5 |
-| 3 | Update CLAUDE.md §5 | `[docs specialist]` | Medium | claude-sonnet-4-6 |
-| 4 | Update GEMINI.md §5 | `[docs specialist]` | Medium | claude-sonnet-4-6 |
-| 5 | `/sync "type(scope): message"` — lifecycle + audit + commit + push + PR | pm | Medium | claude-sonnet-4-6 |
+| 1 | Update agents/pm.md | `[docs specialist]` | Medium | sonnet |
+| 2 | Update scripts/audit.ts | `[implementation specialist]` | Low | haiku |
+| 3 | Update CLAUDE.md §5 | `[docs specialist]` | Medium | sonnet |
+| 4 | Update GEMINI.md §5 | `[docs specialist]` | Medium | sonnet |
+| 5 | `/sync "type(scope): message"` — lifecycle + audit + commit + push + PR | pm | Medium | sonnet |
 
 **Execution Order**: Sequential (platform parity requires CLAUDE.md and GEMINI.md updates together)
 
@@ -387,8 +389,8 @@ When modifying files that affect both CLAUDE.md and GEMINI.md:
 
 | # | Task | Agent | Tier | Model |
 |---|------|-------|------|-------|
-| 1 | Update project README introduction | `[docs specialist]` | Medium | claude-sonnet-4-6 |
-| 2 | `/sync "type(scope): message"` — lifecycle + audit + commit + push + PR | pm | Medium | claude-sonnet-4-6 |
+| 1 | Update project README introduction | `[docs specialist]` | Medium | sonnet |
+| 2 | `/sync "type(scope): message"` — lifecycle + audit + commit + push + PR | pm | Medium | sonnet |
 
 **Execution Order**: Sequential
 

--- a/templates/common/CLAUDE.md
+++ b/templates/common/CLAUDE.md
@@ -194,11 +194,13 @@ For execution plan format, mandatory criteria, and templates, see **[AGENTS.md �
 
 Every execution plan MUST start with Row 0 (Design Gate — architect creates/updates design doc) and end with `/sync`. Between Row 0 and `/sync`, list implementation tasks.
 
+> **Note**: The `Model` column below shows the Claude Code short alias (`sonnet`/`opus`/`haiku`/`fable`) actually passed to the `Agent()` tool's `model` parameter — not the registry ID (e.g. `claude-sonnet-4-6`). See §6 (Native Sub-agents) for the registry-ID → alias translation table. On Gemini/Antigravity, use the literal model ID instead (see GEMINI.md's equivalent example).
+
 | # | Task | Agent | Tier | Model | Spec |
 |---|------|-------|------|-------|------|
-| 0 | Create/update design doc → `docs/designs/<spec-id>-design.md` | architect | High | claude-opus-4-7 | NEW |
+| 0 | Create/update design doc → `docs/designs/<spec-id>-design.md` | architect | High | opus | NEW |
 | 1 | [task description] | [specialist] | High/Medium/Low | [model] | <spec-id> |
-| N | `/sync "type(scope): message"` — lifecycle + audit + commit + push + PR | pm | Medium | claude-sonnet-4-6 | |
+| N | `/sync "type(scope): message"` — lifecycle + audit + commit + push + PR | pm | Medium | sonnet | |
 
 **Exempt tasks** (E1–E5): Replace Row 0 with `── EXEMPT: <category> ──`. See [AGENTS.md §5.1.1](AGENTS.md#511-design-gate-exemptions).
 


### PR DESCRIPTION
[claude pr-body] Attempt 1/2
## Why
chore: update

## What Changed
- CLAUDE.md
- docs/VERSION_MANIFEST.md
- docs/constitution/05-multi-agent-architecture.md
- memory/2026-07-05.md
- templates/co-consult/AGENTS.md
- templates/co-deck/AGENTS.md
- templates/co-design/AGENTS.md
- templates/co-develop/AGENTS.md
- templates/co-security/AGENTS.md
- templates/co-work/AGENTS.md
- templates/common/AGENTS.md
- templates/common/CLAUDE.md

## Test Plan
- [ ] `bash scripts/audit.sh` passes
- [ ] CHANGELOG.md updated under `[Unreleased]`

## Security Checklist
- [ ] No secrets, credentials, or API keys committed
- [ ] No `.env` files staged (use `.env.sample` for templates)
- [ ] Dependencies unchanged or reviewed for new CVEs

## Notes
None

---