### PR TITLE
feat(handbook): expand CSS variable system with Native theme, orphan class rules, and 33 hardcoded hex replacements

### DIFF
--- a/docs/VERSION_MANIFEST.md
+++ b/docs/VERSION_MANIFEST.md
@@ -1,6 +1,6 @@
 # VERSION_MANIFEST.md
 
-**Generated**: 2026-07-17T11:09:06.891Z
+**Generated**: 2026-07-17T12:03:34.805Z
 **Manifest Version**: 1.0
 **Location**: docs\VERSION_MANIFEST.md
 

--- a/memory/2026-07-17.md
+++ b/memory/2026-07-17.md
@@ -137,3 +137,23 @@ feat(handbook): split CSS into 2-file architecture with unified semantic variabl
 
 ## Open Issues
 - None
+
+---
+
+## Session Summary
+feat(handbook): expand CSS variable system with Native theme, orphan class rules, and 33 hardcoded hex replacements
+
+## Changes
+- `M templates/co-deck/scripts/co-deck/handbook/apply-handbook-theme.ts` — modified
+- `templates/co-deck/scripts/co-deck/tests/apply-handbook-theme.test.ts` — modified
+- `templates/co-deck/skills/handbook/SKILL.md` — modified
+- `templates/co-deck/skills/handbook/assets/css/handbook-components.css` — modified
+- `templates/co-deck/skills/handbook/assets/css/handbook-variables.css` — modified
+- `templates/co-deck/skills/handbook/references/AUTHORING_GUIDELINES.md` — modified
+- `templates/co-deck/skills/handbook/references/BUILD_GUIDE.md` — modified
+
+## Decisions
+- None
+
+## Open Issues
+- None

--- a/templates/co-deck/scripts/co-deck/handbook/apply-handbook-theme.ts
+++ b/templates/co-deck/scripts/co-deck/handbook/apply-handbook-theme.ts
@@ -5,7 +5,7 @@
 // OUTPUTS ONLY VARIABLE DECLARATIONS to handbook-variables.css.
 // Structural rules live in handbook-components.css and are NEVER overwritten.
 
-import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { existsSync, mkdirSync, writeFileSync } from "node:fs";
 import { join, resolve } from "node:path";
 
 const args = process.argv.slice(2);
@@ -17,311 +17,341 @@ function getArg(name: string, fallback: string): string {
 
 interface ThemePalette {
   name: string;
+  desc: string;
   light: Record<string, string>;
   dark: Record<string, string>;
 }
 
-// Unified semantic variable names. Each theme provides light + dark values.
+// --- Shared base variables (identical across all themes) ---
+const SHARED: Record<string, string> = {
+  "--radius-sm": "4px",
+  "--radius-md": "6px",
+  "--radius-lg": "10px",
+  "--sidebar-width": "260px",
+  "--content-offset": "280px",
+  "--max-width": "720px",
+  "--wrap-width": "880px",
+  "--spacing-unit": "8px",
+  "--font-family": "-apple-system, BlinkMacSystemFont, 'Segoe UI', 'Noto Sans KR', Roboto, 'Helvetica Neue', Arial, sans-serif",
+  "--font-mono": "'SFMono-Regular', 'Cascadia Code', 'Fira Code', 'JetBrains Mono', Consolas, 'Liberation Mono', monospace",
+  "--font-size": "16px",
+  "--line-height": "1.85",
+};
+
+// --- Variable groups that differ per theme ---
+// Each theme only needs to provide the "accent" group variables.
+// Badge, platform, compare, situation, video variables are computed from accent values.
+
+function badgeVars(
+  b: string, f: string, brd: string,
+): [string, string, string] { return [b, f, brd]; }
+
+function allBadgeVars(
+  green: [string,string,string], blue: [string,string,string], purple: [string,string,string],
+  amber: [string,string,string], orange: [string,string,string], indigo: [string,string,string],
+  violet: [string,string,string], red: [string,string], lab: [string,string,string],
+): Record<string, string> {
+  return {
+    "--badge-green-bg": green[0], "--badge-green-fg": green[1], "--badge-green-border": green[2],
+    "--badge-blue-bg": blue[0], "--badge-blue-fg": blue[1], "--badge-blue-border": blue[2],
+    "--badge-purple-bg": purple[0], "--badge-purple-fg": purple[1], "--badge-purple-border": purple[2],
+    "--badge-amber-bg": amber[0], "--badge-amber-fg": amber[1], "--badge-amber-border": amber[2],
+    "--badge-orange-bg": orange[0], "--badge-orange-fg": orange[1], "--badge-orange-border": orange[2],
+    "--badge-indigo-bg": indigo[0], "--badge-indigo-fg": indigo[1], "--badge-indigo-border": indigo[2],
+    "--badge-violet-bg": violet[0], "--badge-violet-fg": violet[1], "--badge-violet-border": violet[2],
+    "--badge-red-bg": red[0], "--badge-red-fg": red[1],
+    "--badge-lab-bg": lab[0], "--badge-lab-fg": lab[1], "--badge-lab-border": lab[2],
+  };
+}
+
+// Badge palette tuples: [bg, fg, border]
+const BL = {
+  green: badgeVars("#dafbe1","#1a7f37","#a2d9b1"), blue: badgeVars("#ddf4ff","#0550ae","#a5d5f7"),
+  purple: badgeVars("#fbefff","#6639ba","#d2b3f7"), amber: badgeVars("#fff8e1","#92400e","#f5d88a"),
+  orange: badgeVars("#fff3e0","#e65100","#ffcc80"), indigo: badgeVars("#e3f2fd","#0d47a1","#90caf9"),
+  violet: badgeVars("#f3e5f5","#6a1b9a","#ce93d8"), red: ["#ffebe9","#cf222e"] as [string,string],
+  lab: badgeVars("#e8f5e9","#2e7d32","#a5d6a7"),
+};
+const BD = {
+  green: badgeVars("#0f5323","#3fb950","#238636"), blue: badgeVars("#0d2240","#58a6ff","#388bfd"),
+  purple: badgeVars("#2d1539","#bc8cff","#8b949e"), amber: badgeVars("#3b2000","#d29922","#8b6914"),
+  orange: badgeVars("#3b2000","#f0883e","#8b6914"), indigo: badgeVars("#0d2240","#58a6ff","#388bfd"),
+  violet: badgeVars("#2d1539","#bc8cff","#8b949e"), red: ["#490202","#f85149"] as [string,string],
+  lab: badgeVars("#0f5323","#3fb950","#238636"),
+};
+const NL = {
+  green: badgeVars("#e6f9e6","#116329","#a8d8a8"), blue: badgeVars("#e0f0ff","#1a56db","#91bef5"),
+  purple: badgeVars("#f0e0ff","#6e40c9","#c9b8e8"), amber: badgeVars("#fff3cd","#7c5200","#ffd666"),
+  orange: badgeVars("#ffe0cc","#bf4b00","#ffad80"), indigo: badgeVars("#ddecff","#0969da","#8ec8ff"),
+  violet: badgeVars("#ffe0f5","#8250df","#daa0e0"), red: ["#ffebe9","#d1242f"] as [string,string],
+  lab: badgeVars("#dff0df","#116329","#a8d8a8"),
+};
+const ND = {
+  green: badgeVars("#0a2e14","#2ea44f","#1a5c2e"), blue: badgeVars("#0c2d5a","#58a6ff","#1f6feb"),
+  purple: badgeVars("#2d1045","#bc8cff","#6e40c9"), amber: badgeVars("#3d2600","#e3b341","#6e5c1a"),
+  orange: badgeVars("#3d1a00","#f0883e","#6e3c1a"), indigo: badgeVars("#0c2d5a","#58a6ff","#1f6feb"),
+  violet: badgeVars("#2d1045","#bc8cff","#6e40c9"), red: ["#3d0a0a","#f85149"] as [string,string],
+  lab: badgeVars("#0a2e14","#2ea44f","#1a5c2e"),
+};
+
+function buildVars(
+  base: Record<string, string>,
+  badges: typeof BL,
+  overrides: Record<string, string>,
+): Record<string, string> {
+  return { ...base, ...allBadgeVars(badges.green, badges.blue, badges.purple, badges.amber, badges.orange, badges.indigo, badges.violet, badges.red, badges.lab), ...overrides };
+}
+
+// --- Theme definitions ---
+
 const THEMES: Record<string, ThemePalette> = {
   azure: {
     name: "Azure",
-    light: {
-      "--bg": "#ffffff",
-      "--bg2": "#f6f8fa",
-      "--bg3": "#eef1f4",
+    desc: "GitHub Primer-inspired defaults",
+    light: buildVars(SHARED, BL, {
+      "--bg": "#ffffff", "--bg2": "#f6f8fa", "--bg3": "#eef1f4",
       "--border": "#d0d7de",
-      "--text": "#1f2328",
-      "--text-dim": "#636c76",
-      "--accent": "#0969da",
-      "--accent-green": "#1a7f37",
-      "--accent-purple": "#6639ba",
-      "--accent-dark": "#0550ae",
-      "--accent-amber": "#953800",
-      "--accent-red": "#cf222e",
-      "--bg-info": "#ddf4ff",
-      "--bg-note": "#fff8c5",
-      "--bg-warn": "#fff1c5",
-      "--bg-success": "#dafbe1",
-      "--bg-error": "#ffebe9",
-      "--border-info": "#0969da",
-      "--border-note": "#9a6700",
-      "--border-warn": "#9a6700",
-      "--border-success": "#1a7f37",
-      "--border-error": "#cf222e",
-      "--code-bg": "#f6f8fa",
-      "--code-border": "#d0d7de",
-      "--tag-bg": "#ddf4ff",
-      "--tag-text": "#0550ae",
-    },
-    dark: {
-      "--bg": "#0d1117",
-      "--bg2": "#161b22",
-      "--bg3": "#21262d",
+      "--text": "#1f2328", "--text-dim": "#636c76", "--text-inverse": "#fff",
+      "--accent": "#0969da", "--accent-green": "#1a7f37", "--accent-purple": "#6639ba",
+      "--accent-dark": "#0550ae", "--accent-amber": "#953800", "--accent-red": "#cf222e",
+      "--bg-info": "#ddf4ff", "--bg-note": "#fff8c5", "--bg-warn": "#fff1c5", "--bg-success": "#dafbe1", "--bg-error": "#ffebe9",
+      "--bg-situation": "#fffbf0", "--bg-video": "#f0f6ff",
+      "--border-info": "#0969da", "--border-note": "#9a6700", "--border-warn": "#9a6700", "--border-success": "#1a7f37", "--border-error": "#cf222e",
+      "--border-situation": "#f2c97d", "--border-video": "#d0e8ff",
+      "--code-bg": "#f6f8fa", "--code-border": "#d0d7de",
+      "--tag-bg": "#ddf4ff", "--tag-text": "#0550ae",
+      "--platform-claude": "#d97706", "--platform-claudeapp": "#f59e0b", "--platform-agy": "#0550ae", "--platform-antigravity": "#6639ba",
+      "--compare-without-bg": "#fff8f8", "--compare-without-border": "#ffc1bc",
+      "--compare-with-bg": "#f0fff4", "--compare-with-border": "#a2d9b1",
+      "--shadow-sm": "0 1px 2px rgba(0,0,0,.06)", "--shadow-md": "0 4px 14px rgba(9,105,218,.10)",
+    }),
+    dark: buildVars(SHARED, BD, {
+      "--bg": "#0d1117", "--bg2": "#161b22", "--bg3": "#21262d",
       "--border": "#30363d",
-      "--text": "#e6edf3",
-      "--text-dim": "#8b949e",
-      "--accent": "#58a6ff",
-      "--accent-green": "#3fb950",
-      "--accent-purple": "#bc8cff",
-      "--accent-dark": "#1f6feb",
-      "--accent-amber": "#d29922",
-      "--accent-red": "#f85149",
-      "--bg-info": "#0d2240",
-      "--bg-note": "#3b2e00",
-      "--bg-warn": "#3b2000",
-      "--bg-success": "#0f5323",
-      "--bg-error": "#490202",
-      "--border-info": "#58a6ff",
-      "--border-note": "#d29922",
-      "--border-warn": "#d29922",
-      "--border-success": "#3fb950",
-      "--border-error": "#f85149",
-      "--code-bg": "#161b22",
-      "--code-border": "#30363d",
-      "--tag-bg": "#0d2240",
-      "--tag-text": "#58a6ff",
-    },
+      "--text": "#e6edf3", "--text-dim": "#8b949e", "--text-inverse": "#fff",
+      "--accent": "#58a6ff", "--accent-green": "#3fb950", "--accent-purple": "#bc8cff",
+      "--accent-dark": "#1f6feb", "--accent-amber": "#d29922", "--accent-red": "#f85149",
+      "--bg-info": "#0d2240", "--bg-note": "#3b2e00", "--bg-warn": "#3b2000", "--bg-success": "#0f5323", "--bg-error": "#490202",
+      "--bg-situation": "#3b2e00", "--bg-video": "#0d2240",
+      "--border-info": "#58a6ff", "--border-note": "#d29922", "--border-warn": "#d29922", "--border-success": "#3fb950", "--border-error": "#f85149",
+      "--border-situation": "#d29922", "--border-video": "#58a6ff",
+      "--code-bg": "#161b22", "--code-border": "#30363d",
+      "--tag-bg": "#0d2240", "--tag-text": "#58a6ff",
+      "--platform-claude": "#f0883e", "--platform-claudeapp": "#f59e0b", "--platform-agy": "#58a6ff", "--platform-antigravity": "#bc8cff",
+      "--compare-without-bg": "#3b1219", "--compare-without-border": "#f85149",
+      "--compare-with-bg": "#0f5323", "--compare-with-border": "#3fb950",
+      "--shadow-sm": "0 1px 2px rgba(0,0,0,.3)", "--shadow-md": "0 4px 14px rgba(0,0,0,.3)",
+    }),
   },
+
   graphite: {
     name: "Graphite",
-    light: {
-      "--bg": "#ffffff",
-      "--bg2": "#f3f4f6",
-      "--bg3": "#e5e7eb",
+    desc: "Neutral gray palette",
+    light: buildVars(SHARED, BL, {
+      "--bg": "#ffffff", "--bg2": "#f3f4f6", "--bg3": "#e5e7eb",
       "--border": "#9ca3af",
-      "--text": "#111827",
-      "--text-dim": "#6b7280",
-      "--accent": "#4b5563",
-      "--accent-green": "#374151",
-      "--accent-purple": "#6b7280",
-      "--accent-dark": "#1f2937",
-      "--accent-amber": "#78350f",
-      "--accent-red": "#991b1b",
-      "--bg-info": "#eff6ff",
-      "--bg-note": "#fefce8",
-      "--bg-warn": "#fff7ed",
-      "--bg-success": "#f0fdf4",
-      "--bg-error": "#fef2f2",
-      "--border-info": "#4b5563",
-      "--border-note": "#78350f",
-      "--border-warn": "#78350f",
-      "--border-success": "#374151",
-      "--border-error": "#991b1b",
-      "--code-bg": "#f3f4f6",
-      "--code-border": "#9ca3af",
-      "--tag-bg": "#eff6ff",
-      "--tag-text": "#1f2937",
-    },
-    dark: {
-      "--bg": "#111827",
-      "--bg2": "#1f2937",
-      "--bg3": "#374151",
+      "--text": "#111827", "--text-dim": "#6b7280", "--text-inverse": "#fff",
+      "--accent": "#4b5563", "--accent-green": "#374151", "--accent-purple": "#6b7280",
+      "--accent-dark": "#1f2937", "--accent-amber": "#78350f", "--accent-red": "#991b1b",
+      "--bg-info": "#eff6ff", "--bg-note": "#fefce8", "--bg-warn": "#fff7ed", "--bg-success": "#f0fdf4", "--bg-error": "#fef2f2",
+      "--bg-situation": "#fffbf0", "--bg-video": "#f0f6ff",
+      "--border-info": "#4b5563", "--border-note": "#78350f", "--border-warn": "#78350f", "--border-success": "#374151", "--border-error": "#991b1b",
+      "--border-situation": "#f2c97d", "--border-video": "#d0e8ff",
+      "--code-bg": "#f3f4f6", "--code-border": "#9ca3af",
+      "--tag-bg": "#eff6ff", "--tag-text": "#1f2937",
+      "--platform-claude": "#92400e", "--platform-claudeapp": "#b45309", "--platform-agy": "#374151", "--platform-antigravity": "#6b7280",
+      "--compare-without-bg": "#fef2f2", "--compare-without-border": "#fca5a5",
+      "--compare-with-bg": "#f0fdf4", "--compare-with-border": "#6ee7b7",
+      "--shadow-sm": "0 1px 2px rgba(0,0,0,.06)", "--shadow-md": "0 4px 14px rgba(0,0,0,.08)",
+    }),
+    dark: buildVars(SHARED, BD, {
+      "--bg": "#111827", "--bg2": "#1f2937", "--bg3": "#374151",
       "--border": "#4b5563",
-      "--text": "#f9fafb",
-      "--text-dim": "#9ca3af",
-      "--accent": "#d1d5db",
-      "--accent-green": "#6ee7b7",
-      "--accent-purple": "#c4b5fd",
-      "--accent-dark": "#e5e7eb",
-      "--accent-amber": "#fcd34d",
-      "--accent-red": "#fca5a5",
-      "--bg-info": "#1e3a5f",
-      "--bg-note": "#423006",
-      "--bg-warn": "#451a03",
-      "--bg-success": "#14532d",
-      "--bg-error": "#7f1d1d",
-      "--border-info": "#d1d5db",
-      "--border-note": "#fcd34d",
-      "--border-warn": "#fcd34d",
-      "--border-success": "#6ee7b7",
-      "--border-error": "#fca5a5",
-      "--code-bg": "#1f2937",
-      "--code-border": "#4b5563",
-      "--tag-bg": "#1e3a5f",
-      "--tag-text": "#d1d5db",
-    },
+      "--text": "#f9fafb", "--text-dim": "#9ca3af", "--text-inverse": "#fff",
+      "--accent": "#d1d5db", "--accent-green": "#6ee7b7", "--accent-purple": "#c4b5fd",
+      "--accent-dark": "#e5e7eb", "--accent-amber": "#fcd34d", "--accent-red": "#fca5a5",
+      "--bg-info": "#1e3a5f", "--bg-note": "#423006", "--bg-warn": "#451a03", "--bg-success": "#14532d", "--bg-error": "#7f1d1d",
+      "--bg-situation": "#423006", "--bg-video": "#1e3a5f",
+      "--border-info": "#d1d5db", "--border-note": "#fcd34d", "--border-warn": "#fcd34d", "--border-success": "#6ee7b7", "--border-error": "#fca5a5",
+      "--border-situation": "#fcd34d", "--border-video": "#d1d5db",
+      "--code-bg": "#1f2937", "--code-border": "#4b5563",
+      "--tag-bg": "#1e3a5f", "--tag-text": "#d1d5db",
+      "--platform-claude": "#f0883e", "--platform-claudeapp": "#f59e0b", "--platform-agy": "#58a6ff", "--platform-antigravity": "#bc8cff",
+      "--compare-without-bg": "#3b1219", "--compare-without-border": "#f85149",
+      "--compare-with-bg": "#0f5323", "--compare-with-border": "#3fb950",
+      "--shadow-sm": "0 1px 2px rgba(0,0,0,.3)", "--shadow-md": "0 4px 14px rgba(0,0,0,.3)",
+    }),
   },
+
   teal: {
     name: "Teal",
-    light: {
-      "--bg": "#ffffff",
-      "--bg2": "#f0fdfa",
-      "--bg3": "#ccfbf1",
+    desc: "Fresh teal-green palette",
+    light: buildVars(SHARED, BL, {
+      "--bg": "#ffffff", "--bg2": "#f0fdfa", "--bg3": "#ccfbf1",
       "--border": "#99f6e4",
-      "--text": "#134e4a",
-      "--text-dim": "#5eead4",
-      "--accent": "#0d9488",
-      "--accent-green": "#14b8a6",
-      "--accent-purple": "#2dd4bf",
-      "--accent-dark": "#0f766e",
-      "--accent-amber": "#92400e",
-      "--accent-red": "#991b1b",
-      "--bg-info": "#ccfbf1",
-      "--bg-note": "#fefce8",
-      "--bg-warn": "#fff7ed",
-      "--bg-success": "#f0fdf4",
-      "--bg-error": "#fef2f2",
-      "--border-info": "#0d9488",
-      "--border-note": "#92400e",
-      "--border-warn": "#92400e",
-      "--border-success": "#14b8a6",
-      "--border-error": "#991b1b",
-      "--code-bg": "#f0fdfa",
-      "--code-border": "#99f6e4",
-      "--tag-bg": "#ccfbf1",
-      "--tag-text": "#0f766e",
-    },
-    dark: {
-      "--bg": "#042f2e",
-      "--bg2": "#0d3d3a",
-      "--bg3": "#134e4a",
+      "--text": "#134e4a", "--text-dim": "#5eead4", "--text-inverse": "#fff",
+      "--accent": "#0d9488", "--accent-green": "#14b8a6", "--accent-purple": "#2dd4bf",
+      "--accent-dark": "#0f766e", "--accent-amber": "#92400e", "--accent-red": "#991b1b",
+      "--bg-info": "#ccfbf1", "--bg-note": "#fefce8", "--bg-warn": "#fff7ed", "--bg-success": "#f0fdf4", "--bg-error": "#fef2f2",
+      "--bg-situation": "#fffbf0", "--bg-video": "#f0fdf9",
+      "--border-info": "#0d9488", "--border-note": "#92400e", "--border-warn": "#92400e", "--border-success": "#14b8a6", "--border-error": "#991b1b",
+      "--border-situation": "#f2c97d", "--border-video": "#99f6e4",
+      "--code-bg": "#f0fdfa", "--code-border": "#99f6e4",
+      "--tag-bg": "#ccfbf1", "--tag-text": "#0f766e",
+      "--platform-claude": "#b45309", "--platform-claudeapp": "#d97706", "--platform-agy": "#0d9488", "--platform-antigravity": "#2dd4bf",
+      "--compare-without-bg": "#fef2f2", "--compare-without-border": "#fca5a5",
+      "--compare-with-bg": "#f0fdf4", "--compare-with-border": "#6ee7b7",
+      "--shadow-sm": "0 1px 2px rgba(0,0,0,.06)", "--shadow-md": "0 4px 14px rgba(13,148,136,.10)",
+    }),
+    dark: buildVars(SHARED, BD, {
+      "--bg": "#042f2e", "--bg2": "#0d3d3a", "--bg3": "#134e4a",
       "--border": "#1a6b64",
-      "--text": "#ccfbf1",
-      "--text-dim": "#5eead4",
-      "--accent": "#2dd4bf",
-      "--accent-green": "#5eead4",
-      "--accent-purple": "#99f6e4",
-      "--accent-dark": "#14b8a6",
-      "--accent-amber": "#fbbf24",
-      "--accent-red": "#fca5a5",
-      "--bg-info": "#0a3d3d",
-      "--bg-note": "#423006",
-      "--bg-warn": "#451a03",
-      "--bg-success": "#14532d",
-      "--bg-error": "#7f1d1d",
-      "--border-info": "#2dd4bf",
-      "--border-note": "#fbbf24",
-      "--border-warn": "#fbbf24",
-      "--border-success": "#5eead4",
-      "--border-error": "#fca5a5",
-      "--code-bg": "#0d3d3a",
-      "--code-border": "#1a6b64",
-      "--tag-bg": "#0a3d3d",
-      "--tag-text": "#2dd4bf",
-    },
+      "--text": "#ccfbf1", "--text-dim": "#5eead4", "--text-inverse": "#fff",
+      "--accent": "#2dd4bf", "--accent-green": "#5eead4", "--accent-purple": "#99f6e4",
+      "--accent-dark": "#14b8a6", "--accent-amber": "#fbbf24", "--accent-red": "#fca5a5",
+      "--bg-info": "#0a3d3d", "--bg-note": "#423006", "--bg-warn": "#451a03", "--bg-success": "#14532d", "--bg-error": "#7f1d1d",
+      "--bg-situation": "#423006", "--bg-video": "#0a3d3d",
+      "--border-info": "#2dd4bf", "--border-note": "#fbbf24", "--border-warn": "#fbbf24", "--border-success": "#5eead4", "--border-error": "#fca5a5",
+      "--border-situation": "#fbbf24", "--border-video": "#2dd4bf",
+      "--code-bg": "#0d3d3a", "--code-border": "#1a6b64",
+      "--tag-bg": "#0a3d3d", "--tag-text": "#2dd4bf",
+      "--platform-claude": "#f0883e", "--platform-claudeapp": "#f59e0b", "--platform-agy": "#58a6ff", "--platform-antigravity": "#bc8cff",
+      "--compare-without-bg": "#3b1219", "--compare-without-border": "#f85149",
+      "--compare-with-bg": "#0f5323", "--compare-with-border": "#3fb950",
+      "--shadow-sm": "0 1px 2px rgba(0,0,0,.3)", "--shadow-md": "0 4px 14px rgba(0,0,0,.3)",
+    }),
   },
+
   amber: {
     name: "Amber",
-    light: {
-      "--bg": "#fffbeb",
-      "--bg2": "#fef3c7",
-      "--bg3": "#fde68a",
+    desc: "Warm amber/yellow palette",
+    light: buildVars(SHARED, BL, {
+      "--bg": "#fffbeb", "--bg2": "#fef3c7", "--bg3": "#fde68a",
       "--border": "#fcd34d",
-      "--text": "#78350f",
-      "--text-dim": "#92400e",
-      "--accent": "#d97706",
-      "--accent-green": "#65a30d",
-      "--accent-purple": "#9333ea",
-      "--accent-dark": "#92400e",
-      "--accent-amber": "#b45309",
-      "--accent-red": "#dc2626",
-      "--bg-info": "#eff6ff",
-      "--bg-note": "#fefce8",
-      "--bg-warn": "#fff7ed",
-      "--bg-success": "#f0fdf4",
-      "--bg-error": "#fef2f2",
-      "--border-info": "#d97706",
-      "--border-note": "#92400e",
-      "--border-warn": "#92400e",
-      "--border-success": "#65a30d",
-      "--border-error": "#dc2626",
-      "--code-bg": "#fef3c7",
-      "--code-border": "#fcd34d",
-      "--tag-bg": "#fef3c7",
-      "--tag-text": "#92400e",
-    },
-    dark: {
-      "--bg": "#1c1917",
-      "--bg2": "#292524",
-      "--bg3": "#44403c",
+      "--text": "#78350f", "--text-dim": "#92400e", "--text-inverse": "#fff",
+      "--accent": "#d97706", "--accent-green": "#65a30d", "--accent-purple": "#9333ea",
+      "--accent-dark": "#92400e", "--accent-amber": "#b45309", "--accent-red": "#dc2626",
+      "--bg-info": "#eff6ff", "--bg-note": "#fefce8", "--bg-warn": "#fff7ed", "--bg-success": "#f0fdf4", "--bg-error": "#fef2f2",
+      "--bg-situation": "#fffbf0", "--bg-video": "#fffbeb",
+      "--border-info": "#d97706", "--border-note": "#92400e", "--border-warn": "#92400e", "--border-success": "#65a30d", "--border-error": "#dc2626",
+      "--border-situation": "#f2c97d", "--border-video": "#fcd34d",
+      "--code-bg": "#fef3c7", "--code-border": "#fcd34d",
+      "--tag-bg": "#fef3c7", "--tag-text": "#92400e",
+      "--platform-claude": "#b45309", "--platform-claudeapp": "#d97706", "--platform-agy": "#1e40af", "--platform-antigravity": "#7c3aed",
+      "--compare-without-bg": "#fef2f2", "--compare-without-border": "#fca5a5",
+      "--compare-with-bg": "#f0fdf4", "--compare-with-border": "#6ee7b7",
+      "--shadow-sm": "0 1px 2px rgba(0,0,0,.06)", "--shadow-md": "0 4px 14px rgba(217,119,6,.10)",
+    }),
+    dark: buildVars(SHARED, BD, {
+      "--bg": "#1c1917", "--bg2": "#292524", "--bg3": "#44403c",
       "--border": "#57534e",
-      "--text": "#fef3c7",
-      "--text-dim": "#d6d3d1",
-      "--accent": "#fbbf24",
-      "--accent-green": "#a3e635",
-      "--accent-purple": "#c084fc",
-      "--accent-dark": "#f59e0b",
-      "--accent-amber": "#fcd34d",
-      "--accent-red": "#fca5a5",
-      "--bg-info": "#1e3a5f",
-      "--bg-note": "#423006",
-      "--bg-warn": "#451a03",
-      "--bg-success": "#14532d",
-      "--bg-error": "#7f1d1d",
-      "--border-info": "#fbbf24",
-      "--border-note": "#fcd34d",
-      "--border-warn": "#fcd34d",
-      "--border-success": "#a3e635",
-      "--border-error": "#fca5a5",
-      "--code-bg": "#292524",
-      "--code-border": "#57534e",
-      "--tag-bg": "#44403c",
-      "--tag-text": "#fbbf24",
-    },
+      "--text": "#fef3c7", "--text-dim": "#d6d3d1", "--text-inverse": "#fff",
+      "--accent": "#fbbf24", "--accent-green": "#a3e635", "--accent-purple": "#c084fc",
+      "--accent-dark": "#f59e0b", "--accent-amber": "#fcd34d", "--accent-red": "#fca5a5",
+      "--bg-info": "#1e3a5f", "--bg-note": "#423006", "--bg-warn": "#451a03", "--bg-success": "#14532d", "--bg-error": "#7f1d1d",
+      "--bg-situation": "#423006", "--bg-video": "#1e3a5f",
+      "--border-info": "#fbbf24", "--border-note": "#fcd34d", "--border-warn": "#fcd34d", "--border-success": "#a3e635", "--border-error": "#fca5a5",
+      "--border-situation": "#fcd34d", "--border-video": "#fbbf24",
+      "--code-bg": "#292524", "--code-border": "#57534e",
+      "--tag-bg": "#44403c", "--tag-text": "#fbbf24",
+      "--platform-claude": "#f0883e", "--platform-claudeapp": "#f59e0b", "--platform-agy": "#58a6ff", "--platform-antigravity": "#bc8cff",
+      "--compare-without-bg": "#3b1219", "--compare-without-border": "#f85149",
+      "--compare-with-bg": "#0f5323", "--compare-with-border": "#3fb950",
+      "--shadow-sm": "0 1px 2px rgba(0,0,0,.3)", "--shadow-md": "0 4px 14px rgba(0,0,0,.3)",
+    }),
   },
+
   indigo: {
     name: "Indigo",
-    light: {
-      "--bg": "#ffffff",
-      "--bg2": "#eef2ff",
-      "--bg3": "#e0e7ff",
+    desc: "Deep indigo/purple palette",
+    light: buildVars(SHARED, BL, {
+      "--bg": "#ffffff", "--bg2": "#eef2ff", "--bg3": "#e0e7ff",
       "--border": "#c7d2fe",
-      "--text": "#1e1b4b",
-      "--text-dim": "#6366f1",
-      "--accent": "#4f46e5",
-      "--accent-green": "#16a34a",
-      "--accent-purple": "#7c3aed",
-      "--accent-dark": "#3730a3",
-      "--accent-amber": "#b45309",
-      "--accent-red": "#dc2626",
-      "--bg-info": "#eef2ff",
-      "--bg-note": "#fefce8",
-      "--bg-warn": "#fff7ed",
-      "--bg-success": "#f0fdf4",
-      "--bg-error": "#fef2f2",
-      "--border-info": "#4f46e5",
-      "--border-note": "#b45309",
-      "--border-warn": "#b45309",
-      "--border-success": "#16a34a",
-      "--border-error": "#dc2626",
-      "--code-bg": "#eef2ff",
-      "--code-border": "#c7d2fe",
-      "--tag-bg": "#eef2ff",
-      "--tag-text": "#3730a3",
-    },
-    dark: {
-      "--bg": "#0f0e17",
-      "--bg2": "#1a1a2e",
-      "--bg3": "#232347",
+      "--text": "#1e1b4b", "--text-dim": "#6366f1", "--text-inverse": "#fff",
+      "--accent": "#4f46e5", "--accent-green": "#16a34a", "--accent-purple": "#7c3aed",
+      "--accent-dark": "#3730a3", "--accent-amber": "#b45309", "--accent-red": "#dc2626",
+      "--bg-info": "#eef2ff", "--bg-note": "#fefce8", "--bg-warn": "#fff7ed", "--bg-success": "#f0fdf4", "--bg-error": "#fef2f2",
+      "--bg-situation": "#fffbf0", "--bg-video": "#eef2ff",
+      "--border-info": "#4f46e5", "--border-note": "#b45309", "--border-warn": "#b45309", "--border-success": "#16a34a", "--border-error": "#dc2626",
+      "--border-situation": "#f2c97d", "--border-video": "#c7d2fe",
+      "--code-bg": "#eef2ff", "--code-border": "#c7d2fe",
+      "--tag-bg": "#eef2ff", "--tag-text": "#3730a3",
+      "--platform-claude": "#d97706", "--platform-claudeapp": "#ea580c", "--platform-agy": "#1e40af", "--platform-antigravity": "#7c3aed",
+      "--compare-without-bg": "#fef2f2", "--compare-without-border": "#fca5a5",
+      "--compare-with-bg": "#f0fdf4", "--compare-with-border": "#6ee7b7",
+      "--shadow-sm": "0 1px 2px rgba(0,0,0,.06)", "--shadow-md": "0 4px 14px rgba(79,70,229,.10)",
+    }),
+    dark: buildVars(SHARED, BD, {
+      "--bg": "#0f0e17", "--bg2": "#1a1a2e", "--bg3": "#232347",
       "--border": "#2e2e5e",
-      "--text": "#e0e7ff",
-      "--text-dim": "#a5b4fc",
-      "--accent": "#818cf8",
-      "--accent-green": "#4ade80",
-      "--accent-purple": "#a78bfa",
-      "--accent-dark": "#6366f1",
-      "--accent-amber": "#fbbf24",
-      "--accent-red": "#fca5a5",
-      "--bg-info": "#1a1a3e",
-      "--bg-note": "#423006",
-      "--bg-warn": "#451a03",
-      "--bg-success": "#14532d",
-      "--bg-error": "#7f1d1d",
-      "--border-info": "#818cf8",
-      "--border-note": "#fbbf24",
-      "--border-warn": "#fbbf24",
-      "--border-success": "#4ade80",
-      "--border-error": "#fca5a5",
-      "--code-bg": "#1a1a2e",
-      "--code-border": "#2e2e5e",
-      "--tag-bg": "#1a1a3e",
-      "--tag-text": "#818cf8",
-    },
+      "--text": "#e0e7ff", "--text-dim": "#a5b4fc", "--text-inverse": "#fff",
+      "--accent": "#818cf8", "--accent-green": "#4ade80", "--accent-purple": "#a78bfa",
+      "--accent-dark": "#6366f1", "--accent-amber": "#fbbf24", "--accent-red": "#fca5a5",
+      "--bg-info": "#1a1a3e", "--bg-note": "#423006", "--bg-warn": "#451a03", "--bg-success": "#14532d", "--bg-error": "#7f1d1d",
+      "--bg-situation": "#423006", "--bg-video": "#1a1a3e",
+      "--border-info": "#818cf8", "--border-note": "#fbbf24", "--border-warn": "#fbbf24", "--border-success": "#4ade80", "--border-error": "#fca5a5",
+      "--border-situation": "#fbbf24", "--border-video": "#818cf8",
+      "--code-bg": "#1a1a2e", "--code-border": "#2e2e5e",
+      "--tag-bg": "#1a1a3e", "--tag-text": "#818cf8",
+      "--platform-claude": "#f0883e", "--platform-claudeapp": "#f59e0b", "--platform-agy": "#58a6ff", "--platform-antigravity": "#bc8cff",
+      "--compare-without-bg": "#3b1219", "--compare-without-border": "#f85149",
+      "--compare-with-bg": "#0f5323", "--compare-with-border": "#3fb950",
+      "--shadow-sm": "0 1px 2px rgba(0,0,0,.3)", "--shadow-md": "0 4px 14px rgba(0,0,0,.3)",
+    }),
   },
+
+  native: {
+    name: "Native",
+    desc: "Source project original color values (GitHub-style with lighter callouts)",
+    light: buildVars(SHARED, NL, {
+      "--bg": "#ffffff", "--bg2": "#f6f8fa", "--bg3": "#eef1f4",
+      "--border": "#d0d7de",
+      "--text": "#1f2328", "--text-dim": "#636c76", "--text-inverse": "#fff",
+      "--accent": "#0969da", "--accent-green": "#1a7f37", "--accent-purple": "#6639ba",
+      "--accent-dark": "#0550ae", "--accent-amber": "#953800", "--accent-red": "#cf222e",
+      "--bg-info": "#f0f7ff", "--bg-note": "#fff8c5", "--bg-warn": "#fff8f8", "--bg-success": "#f0fff4", "--bg-error": "#ffebe9",
+      "--bg-situation": "#fffbf0", "--bg-video": "#f0f6ff",
+      "--border-info": "#0969da", "--border-note": "#9a6700", "--border-warn": "#cf222e", "--border-success": "#1a7f37", "--border-error": "#cf222e",
+      "--border-situation": "#f2c97d", "--border-video": "#d0e8ff",
+      "--code-bg": "#f6f8fa", "--code-border": "#d0d7de",
+      "--tag-bg": "#ddf4ff", "--tag-text": "#0550ae",
+      "--platform-claude": "#d97706", "--platform-claudeapp": "#f59e0b", "--platform-agy": "#0550ae", "--platform-antigravity": "#6639ba",
+      "--compare-without-bg": "#fff8f8", "--compare-without-border": "#ffc1bc",
+      "--compare-with-bg": "#f0fff4", "--compare-with-border": "#a2d9b1",
+      "--shadow-sm": "0 1px 2px rgba(0,0,0,.06)", "--shadow-md": "0 4px 14px rgba(9,105,218,.10)",
+    }),
+    dark: buildVars(SHARED, ND, {
+      "--bg": "#0d1117", "--bg2": "#161b22", "--bg3": "#21262d",
+      "--border": "#30363d",
+      "--text": "#e6edf3", "--text-dim": "#8b949e", "--text-inverse": "#fff",
+      "--accent": "#58a6ff", "--accent-green": "#3fb950", "--accent-purple": "#bc8cff",
+      "--accent-dark": "#1f6feb", "--accent-amber": "#d29922", "--accent-red": "#f85149",
+      "--bg-info": "#0d2240", "--bg-note": "#3b2e00", "--bg-warn": "#3b1219", "--bg-success": "#0f5323", "--bg-error": "#490202",
+      "--bg-situation": "#3b2e00", "--bg-video": "#0d2240",
+      "--border-info": "#58a6ff", "--border-note": "#d29922", "--border-warn": "#f85149", "--border-success": "#3fb950", "--border-error": "#f85149",
+      "--border-situation": "#d29922", "--border-video": "#58a6ff",
+      "--code-bg": "#161b22", "--code-border": "#30363d",
+      "--tag-bg": "#0d2240", "--tag-text": "#58a6ff",
+      "--platform-claude": "#f0883e", "--platform-claudeapp": "#f59e0b", "--platform-agy": "#58a6ff", "--platform-antigravity": "#bc8cff",
+      "--compare-without-bg": "#3b1219", "--compare-without-border": "#f85149",
+      "--compare-with-bg": "#0f5323", "--compare-with-border": "#3fb950",
+      "--shadow-sm": "0 1px 2px rgba(0,0,0,.3)", "--shadow-md": "0 4px 14px rgba(0,0,0,.3)",
+    }),
+  },
+};
+
+// Backward-compatible aliases added to every theme
+const ALIASES = {
+  "--accent2": "var(--accent-green)",
+  "--accent3": "var(--accent-amber)",
+  "--accent4": "var(--accent-purple)",
+  "--accent5": "var(--accent-red)",
+  "--accent6": "var(--accent-dark)",
 };
 
 function generateCss(theme: ThemePalette): string {
   let css = `/* handbook-variables.css — ${theme.name} theme */\n`;
+  css += `/* ${theme.desc} */\n`;
   css += `/* Auto-generated by apply-handbook-theme.ts */\n`;
   css += `/* Structural rules live in handbook-components.css (never overwritten) */\n\n`;
 
@@ -331,9 +361,9 @@ function generateCss(theme: ThemePalette): string {
     css += `  ${key}: ${value};\n`;
   }
   css += `  /* Backward-compatible aliases */\n`;
-  css += `  --accent2: var(--accent-green);\n`;
-  css += `  --accent4: var(--accent-purple);\n`;
-  css += `  --accent6: var(--accent-dark);\n`;
+  for (const [key, value] of Object.entries(ALIASES)) {
+    css += `  ${key}: ${value};\n`;
+  }
   css += `}\n\n`;
 
   // Dark mode auto-detect
@@ -342,9 +372,9 @@ function generateCss(theme: ThemePalette): string {
   for (const [key, value] of Object.entries(theme.dark)) {
     css += `    ${key}: ${value};\n`;
   }
-  css += `    --accent2: var(--accent-green);\n`;
-  css += `    --accent4: var(--accent-purple);\n`;
-  css += `    --accent6: var(--accent-dark);\n`;
+  for (const [key, value] of Object.entries(ALIASES)) {
+    css += `    ${key}: ${value};\n`;
+  }
   css += `  }\n`;
   css += `}\n\n`;
 
@@ -353,9 +383,9 @@ function generateCss(theme: ThemePalette): string {
   for (const [key, value] of Object.entries(theme.dark)) {
     css += `  ${key}: ${value};\n`;
   }
-  css += `  --accent2: var(--accent-green);\n`;
-  css += `  --accent4: var(--accent-purple);\n`;
-  css += `  --accent6: var(--accent-dark);\n`;
+  for (const [key, value] of Object.entries(ALIASES)) {
+    css += `  ${key}: ${value};\n`;
+  }
   css += `}\n`;
 
   return css;
@@ -383,4 +413,4 @@ if (!existsSync(cssDir)) {
 }
 
 writeFileSync(cssPath, css, "utf-8");
-console.log(`Theme "${themeName}" applied to ${cssPath}`);
+console.log(`Theme "${themeName}" (${theme.desc}) applied to ${cssPath}`);

--- a/templates/co-deck/scripts/co-deck/tests/apply-handbook-theme.test.ts
+++ b/templates/co-deck/scripts/co-deck/tests/apply-handbook-theme.test.ts
@@ -82,7 +82,9 @@ describe("apply-handbook-theme.ts", () => {
     const css = readFileSync(join(tmpDir, "docs", "assets", "css", "handbook-variables.css"), "utf-8");
 
     expect(css).toContain("--accent2: var(--accent-green)");
+    expect(css).toContain("--accent3: var(--accent-amber)");
     expect(css).toContain("--accent4: var(--accent-purple)");
+    expect(css).toContain("--accent5: var(--accent-red)");
     expect(css).toContain("--accent6: var(--accent-dark)");
   });
 
@@ -102,11 +104,10 @@ describe("apply-handbook-theme.ts", () => {
     expect(css).not.toContain(".scenario-card");
     expect(css).not.toContain(".badge");
     expect(css).not.toContain("box-sizing: border-box");
-    expect(css).not.toContain("font-family:");
   });
 
-  test("all 5 built-in themes generate valid CSS", () => {
-    const themes = ["azure", "graphite", "teal", "amber", "indigo"];
+  test("all 6 built-in themes generate valid CSS", () => {
+    const themes = ["azure", "graphite", "teal", "amber", "indigo", "native"];
 
     for (const theme of themes) {
       execSync(`bun run ${SCRIPT} --project ${tmpDir} --theme ${theme}`, {
@@ -124,6 +125,52 @@ describe("apply-handbook-theme.ts", () => {
       // Clean up for next theme
       rmSync(join(tmpDir, "docs", "assets", "css", "handbook-variables.css"));
     }
+  });
+
+  test("includes expanded variable categories (platform, badge, compare, situation, video)", () => {
+    execSync(`bun run ${SCRIPT} --project ${tmpDir} --theme azure`, {
+      stdio: "pipe",
+    });
+
+    const css = readFileSync(join(tmpDir, "docs", "assets", "css", "handbook-variables.css"), "utf-8");
+
+    // Text inverse
+    expect(css).toContain("--text-inverse:");
+
+    // Platform colors
+    expect(css).toContain("--platform-claude:");
+    expect(css).toContain("--platform-claudeapp:");
+    expect(css).toContain("--platform-agy:");
+    expect(css).toContain("--platform-antigravity:");
+
+    // Badge palettes
+    expect(css).toContain("--badge-green-bg:");
+    expect(css).toContain("--badge-blue-fg:");
+    expect(css).toContain("--badge-purple-border:");
+    expect(css).toContain("--badge-red-bg:");
+
+    // Compare boxes
+    expect(css).toContain("--compare-without-bg:");
+    expect(css).toContain("--compare-with-bg:");
+
+    // Situation & video
+    expect(css).toContain("--bg-situation:");
+    expect(css).toContain("--border-situation:");
+    expect(css).toContain("--bg-video:");
+    expect(css).toContain("--border-video:");
+  });
+
+  test("native theme has source-project-specific callout colors", () => {
+    execSync(`bun run ${SCRIPT} --project ${tmpDir} --theme native`, {
+      stdio: "pipe",
+    });
+
+    const css = readFileSync(join(tmpDir, "docs", "assets", "css", "handbook-variables.css"), "utf-8");
+
+    // Native theme uses lighter callout backgrounds than Azure
+    expect(css).toContain("--bg-info: #f0f7ff");   // Azure uses #ddf4ff
+    expect(css).toContain("--bg-warn: #fff8f8");   // Azure uses #fff1c5
+    expect(css).toContain("--bg-success: #f0fff4"); // Azure uses #dafbe1
   });
 
   test("exits with error for unknown theme", () => {

--- a/templates/co-deck/skills/handbook/SKILL.md
+++ b/templates/co-deck/skills/handbook/SKILL.md
@@ -92,7 +92,7 @@ Dispatch `handbook-reviewer` agent to run:
 ### H-6: Apply Theme
 
 Theme is a **domain decision step** (not just an asset):
-1. Select theme from built-in options (azure, graphite, teal, amber, indigo)
+1. Select theme from built-in options (azure, graphite, teal, amber, indigo, native)
 2. Run `bun run apply-theme --theme <name>`
 3. Generate CSS with 3-layer dark mode
 4. Update `site-search.js` DOCS array

--- a/templates/co-deck/skills/handbook/assets/css/handbook-components.css
+++ b/templates/co-deck/skills/handbook/assets/css/handbook-components.css
@@ -20,11 +20,12 @@
      N. Compare & Version
      O. FAQ & Glossary
      P. Course Overview & Lecture Guide
-     Q. Checklist
-     R. Workflow
-     S. Search & Utilities
-     T. Responsive
-     U. Print
+     Q. Quiz
+     R. Checklist
+     S. Workflow
+     T. Search & Utilities
+     U. Responsive
+     V. Print
    ========================================================================== */
 
 /* ==========================================================================
@@ -85,6 +86,18 @@ nav .nav-section {
   color: var(--text-dim);
 }
 
+/* Sidebar nav group heading (practice/manual pages) */
+nav .nav-group {
+  margin-top: 16px;
+  padding: 8px 16px 4px;
+  font-size: 11px;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: .06em;
+  color: var(--accent);
+  border-bottom: 1px solid var(--border);
+}
+
 nav a {
   display: block;
   padding: 6px 16px;
@@ -120,8 +133,8 @@ h1 { font-size: 2.1rem; font-weight: 700; letter-spacing: -0.01em; margin-bottom
 .subtitle a:hover { text-decoration: underline; }
 
 .meta {
-  background: #f0f7ff;
-  border: 1px solid #a5d5f7;
+  background: var(--bg-info);
+  border: 1px solid var(--border-info);
   border-left: 4px solid var(--accent);
   border-radius: var(--radius-md);
   padding: 12px 18px;
@@ -142,7 +155,7 @@ h1 { font-size: 2.1rem; font-weight: 700; letter-spacing: -0.01em; margin-bottom
 .section-label .day {
   display: inline-block;
   background: var(--accent-dark);
-  color: #fff;
+  color: var(--text-inverse);
   padding: 2px 10px;
   border-radius: 12px;
   font-size: 11px;
@@ -193,8 +206,8 @@ h1 { font-size: 2.1rem; font-weight: 700; letter-spacing: -0.01em; margin-bottom
   vertical-align: middle;
 }
 .card .tag-ref  { background: var(--bg3); color: var(--text-dim); }
-.card .tag-ex   { background: var(--accent-purple); color: #fff; }
-.card .tag-ch   { background: var(--accent-dark); color: #fff; }
+.card .tag-ex   { background: var(--accent-purple); color: var(--text-inverse); }
+.card .tag-ch   { background: var(--accent-dark); color: var(--text-inverse); }
 .card .go       { color: var(--accent); font-weight: 600; font-size: 14px; }
 
 .group { margin-top: 36px; }
@@ -218,8 +231,8 @@ h1 { font-size: 2.1rem; font-weight: 700; letter-spacing: -0.01em; margin-bottom
 .source-line a { color: var(--accent); text-decoration: none; }
 
 .keypoints {
-  background: #f0f7ff;
-  border: 1px solid #a5d5f7;
+  background: var(--bg-info);
+  border: 1px solid var(--border-info);
   border-left: 4px solid var(--accent);
   border-radius: 8px;
   padding: 18px 22px;
@@ -255,6 +268,20 @@ h1 { font-size: 2.1rem; font-weight: 700; letter-spacing: -0.01em; margin-bottom
   border-radius: var(--radius-sm);
   font-size: 15px;
   margin: 18px 0;
+}
+
+/* Stage cards (capstone, phased sections) */
+.stage {
+  border: 1px solid var(--border);
+  border-radius: var(--radius-lg);
+  padding: 18px 22px;
+  margin: 20px 0;
+}
+.stage-title {
+  font-weight: 700;
+  font-size: 15px;
+  margin-bottom: 8px;
+  color: var(--accent-dark);
 }
 
 /* Headings */
@@ -365,8 +392,8 @@ pre.code-block {
   cursor: pointer;
   transition: background-color .15s, color .15s;
 }
-.copy-btn:hover { background: var(--accent); color: #fff; }
-.copy-btn.copied { background: var(--accent-green); color: #fff; }
+.copy-btn:hover { background: var(--accent); color: var(--text-inverse); }
+.copy-btn.copied { background: var(--accent-green); color: var(--text-inverse); }
 
 /* ==========================================================================
    G. Scenario Cards (Practice Pages)
@@ -422,20 +449,46 @@ pre.code-block {
   margin-bottom: 10px;
 }
 
-.platform-block.claude  { border-left: 3px solid #d97706; }
-.platform-block.claudeapp { border-left: 3px solid #f59e0b; }
-.platform-block.agy     { border-left: 3px solid #0550ae; }
-.platform-block.antigravity { border-left: 3px solid #6639ba; }
+.platform-block.claude  { border-left: 3px solid var(--platform-claude); }
+.platform-block.claudeapp { border-left: 3px solid var(--platform-claudeapp); }
+.platform-block.agy     { border-left: 3px solid var(--platform-agy); }
+.platform-block.antigravity { border-left: 3px solid var(--platform-antigravity); }
 
 .situation {
-  background: #fffbf0;
-  border: 1px solid #f2c97d;
+  background: var(--bg-situation);
+  border: 1px solid var(--border-situation);
   border-radius: var(--radius-md);
   padding: 16px 20px;
   margin: calc(var(--spacing-unit) * 3) 0;
   font-size: 14px;
 }
 .situation::before { content: "📋 "; }
+
+/* Variant practice area sections */
+.area-header {
+  font-weight: 600;
+  font-size: 14px;
+  padding: 10px 0;
+  border-bottom: 1px solid var(--border);
+  margin-bottom: 12px;
+}
+.area-icon {
+  font-size: 1.5rem;
+  margin-right: 8px;
+}
+.area-title {
+  font-weight: 700;
+  color: var(--accent-dark);
+}
+.area-title-existing {
+  font-weight: 700;
+  color: var(--accent-green);
+}
+.area-desc {
+  font-size: 14px;
+  color: var(--text-dim);
+  line-height: 1.7;
+}
 
 /* ==========================================================================
    H. Steps & Procedures
@@ -462,7 +515,7 @@ pre.code-block {
   width: 24px;
   height: 24px;
   background: var(--accent);
-  color: #fff;
+  color: var(--text-inverse);
   border-radius: 50%;
   display: flex;
   align-items: center;
@@ -491,6 +544,17 @@ pre.code-block {
   font-size: 12px;
   font-weight: 600;
   font-family: var(--font-mono);
+}
+
+/* Tool name and description spans (inline command reference) */
+.cmd-name {
+  font-family: var(--font-mono);
+  font-weight: 700;
+  font-size: 14px;
+}
+.cmd-desc {
+  font-size: 14px;
+  color: var(--text-dim);
 }
 
 .related-cmds { margin-top: 16px; font-size: 13px; color: var(--text-dim); }
@@ -575,25 +639,25 @@ pre.code-block {
 }
 
 /* Difficulty badges */
-.badge-g { background: #dafbe1; color: #1a7f37; border-color: #a2d9b1; }
-.badge-b { background: #ddf4ff; color: #0550ae; border-color: #a5d5f7; }
-.badge-p { background: #fbefff; color: #6639ba; border-color: #d2b3f7; }
+.badge-g { background: var(--badge-green-bg); color: var(--badge-green-fg); border-color: var(--badge-green-border); }
+.badge-b { background: var(--badge-blue-bg); color: var(--badge-blue-fg); border-color: var(--badge-blue-border); }
+.badge-p { background: var(--badge-purple-bg); color: var(--badge-purple-fg); border-color: var(--badge-purple-border); }
 
 /* Platform badges */
-.badge-claude  { background: #fff8e1; color: #92400e; border-color: #f5d88a; }
-.badge-claudeapp { background: #fff3e0; color: #e65100; border-color: #ffcc80; }
-.badge-agy     { background: #e3f2fd; color: #0d47a1; border-color: #90caf9; }
-.badge-antigravity { background: #f3e5f5; color: #6a1b9a; border-color: #ce93d8; }
+.badge-claude  { background: var(--badge-amber-bg); color: var(--badge-amber-fg); border-color: var(--badge-amber-border); }
+.badge-claudeapp { background: var(--badge-orange-bg); color: var(--badge-orange-fg); border-color: var(--badge-orange-border); }
+.badge-agy     { background: var(--badge-indigo-bg); color: var(--badge-indigo-fg); border-color: var(--badge-indigo-border); }
+.badge-antigravity { background: var(--badge-violet-bg); color: var(--badge-violet-fg); border-color: var(--badge-violet-border); }
 
 /* Tool-type badges */
 .badge-alias    { background: var(--bg3); color: var(--text-dim); }
-.badge-skill    { background: #dafbe1; color: #1a7f37; }
-.badge-workflow { background: #ddf4ff; color: #0550ae; }
-.badge-new      { background: #ffebe9; color: #cf222e; }
+.badge-skill    { background: var(--badge-green-bg); color: var(--badge-green-fg); }
+.badge-workflow { background: var(--badge-blue-bg); color: var(--badge-blue-fg); }
+.badge-new      { background: var(--badge-red-bg); color: var(--badge-red-fg); }
 
 /* Lecture guide badges */
-.badge-demo { background: #e3f2fd; color: #0d47a1; border-color: #90caf9; }
-.badge-do   { background: #e8f5e9; color: #2e7d32; border-color: #a5d6a7; }
+.badge-demo { background: var(--badge-indigo-bg); color: var(--badge-indigo-fg); border-color: var(--badge-indigo-border); }
+.badge-do   { background: var(--badge-lab-bg); color: var(--badge-lab-fg); border-color: var(--badge-lab-border); }
 
 /* Section badge (manual pages) */
 .section-badge {
@@ -603,7 +667,7 @@ pre.code-block {
   padding: 2px 10px;
   border-radius: 12px;
   background: var(--accent-dark);
-  color: #fff;
+  color: var(--text-inverse);
   margin-left: 8px;
   vertical-align: middle;
 }
@@ -676,8 +740,8 @@ pre.code-block {
   border-radius: var(--radius-lg);
   padding: 20px;
 }
-.compare-box.without { background: #fff8f8; border-color: #ffc1bc; }
-.compare-box.with    { background: #f0fff4; border-color: #a2d9b1; }
+.compare-box.without { background: var(--compare-without-bg); border-color: var(--compare-without-border); }
+.compare-box.with    { background: var(--compare-with-bg); border-color: var(--compare-with-border); }
 .compare-box .cb-title { font-weight: 700; font-size: 14px; margin-bottom: 10px; }
 .compare-box.without .cb-title { color: var(--accent-red); }
 .compare-box.with .cb-title    { color: var(--accent-green); }
@@ -715,7 +779,7 @@ pre.code-block {
 }
 .q:first-child { border-top: none; padding-top: 0; margin-top: 0; }
 
-.a { margin: 0 0 8px; font-size: 14px; line-height: 1.7; }
+.faq-answer { margin: 0 0 8px; font-size: 14px; line-height: 1.7; }
 
 .see { font-size: 13px; color: var(--text-dim); margin-top: 12px; }
 
@@ -723,6 +787,14 @@ pre.code-block {
 .jump a { margin-right: 6px; font-size: 13px; }
 
 .en { font-size: 13px; color: var(--text-dim); font-style: italic; }
+
+/* Language comparison grid (multilingual preview) */
+.lang-compare {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 16px;
+  margin: 20px 0;
+}
 
 /* ==========================================================================
    P. Course Overview & Lecture Guide
@@ -776,10 +848,17 @@ pre.code-block {
 .schedule-body { padding: 14px 18px; font-size: 14px; }
 .schedule-break { background: var(--bg3); text-align: center; font-size: 13px; color: var(--text-dim); padding: 10px; }
 
-.tag-lecture { background: var(--accent-dark); color: #fff; }
-.tag-lab     { background: var(--accent-green); color: #fff; }
-.tag-discuss { background: var(--accent-purple); color: #fff; }
-.tag-demo    { background: var(--accent-amber); color: #fff; }
+/* Schedule total row */
+.schedule-total {
+  font-weight: 700;
+  background: var(--bg3);
+  border-top: 2px solid var(--border);
+}
+
+.tag-lecture { background: var(--accent-dark); color: var(--text-inverse); }
+.tag-lab     { background: var(--accent-green); color: var(--text-inverse); }
+.tag-discuss { background: var(--accent-purple); color: var(--text-inverse); }
+.tag-demo    { background: var(--accent-amber); color: var(--text-inverse); }
 
 /* Note: these share .badge styling but as non-inline-block tags for schedule */
 .tag-lecture, .tag-lab, .tag-discuss, .tag-demo {
@@ -801,7 +880,24 @@ pre.code-block {
 .hl-title { font-weight: 700; font-size: 14px; margin-bottom: 8px; color: var(--accent-dark); }
 
 /* ==========================================================================
-   Q. Checklist
+   Q. Quiz
+   ========================================================================== */
+
+.quiz {
+  border: 1px solid var(--border);
+  border-radius: var(--radius-lg);
+  padding: 18px 22px;
+  margin: 20px 0;
+}
+.quiz-title {
+  font-weight: 700;
+  font-size: 15px;
+  margin-bottom: 10px;
+  color: var(--accent-dark);
+}
+
+/* ==========================================================================
+   R. Checklist
    ========================================================================== */
 
 .checklist { margin: 16px 0; }
@@ -810,10 +906,11 @@ pre.code-block {
 .chk-list { list-style: none; padding: 0; }
 .chk-list li { padding: 6px 0 6px 24px; position: relative; font-size: 14px; }
 .chk-list li::before { content: "☐"; position: absolute; left: 0; color: var(--accent); }
+.chk-list li.sub { margin-left: 24px; font-size: 14px; }
 .chk { /* checkmark for completed items */ }
 
 /* ==========================================================================
-   R. Workflow
+   S. Workflow
    ========================================================================== */
 
 .wf-card {
@@ -829,7 +926,7 @@ pre.code-block {
 .wf-gate {
   display: inline-block;
   background: var(--accent);
-  color: #fff;
+  color: var(--text-inverse);
   padding: 3px 10px;
   border-radius: 12px;
   font-size: 12px;
@@ -850,7 +947,7 @@ pre.code-block {
 .variant-name { font-weight: 600; font-size: 14px; }
 
 /* ==========================================================================
-   S. Search & Utilities
+   T. Search & Utilities
    ========================================================================== */
 
 /* Site-wide search bar */
@@ -887,7 +984,7 @@ pre.code-block {
 
 /* In-page search highlight */
 .inpage-search-highlight { background: var(--accent); color: var(--bg); border-radius: 2px; padding: 0 2px; }
-.inpage-search-highlight.active { background: var(--accent2); outline: 2px solid var(--accent4); outline-offset: 1px; }
+.inpage-search-highlight.active { background: var(--accent-green); outline: 2px solid var(--accent-purple); outline-offset: 1px; }
 
 .inpage-search-bar {
   position: fixed; top: calc(var(--spacing-unit) * 2); right: calc(var(--spacing-unit) * 2);
@@ -936,17 +1033,27 @@ pre.code-block {
 .lang-switcher select:focus { outline: none; border-color: var(--accent); }
 
 /* Video references */
-.video-refs { margin: 28px 0; padding: 16px 20px; background: #f0f6ff; border: 1px solid #d0e8ff; border-radius: 8px; }
+.video-refs { margin: 28px 0; padding: 16px 20px; background: var(--bg-video); border: 1px solid var(--border-video); border-radius: 8px; }
 .video-refs h3 { font-size: 15px; font-weight: 700; color: var(--accent-dark); margin: 0 0 12px; }
 .video-refs ul { list-style: none; padding: 0; margin: 0; }
 .video-refs li { padding: 6px 0; line-height: 1.6; }
-.video-badge { display: inline-block; font-size: 11px; font-weight: 700; padding: 1px 6px; border-radius: 3px; color: #fff; vertical-align: middle; margin-right: 6px; }
+.video-badge { display: inline-block; font-size: 11px; font-weight: 700; padding: 1px 6px; border-radius: 3px; color: var(--text-inverse); vertical-align: middle; margin-right: 6px; }
 .video-badge.en { background: var(--accent); }
 .video-badge.ko { background: var(--accent-green); }
 .video-meta { font-size: 12px; color: var(--text-dim); }
 
+/* Preview banner (multilingual preview page) */
+.preview-banner {
+  background: var(--bg-warn);
+  border: 1px solid var(--border-warn);
+  border-radius: var(--radius-sm);
+  padding: 12px 18px;
+  font-size: 13px;
+  text-align: center;
+}
+
 /* ==========================================================================
-   T. Responsive
+   U. Responsive
    ========================================================================== */
 
 @media (max-width: 640px) {
@@ -958,7 +1065,7 @@ pre.code-block {
 }
 
 /* ==========================================================================
-   U. Print
+   V. Print
    ========================================================================== */
 
 @media print {

--- a/templates/co-deck/skills/handbook/assets/css/handbook-variables.css
+++ b/templates/co-deck/skills/handbook/assets/css/handbook-variables.css
@@ -22,6 +22,7 @@
   /* Text */
   --text:       #1f2328;
   --text-dim:   #636c76;
+  --text-inverse: #fff;
 
   /* Accent palette (GitHub Primer) */
   --accent:     #0969da;    /* Primary — blue */
@@ -33,7 +34,9 @@
 
   /* Backward-compatible aliases (deprecated — use semantic names) */
   --accent2: var(--accent-green);
+  --accent3: var(--accent-amber);
   --accent4: var(--accent-purple);
+  --accent5: var(--accent-red);
   --accent6: var(--accent-dark);
 
   /* Semantic callout backgrounds */
@@ -42,6 +45,8 @@
   --bg-warn:      #fff1c5;
   --bg-success:   #dafbe1;
   --bg-error:     #ffebe9;
+  --bg-situation: #fffbf0;
+  --bg-video:     #f0f6ff;
 
   /* Semantic callout borders */
   --border-info:    #0969da;
@@ -49,6 +54,8 @@
   --border-warn:    #9a6700;
   --border-success: #1a7f37;
   --border-error:   #cf222e;
+  --border-situation: #f2c97d;
+  --border-video:     #d0e8ff;
 
   /* Code */
   --code-bg:      #f6f8fa;
@@ -57,6 +64,27 @@
   /* Tags / Chips */
   --tag-bg:       #ddf4ff;
   --tag-text:     #0550ae;
+
+  /* Platform colors */
+  --platform-claude: #d97706;
+  --platform-claudeapp: #f59e0b;
+  --platform-agy: #0550ae;
+  --platform-antigravity: #6639ba;
+
+  /* Badge palettes */
+  --badge-green-bg: #dafbe1;  --badge-green-fg: #1a7f37;  --badge-green-border: #a2d9b1;
+  --badge-blue-bg: #ddf4ff;   --badge-blue-fg: #0550ae;   --badge-blue-border: #a5d5f7;
+  --badge-purple-bg: #fbefff; --badge-purple-fg: #6639ba;  --badge-purple-border: #d2b3f7;
+  --badge-amber-bg: #fff8e1;  --badge-amber-fg: #92400e;  --badge-amber-border: #f5d88a;
+  --badge-orange-bg: #fff3e0; --badge-orange-fg: #e65100; --badge-orange-border: #ffcc80;
+  --badge-indigo-bg: #e3f2fd; --badge-indigo-fg: #0d47a1; --badge-indigo-border: #90caf9;
+  --badge-violet-bg: #f3e5f5; --badge-violet-fg: #6a1b9a; --badge-violet-border: #ce93d8;
+  --badge-red-bg: #ffebe9;    --badge-red-fg: #cf222e;
+  --badge-lab-bg: #e8f5e9;   --badge-lab-fg: #2e7d32;    --badge-lab-border: #a5d6a7;
+
+  /* Compare box */
+  --compare-without-bg: #fff8f8;  --compare-without-border: #ffc1bc;
+  --compare-with-bg: #f0fff4;     --compare-with-border: #a2d9b1;
 
   /* Shadows */
   --shadow-sm:    0 1px 2px rgba(0,0,0,.06);
@@ -92,6 +120,7 @@
 
     --text:       #e6edf3;
     --text-dim:   #8b949e;
+    --text-inverse: #fff;
 
     --accent:       #58a6ff;
     --accent-green:  #3fb950;
@@ -105,18 +134,40 @@
     --bg-warn:      #3b2000;
     --bg-success:   #0f5323;
     --bg-error:     #490202;
+    --bg-situation: #3b2e00;
+    --bg-video:     #0d2240;
 
     --border-info:    #58a6ff;
     --border-note:    #d29922;
     --border-warn:    #d29922;
     --border-success: #3fb950;
     --border-error:   #f85149;
+    --border-situation: #d29922;
+    --border-video:     #58a6ff;
 
     --code-bg:      #161b22;
     --code-border:  #30363d;
 
     --tag-bg:       #0d2240;
     --tag-text:     #58a6ff;
+
+    --platform-claude: #f0883e;
+    --platform-claudeapp: #f59e0b;
+    --platform-agy: #58a6ff;
+    --platform-antigravity: #bc8cff;
+
+    --badge-green-bg: #0f5323;  --badge-green-fg: #3fb950;  --badge-green-border: #238636;
+    --badge-blue-bg: #0d2240;   --badge-blue-fg: #58a6ff;   --badge-blue-border: #388bfd;
+    --badge-purple-bg: #2d1539; --badge-purple-fg: #bc8cff;  --badge-purple-border: #8b949e;
+    --badge-amber-bg: #3b2000;  --badge-amber-fg: #d29922;  --badge-amber-border: #8b6914;
+    --badge-orange-bg: #3b2000; --badge-orange-fg: #f0883e; --badge-orange-border: #8b6914;
+    --badge-indigo-bg: #0d2240; --badge-indigo-fg: #58a6ff; --badge-indigo-border: #388bfd;
+    --badge-violet-bg: #2d1539; --badge-violet-fg: #bc8cff; --badge-violet-border: #8b949e;
+    --badge-red-bg: #490202;    --badge-red-fg: #f85149;
+    --badge-lab-bg: #0f5323;   --badge-lab-fg: #3fb950;    --badge-lab-border: #238636;
+
+    --compare-without-bg: #3b1219;  --compare-without-border: #f85149;
+    --compare-with-bg: #0f5323;     --compare-with-border: #3fb950;
 
     --shadow-sm:    0 1px 2px rgba(0,0,0,.3);
     --shadow-md:    0 4px 14px rgba(0,0,0,.3);
@@ -133,6 +184,7 @@
 
   --text:       #e6edf3;
   --text-dim:   #8b949e;
+  --text-inverse: #fff;
 
   --accent:       #58a6ff;
   --accent-green:  #3fb950;
@@ -146,18 +198,40 @@
   --bg-warn:      #3b2000;
   --bg-success:   #0f5323;
   --bg-error:     #490202;
+  --bg-situation: #3b2e00;
+  --bg-video:     #0d2240;
 
   --border-info:    #58a6ff;
   --border-note:    #d29922;
   --border-warn:    #d29922;
   --border-success: #3fb950;
   --border-error:   #f85149;
+  --border-situation: #d29922;
+  --border-video:     #58a6ff;
 
   --code-bg:      #161b22;
   --code-border:  #30363d;
 
   --tag-bg:       #0d2240;
   --tag-text:     #58a6ff;
+
+  --platform-claude: #f0883e;
+  --platform-claudeapp: #f59e0b;
+  --platform-agy: #58a6ff;
+  --platform-antigravity: #bc8cff;
+
+  --badge-green-bg: #0f5323;  --badge-green-fg: #3fb950;  --badge-green-border: #238636;
+  --badge-blue-bg: #0d2240;   --badge-blue-fg: #58a6ff;   --badge-blue-border: #388bfd;
+  --badge-purple-bg: #2d1539; --badge-purple-fg: #bc8cff;  --badge-purple-border: #8b949e;
+  --badge-amber-bg: #3b2000;  --badge-amber-fg: #d29922;  --badge-amber-border: #8b6914;
+  --badge-orange-bg: #3b2000; --badge-orange-fg: #f0883e; --badge-orange-border: #8b6914;
+  --badge-indigo-bg: #0d2240; --badge-indigo-fg: #58a6ff; --badge-indigo-border: #388bfd;
+  --badge-violet-bg: #2d1539; --badge-violet-fg: #bc8cff; --badge-violet-border: #8b949e;
+  --badge-red-bg: #490202;    --badge-red-fg: #f85149;
+  --badge-lab-bg: #0f5323;   --badge-lab-fg: #3fb950;    --badge-lab-border: #238636;
+
+  --compare-without-bg: #3b1219;  --compare-without-border: #f85149;
+  --compare-with-bg: #0f5323;     --compare-with-border: #3fb950;
 
   --shadow-sm:    0 1px 2px rgba(0,0,0,.3);
   --shadow-md:    0 4px 14px rgba(0,0,0,.3);

--- a/templates/co-deck/skills/handbook/references/AUTHORING_GUIDELINES.md
+++ b/templates/co-deck/skills/handbook/references/AUTHORING_GUIDELINES.md
@@ -673,23 +673,49 @@ structural rules live in `assets/css/handbook-components.css` (never overwritten
 
 ```css
 :root {
+  /* Backgrounds & text */
   --bg: #ffffff;       --bg2: #f6f8fa;     --bg3: #eef1f4;
   --border: #d0d7de;   --text: #1f2328;    --text-dim: #636c76;
+  --text-inverse: #fff;
+
+  /* Accent palette */
   --accent: #0969da;
   --accent-green: #1a7f37;  --accent-purple: #6639ba;
   --accent-dark: #0550ae;   --accent-amber: #953800;   --accent-red: #cf222e;
+
+  /* Semantic callout backgrounds & borders */
   --bg-info: #ddf4ff;  --bg-note: #fff8c5;  --bg-warn: #fff1c5;
   --bg-success: #dafbe1; --bg-error: #ffebe9;
   --border-info: #0969da; --border-note: #9a6700;
   --border-warn: #9a6700; --border-success: #1a7f37; --border-error: #cf222e;
+
+  /* Code blocks & tags */
   --code-bg: #f6f8fa;  --code-border: #d0d7de;
   --tag-bg: #ddf4ff;   --tag-text: #0550ae;
+
+  /* Platform colors (Claude, Claude App, AGY, Antigravity) */
+  --platform-claude: #d97706;   --platform-claudeapp: #f59e0b;
+  --platform-agy: #0550ae;      --platform-antigravity: #6639ba;
+
+  /* Badge palettes (bg/fg/border per color) */
+  --badge-green-bg/fg/border;   --badge-blue-bg/fg/border;
+  --badge-purple-bg/fg/border;  --badge-amber-bg/fg/border;
+  --badge-orange-bg/fg/border;  --badge-indigo-bg/fg/border;
+  --badge-violet-bg/fg/border;  --badge-red-bg/fg;
+  --badge-lab-bg/fg/border;
+
+  /* Compare boxes & situation/video */
+  --compare-without-bg/border;  --compare-with-bg/border;
+  --bg-situation;  --border-situation;
+  --bg-video;      --border-video;
 }
 ```
 
 **Backward-compatible aliases** (legacy files still work):
 - `--accent2` → `var(--accent-green)`
+- `--accent3` → `var(--accent-amber)`
 - `--accent4` → `var(--accent-purple)`
+- `--accent5` → `var(--accent-red)`
 - `--accent6` → `var(--accent-dark)`
 
 ### 22-3. Prohibitions

--- a/templates/co-deck/skills/handbook/references/BUILD_GUIDE.md
+++ b/templates/co-deck/skills/handbook/references/BUILD_GUIDE.md
@@ -159,7 +159,7 @@ bun run validate-nav --docs-dir docs
 **Theme is a domain decision step**, not just an asset operation.
 
 ### Step 1: Select Theme
-Choose from built-in themes: **azure**, **graphite**, **teal**, **amber**, **indigo**.
+Choose from built-in themes: **azure**, **graphite**, **teal**, **amber**, **indigo**, **native**.
 
 ### Step 2: Apply Theme
 ```bash


### PR DESCRIPTION
[claude pr-body] Attempt 1/2
[claude pr-body]  Success on attempt 1
## Why
feat(handbook): expand CSS variable system with Native theme, orphan class rules, and 33 hardcoded hex replacements

## What Changed
- docs/VERSION_MANIFEST.md
- memory/2026-07-17.md
- templates/co-deck/scripts/co-deck/handbook/apply-handbook-theme.ts
- templates/co-deck/scripts/co-deck/tests/apply-handbook-theme.test.ts
- templates/co-deck/skills/handbook/SKILL.md
- templates/co-deck/skills/handbook/assets/css/handbook-components.css
- templates/co-deck/skills/handbook/assets/css/handbook-variables.css
- templates/co-deck/skills/handbook/references/AUTHORING_GUIDELINES.md
- templates/co-deck/skills/handbook/references/BUILD_GUIDE.md

## Test Plan
- [ ] `bun scripts/audit.ts` passes
- [ ] CHANGELOG.md updated under `[Unreleased]`

## Security Checklist
- [ ] No secrets, credentials, or API keys committed
- [ ] No `.env` files staged (use `.env.sample` for templates)
- [ ] Dependencies unchanged or reviewed for new CVEs

## Notes
None

---