### PR TITLE
chore: update

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
 
+- **[2026-07-16]**: feat(co-deck): propagate Uniform Layout Principle from co-deck1 to templates/co-deck — all content slides must use `standard` type; special types (`punchline`, `divider`, `profile`) reserved for designated structural purpose only; applied to 9 files: agents/storyline.md (type-to-purpose table + self-check rule), skills/storyline/SKILL.md (warning block + balance check), .claude/skills/storyline/SKILL.md, .gemini/skills/storyline/SKILL.md (platform copies), docs/co-deck.context.md (Content Rules item 6 + Template Provenance), skills/theme-authoring/SKILL.md (slide_type_usage in content_rules schema), and 5 theme.json files (outline, pitch, pitch-enhanced, vertical, zen — slide_type_usage object in content_rules)
 - **[2026-07-12]**: docs(designs): mark `workspace-hardening-design.md` Acceptance Criteria complete and Status: Completed — verified all three PRs (parser/M-item fixes, CI gitleaks + weekly health check, variant roadmap/docs-diet reports) were already merged to `main` (PRs #394-#400, #402); the design doc's checkboxes had been left unchecked despite the work being done, so this closes that documentation gap without any code change
 - **[2026-07-11]**: docs(governance): add Sequential Branch Dependency Rule (§3.3) to workspace root and project templates — codifies a lesson from this session's PR merge process: 6 PR branches were all created from the same stale `main` commit without merging any first, so every one conflicted on shared pipeline files (CHANGELOG.md, memory logs, VERSION_MANIFEST.md, generated READMEs) that `dev-sync.ts` touches on every commit regardless of workstream; sequential *merge* order could not resolve this since the conflicts were baked in at branch-*creation* time; new rule requires merging a prior open PR before branching for the next task unless parallel branching is explicitly justified in the plan's Trade-offs section; added to `docs/constitution/03-pr-workflow.md` (summary in `CONSTITUTION.md` §3, cross-reference in `AGENTS.md` §5.1) **and propagated to `templates/common/CLAUDE.md`/`GEMINI.md`** so projects scaffolded via `new-project.ts` inherit the discipline from day one
 - **[2026-07-11]**: test(security): recreate `tests/unit/ssrf-safe-fetch.test.ts` (M15 regression suite) — discovered missing from `main` despite the corresponding `scripts/lib/ssrf.ts` `safeFetch()`/`fetchPinned()`/`SSRFBlockedError` changes having merged via PR #399; the test file was never actually included in that commit; 5 tests covering blocked-range rejection, redirect refusal, and the core TOCTOU-closing property (pinned connection succeeds against a non-resolvable hostname, proving no fresh DNS lookup occurs)
@@ -874,7 +875,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ---
 
-*Last Updated: 2026-07-11*
+*Last Updated: 2026-07-15*
 
 
 

--- a/docs/VERSION_MANIFEST.md
+++ b/docs/VERSION_MANIFEST.md
@@ -1,6 +1,6 @@
 # VERSION_MANIFEST.md
 
-**Generated**: 2026-07-15T15:43:40.041Z
+**Generated**: 2026-07-15T22:29:56.903Z
 **Manifest Version**: 1.0
 **Location**: docs\VERSION_MANIFEST.md
 

--- a/memory/2026-07-15.md
+++ b/memory/2026-07-15.md
@@ -29,3 +29,28 @@ fix(new-project): add root package.json generation and bun install to new-projec
 
 ## Open Issues
 - None
+
+---
+
+## Session Summary
+chore: update
+
+## Changes
+- `M CHANGELOG.md` — modified
+- `templates/co-deck/.claude/skills/storyline/SKILL.md` — modified
+- `templates/co-deck/.gemini/skills/storyline/SKILL.md` — modified
+- `templates/co-deck/agents/storyline.md` — modified
+- `templates/co-deck/docs/co-deck.context.md` — modified
+- `templates/co-deck/docs/html-themes/themes/outline/theme.json` — modified
+- `templates/co-deck/docs/html-themes/themes/pitch-enhanced/theme.json` — modified
+- `templates/co-deck/docs/html-themes/themes/pitch/theme.json` — modified
+- `templates/co-deck/docs/html-themes/themes/vertical/theme.json` — modified
+- `templates/co-deck/docs/html-themes/themes/zen/theme.json` — modified
+- `templates/co-deck/skills/storyline/SKILL.md` — modified
+- `templates/co-deck/skills/theme-authoring/SKILL.md` — modified
+
+## Decisions
+- None
+
+## Open Issues
+- None

--- a/templates/co-deck/.claude/skills/storyline/SKILL.md
+++ b/templates/co-deck/.claude/skills/storyline/SKILL.md
@@ -113,6 +113,8 @@ Repeat this structure for every slide. Dividers include part number and descript
 > - AX(AI Transformation)의 정의
 > ```
 
+> ⚠️ **Uniform Layout Principle**: All content slides within a single deck MUST use `standard` type. Special types (`punchline`, `divider`, `profile`) are reserved for their designated structural purpose only. `punchline` is allowed ONLY as the last content slide with a single-statement message (≤1 line, no bullets). Mixing slide types for content slides is prohibited — each type has a distinct CSS layout (2-column vs center-aligned), and mixing breaks visual consistency.
+
 ---
 
 ### Step 4: Balance Check
@@ -122,8 +124,9 @@ Self-review after writing both files:
 - Are slide counts balanced across chapters (within ±20%)?
 - Any slides with too many bullets? (4 max recommended, 5 is hard limit)
 - No more than 3 consecutive slides without visuals?
-
----
+- Does every slide have a `script` field with narration text?
+- If multi-language narration is requested, do translated script fields exist?
+- **Uniform Layout check**: Do ALL content slides (between cover and closing) use `type: standard`? If any content slide uses `punchline` or another non-standard type, convert it to `standard`.
 
 ## Output Format
 

--- a/templates/co-deck/.gemini/skills/storyline/SKILL.md
+++ b/templates/co-deck/.gemini/skills/storyline/SKILL.md
@@ -113,6 +113,8 @@ Repeat this structure for every slide. Dividers include part number and descript
 > - AX(AI Transformation)의 정의
 > ```
 
+> ⚠️ **Uniform Layout Principle**: All content slides within a single deck MUST use `standard` type. Special types (`punchline`, `divider`, `profile`) are reserved for their designated structural purpose only. `punchline` is allowed ONLY as the last content slide with a single-statement message (≤1 line, no bullets). Mixing slide types for content slides is prohibited — each type has a distinct CSS layout (2-column vs center-aligned), and mixing breaks visual consistency.
+
 ---
 
 ### Step 4: Balance Check
@@ -122,8 +124,9 @@ Self-review after writing both files:
 - Are slide counts balanced across chapters (within ±20%)?
 - Any slides with too many bullets? (4 max recommended, 5 is hard limit)
 - No more than 3 consecutive slides without visuals?
-
----
+- Does every slide have a `script` field with narration text?
+- If multi-language narration is requested, do translated script fields exist?
+- **Uniform Layout check**: Do ALL content slides (between cover and closing) use `type: standard`? If any content slide uses `punchline` or another non-standard type, convert it to `standard`.
 
 ## Output Format
 

--- a/templates/co-deck/agents/storyline.md
+++ b/templates/co-deck/agents/storyline.md
@@ -85,15 +85,22 @@ After drafting the outline but **before writing the full `slide_deck.md`**, pres
 
 Slide types: `cover` · `speaker intro` · `divider` · `punchline` · `standard` · `contact`
 
-**Theme-specific slide type rules:**
-> **SSOT**: Read `slide_types` from `docs/html-themes/themes/<theme>/theme.json` at runtime. Each theme declares which slide types it supports (e.g., `"punchline": true` or `"punchline": false`). Do NOT hardcode theme-specific rules here — the theme.json is the single source of truth.
->
-> Common patterns:
-> - `isPunchline: true` — use for impact/summary slides (large-font single-statement emphasis). Supported when `theme.json` declares `"punchline": true`.
-> - `isDividerSlide: true` — use for chapter/part boundaries. Supported when `theme.json` declares `"divider": true`.
-> - `isProfileSlide: true` — speaker intro slide. Supported when `theme.json` declares `"profile": true`.
->
-> Available themes and compatibility: see `docs/html-themes/THEMES.md` registry.
+**⚠️ Uniform Layout Principle — Single slide type for all content slides:**
+
+Within a single HTML presentation, ALL content slides MUST use the same slide type (`standard`). Special slide types (`punchline`, `divider`, `profile`) may only be used for their designated structural purpose (see table below). **Mixing `standard` and `punchline` (or any other non-standard type) for content slides within the same deck is PROHIBITED.**
+
+> **Rationale**: Each slide type has a distinct CSS layout (2-column grid vs center-aligned single-column). Mixing types causes visual inconsistency that breaks the audience's reading rhythm. The audience expects a uniform layout for all content slides.
+
+| Slide Type | Allowed Usage | Layout Pattern | Content Limit |
+|------------|--------------|----------------|---------------|
+| `standard` | **ALL content slides** (mandatory) | 2-column: text left + visual right | 3–4 bullets per slide |
+| `title` | First slide (cover) only | Full-bleed background, centered text | Title + subtitle |
+| `punchline` | **Last content slide only** — single-statement closing (≤1 line) | Center-aligned, large font, no bullets | 1 key message |
+| `divider` | Chapter/part boundaries only | 2-column: text + image | Part label + title + short description |
+| `profile` | Speaker intro slide only | Centered, avatar + name + affiliation | Name, title, bio |
+| `contact` | Final slide only | 2-column: text left + visual right | Contact info + closing |
+
+**Self-check rule**: Before finalizing `slide_deck.md`, verify that ALL content slides (everything between cover and closing) have `type: standard`. If any content slide uses `punchline` or `divider`, convert it to `standard`.
 
 ### slide_deck.md — Image Fields (per slide)
 

--- a/templates/co-deck/docs/co-deck.context.md
+++ b/templates/co-deck/docs/co-deck.context.md
@@ -1,6 +1,6 @@
 ---
 # co-deck — Variant Configuration
-# Last Updated: 2026-06-28
+# Last Updated: 2026-07-15
 ---
 
 > Extends docs/context.md. This file IS the customization layer for this project.
@@ -437,6 +437,7 @@ PM reads lecture-profile.md → confirms presentation.theme + presentation.style
 3. Each slide: ≤ bullets per `content_rules`; `image_role: none` max 3 consecutive slides
 4. Speaker intro (slide 2) and contact (last slide) are mandatory
 5. Every slide in slide_deck.md must have `image_role`, `image_query`, `image_license` fields
+6. **Uniform Layout Principle**: All content slides within a single deck MUST use `standard` type. Special types (`punchline`, `divider`, `profile`) are reserved for their designated structural purpose only. `punchline` is allowed ONLY as the last content slide with a single-statement message (≤1 line, no bullets). Mixing slide types for content slides is prohibited — each type has a distinct CSS layout (2-column vs center-aligned), and mixing breaks visual consistency.
 
 ### Design Rules
 1. 8-role color palette: defined in design_spec.md CSS variable block
@@ -558,3 +559,8 @@ slideData[i].visualImage = "../assets/diagrams/<stem>.svg"   ← always SVG (gen
 ---
 
 *co-deck.context.md version: 4.2 — updated 2026-06-28: FullscreenManager (F key + footer button) + @media print (Ctrl+P one slide per page) for all 5 themes; G1+G2 Tier 1 preview enhancements.*
+
+## Template Provenance
+
+- **Template-Version**: 0.5.3
+- **Template-Variant**: co-deck

--- a/templates/co-deck/docs/html-themes/themes/outline/theme.json
+++ b/templates/co-deck/docs/html-themes/themes/outline/theme.json
@@ -13,7 +13,15 @@
     "max_bullets_per_slide": 6,
     "max_title_chars": 35,
     "recommended_slide_count": "20-50",
-    "notes": "Research-oriented outline style. Titles up to 35 chars. Max 6 bullets per slide. Images and diagrams are NOT displayed. Focus on structured text content."
+    "notes": "Research-oriented outline style. Titles up to 35 chars. Max 6 bullets per slide. Images and diagrams are NOT displayed. Focus on structured text content.",
+    "slide_type_usage": {
+      "standard": "All content slides (mandatory)",
+      "punchline": "Last content slide only — single-statement message (≤1 line, no bullets)",
+      "divider": "Chapter/part boundaries only",
+      "profile": "Speaker intro only",
+      "title": "First slide (cover) only",
+      "contact": "Final slide only"
+    }
   },
   "compatible_styles": ["classic", "minimal", "premium-dark", "academic", "visual-heavy"],
   "partial_styles": [],

--- a/templates/co-deck/docs/html-themes/themes/pitch-enhanced/theme.json
+++ b/templates/co-deck/docs/html-themes/themes/pitch-enhanced/theme.json
@@ -12,7 +12,15 @@
     "max_bullets_per_slide": 4,
     "max_title_chars": 28,
     "recommended_slide_count": "20-50",
-    "notes": "Same content rules as pitch. Floating card leaves natural padding on all sides. Titles up to 28 chars (2 display lines OK). Max 4 bullets. Divider slides must have a compelling image. Punchline type supported for impactful closing statements."
+    "notes": "Same content rules as pitch. Floating card leaves natural padding on all sides. Titles up to 28 chars (2 display lines OK). Max 4 bullets. Divider slides must have a compelling image. Punchline type supported for impactful closing statements.",
+    "slide_type_usage": {
+      "standard": "All content slides (mandatory)",
+      "punchline": "Last content slide only — single-statement message (≤1 line, no bullets)",
+      "divider": "Chapter/part boundaries only",
+      "profile": "Speaker intro only",
+      "title": "First slide (cover) only",
+      "contact": "Final slide only"
+    }
   },
   "compatible_styles": ["classic", "minimal", "premium-dark", "academic", "visual-heavy"],
   "incompatible_styles": [],

--- a/templates/co-deck/docs/html-themes/themes/pitch/theme.json
+++ b/templates/co-deck/docs/html-themes/themes/pitch/theme.json
@@ -12,7 +12,15 @@
     "max_bullets_per_slide": 4,
     "max_title_chars": 28,
     "recommended_slide_count": "20-50",
-    "notes": "Floating card leaves natural padding on all sides. Titles up to 28 chars (2 display lines OK). Max 4 bullets; each bullet should be a concise takeaway. Divider slides must have a compelling image on the right panel. Script field is shown in the presenter panel — keep it to 2-3 sentences."
+    "notes": "Floating card leaves natural padding on all sides. Titles up to 28 chars (2 display lines OK). Max 4 bullets; each bullet should be a concise takeaway. Divider slides must have a compelling image on the right panel. Script field is shown in the presenter panel — keep it to 2-3 sentences.",
+    "slide_type_usage": {
+      "standard": "All content slides (mandatory)",
+      "punchline": "Last content slide only — single-statement message (≤1 line, no bullets)",
+      "divider": "Chapter/part boundaries only",
+      "profile": "Speaker intro only",
+      "title": "First slide (cover) only",
+      "contact": "Final slide only"
+    }
   },
   "compatible_styles": ["classic", "minimal", "premium-dark"],
   "incompatible_styles": [

--- a/templates/co-deck/docs/html-themes/themes/vertical/theme.json
+++ b/templates/co-deck/docs/html-themes/themes/vertical/theme.json
@@ -14,7 +14,15 @@
     "max_bullets_per_slide": 5,
     "max_title_chars": 28,
     "recommended_slide_count": "30-60",
-    "notes": "Vertical scroll suits long-form content. Titles up to 28 chars. Max 5 bullets per slide. All slide types supported. Works well with 30+ slides for deep-dive presentations. Keyboard: ArrowUp/Down, PageUp/PageDown, Home/End, Space."
+    "notes": "Vertical scroll suits long-form content. Titles up to 28 chars. Max 5 bullets per slide. All slide types supported. Works well with 30+ slides for deep-dive presentations. Keyboard: ArrowUp/Down, PageUp/PageDown, Home/End, Space.",
+    "slide_type_usage": {
+      "standard": "All content slides (mandatory)",
+      "punchline": "Last content slide only — single-statement message (≤1 line, no bullets)",
+      "divider": "Chapter/part boundaries only",
+      "profile": "Speaker intro only",
+      "title": "First slide (cover) only",
+      "contact": "Final slide only"
+    }
   },
   "compatible_styles": ["classic", "minimal", "premium-dark", "academic", "visual-heavy"],
   "partial_styles": [],

--- a/templates/co-deck/docs/html-themes/themes/zen/theme.json
+++ b/templates/co-deck/docs/html-themes/themes/zen/theme.json
@@ -13,7 +13,15 @@
     "max_bullets_per_slide": 3,
     "max_title_chars": 30,
     "recommended_slide_count": "15-25",
-    "notes": "Presentation Zen style. Titles up to 30 chars. Max 3 bullets per slide as subtle secondary text. Background image expected on every slide. Speaker script for narration."
+    "notes": "Presentation Zen style. Titles up to 30 chars. Max 3 bullets per slide as subtle secondary text. Background image expected on every slide. Speaker script for narration.",
+    "slide_type_usage": {
+      "standard": "All content slides (mandatory)",
+      "punchline": "Last content slide only — single-statement message (≤1 line, no bullets)",
+      "divider": "Chapter/part boundaries only",
+      "profile": "Speaker intro only",
+      "title": "First slide (cover) only",
+      "contact": "Final slide only"
+    }
   },
   "compatible_styles": ["classic", "minimal", "premium-dark", "academic"],
   "partial_styles": [],

--- a/templates/co-deck/skills/storyline/SKILL.md
+++ b/templates/co-deck/skills/storyline/SKILL.md
@@ -115,6 +115,8 @@ Repeat this structure for every slide. Dividers include part number and descript
 > - Definition of AX (AI Transformation)
 > ```
 
+> ⚠️ **Uniform Layout Principle**: All content slides within a single deck MUST use `standard` type. Special types (`punchline`, `divider`, `profile`) are reserved for their designated structural purpose only. `punchline` is allowed ONLY as the last content slide with a single-statement message (≤1 line, no bullets). Mixing slide types for content slides is prohibited — each type has a distinct CSS layout (2-column vs center-aligned), and mixing breaks visual consistency.
+
 ---
 
 ### Step 4: Balance Check
@@ -126,6 +128,7 @@ Self-review after writing both files:
 - No more than 3 consecutive slides without visuals?
 - Does every slide have a `script` field with narration text?
 - If multi-language narration is requested, do translated script fields exist?
+- **Uniform Layout check**: Do ALL content slides (between cover and closing) use `type: standard`? If any content slide uses `punchline` or another non-standard type, convert it to `standard`.
 
 ---
 

--- a/templates/co-deck/skills/theme-authoring/SKILL.md
+++ b/templates/co-deck/skills/theme-authoring/SKILL.md
@@ -105,6 +105,14 @@ design authors `docs/html-themes/themes/<name>/theme.json`:
     "max_bullets_per_slide": N,
     "max_title_chars": N,
     "recommended_slide_count": "X-Y",
+    "slide_type_usage": {
+      "standard": "All content slides (mandatory)",
+      "punchline": "Last content slide only — single-statement message (≤1 line, no bullets)",
+      "divider": "Chapter/part boundaries only",
+      "profile": "Speaker intro only",
+      "title": "First slide (cover) only",
+      "contact": "Final slide only"
+    },
     "notes": "..."
   },
   "compatible_styles": ["classic", "minimal"],


### PR DESCRIPTION
[claude pr-body] Attempt 1/2
[claude pr-body]  Success on attempt 1
## Why
The co-deck template allowed content slides to mix slide types (`standard`, `punchline`, `divider`), which broke visual consistency because each type has a distinct CSS layout (2-column vs center-aligned). This propagates the Uniform Layout Principle already enforced in co-deck1 into the shared `templates/co-deck` so all newly scaffolded decks inherit the discipline.

## What Changed
- **`agents/storyline.md`**: Replaced the runtime SSOT note with a Uniform Layout Principle section — a type-to-purpose table (`standard`, `title`, `punchline`, `divider`, `profile`, `contact`) plus a self-check rule requiring all content slides to use `type: standard`.
- **`skills/storyline/SKILL.md`**, **`.claude/`** and **`.gemini/`** copies: Added a ⚠️ Uniform Layout warning block and a "Uniform Layout check" item to the Step 4 balance check.
- **`skills/theme-authoring/SKILL.md`**: Added a `slide_type_usage` object to the documented `content_rules` theme.json schema.
- **5 `theme.json` files** (`outline`, `pitch`, `pitch-enhanced`, `vertical`, `zen`): Added the `slide_type_usage` object inside `content_rules`.
- **`docs/co-deck.context.md`**: Added Content Rules item 6 (Uniform Layout Principle) and a Template Provenance block (Template-Version 0.5.3, co-deck variant); bumped Last Updated to 2026-07-15.
- **`CHANGELOG.md`** / **`docs/VERSION_MANIFEST.md`** / **`memory/2026-07-15.md`**: Changelog entry, manifest bump, and session log.

## Test Plan
- [ ] `bun scripts/audit.ts` passes
- [ ] Spot-check that the `slide_type_usage` JSON in all 5 `theme.json` files parses cleanly (`bun -e "JSON.parse(require('fs').readFileSync('templates/co-deck/docs/html-themes/themes/outline/theme.json','utf8'))"`)
- [ ] Confirm the `.claude/` and `.gemini/` storyline skill copies stay byte-identical to the canonical `skills/storyline/SKILL.md` (platform parity)

## Security Checklist
- [ ] No secrets, credentials, or API keys committed
- [ ] No `.env` files staged (use `.env.sample` for templates)
- [ ] Dependencies unchanged or reviewed for new CVEs

## Notes
None