### PR TITLE
docs(readme): update multi-language READMEs with handbook learning resources section

### DIFF
--- a/README.md
+++ b/README.md
@@ -291,6 +291,18 @@ Checks: agent frontmatter completeness, required sections (`## Meeting Participa
 
 ---
 
+## 📚 Learning Resources
+
+A comprehensive educational handbook is available for practitioners looking to master the multi-agent workflow of this workspace:
+
+**[Multi-Agent Harness Engineering Handbook](https://5throck.github.io/multi-agent-harness-handbook/)**
+
+This handbook is a 2-day intensive curriculum covering:
+- **Day 1 — General Users**: Core AI concepts, Vibe Coding vs. Harness Engineering principles, guardrails, permission models, and basic multi-agent operations.
+- **Day 2 — IT Professionals**: Deep-dive architecture (SSOT hierarchy L0→L1→L2), enterprise deployment strategies, custom variant engineering (Phase A/B), and comprehensive capstone projects.
+
+All concepts are demonstrated across four major platforms (Claude Code, Claude App, Antigravity CLI, and Antigravity 2.0).
+
 ---
 
 ## Contributing

--- a/README_es.md
+++ b/README_es.md
@@ -289,6 +289,18 @@ Verifica: completitud del frontmatter del agente, secciones requeridas (`## Meet
 
 ---
 
+## 📚 Recursos de Aprendizaje (Learning Resources)
+
+Un manual educativo completo está disponible para los profesionales que deseen dominar el flujo de trabajo multi-agente de este espacio de trabajo:
+
+**[Manual de Multi-Agent Harness Engineering](https://5throck.github.io/multi-agent-harness-handbook/)**
+
+Este manual es un programa intensivo de 2 días que cubre:
+- **Día 1 — Usuarios Generales**: Conceptos fundamentales de IA, principios de Vibe Coding vs. Harness Engineering, salvaguardas, modelos de permisos y operaciones básicas multi-agente.
+- **Día 2 — Profesionales de TI**: Arquitectura detallada (jerarquía SSOT L0→L1→L2), estrategias de despliegue empresarial, ingeniería de variantes personalizadas (Fase A/B) y proyectos finales integrales.
+
+Todos los conceptos se demuestran en cuatro plataformas principales (Claude Code, Claude App, Antigravity CLI y Antigravity 2.0).
+
 ---
 
 ## Contribuciones

--- a/README_ja.md
+++ b/README_ja.md
@@ -3,6 +3,10 @@ translated_from_hash: PLACEHOLDER
 sync_version: 1
 ---
 
+**言語**: [English](README.md) · [한국어](README_ko.md) · [Español](README_es.md) · [日本語](README_ja.md)
+
+---
+
 # AI ワークスペース標準 (AI Workspace Standards)
 
 > **すべてのAIコーディングツールにおけるVibe CodingおよびHarness Engineeringのマスター設定。**

--- a/README_ko.md
+++ b/README_ko.md
@@ -289,6 +289,20 @@ bun scripts/validate-templates.ts
 
 ---
 
+## 📚 학습 리소스 (Learning Resources)
+
+본 워크스페이스의 멀티 에이전트 워크플로를 습득하려는 실무자를 위한 종합 교육 핸드북이 제공됩니다:
+
+**[Multi-Agent Harness Engineering 핸드북](https://5throck.github.io/multi-agent-harness-handbook/)**
+
+이 핸드북은 2일간의 집중 커리큘럼으로 구성되어 있습니다:
+- **Day 1 — 일반 사용자**: 핵심 AI 개념, Vibe Coding vs. Harness Engineering 원칙, 가드레일, 권한 모델, 기본적인 멀티 에이전트 조작
+- **Day 2 — IT 전문가**: 아키텍처 심층 해설 (SSOT 계층 L0→L1→L2), 엔터프라이즈 배포 전략, 커스텀 바리안트 엔지니어링 (Phase A/B), 종합 실습 프로젝트
+
+모든 개념은 4가지 주요 플랫폼 (Claude Code, Claude App, Antigravity CLI, Antigravity 2.0)에서 시연됩니다.
+
+---
+
 ## 기여하기 (Contributing)
 
 이 저장소는 **공개 저장소(Public Repository)**입니다. 누구나 Pull Request를 통해 기여할 수 있습니다.

--- a/docs/VERSION_MANIFEST.md
+++ b/docs/VERSION_MANIFEST.md
@@ -1,6 +1,6 @@
 # VERSION_MANIFEST.md
 
-**Generated**: 2026-07-30T05:02:26.788Z
+**Generated**: 2026-07-30T05:38:13.158Z
 **Manifest Version**: 1.0
 **Location**: docs\VERSION_MANIFEST.md
 

--- a/memory/2026-07-30.md
+++ b/memory/2026-07-30.md
@@ -50,3 +50,20 @@ docs(readme): add handbook learning resources section to multi-language READMEs
 
 ## Open Issues
 - None
+
+---
+
+## Session Summary
+docs(readme): update multi-language READMEs with handbook learning resources section
+
+## Changes
+- `M README.md` — modified
+- `README_es.md` — modified
+- `README_ja.md` — modified
+- `README_ko.md` — modified
+
+## Decisions
+- None
+
+## Open Issues
+- None


### PR DESCRIPTION
[claude pr-body] Attempt 1/2
[claude pr-body] Waiting 1000ms before retry...
[claude pr-body] Attempt 2/2
## Why
docs(readme): update multi-language READMEs with handbook learning resources section

## What Changed
- README.md
- README_es.md
- README_ja.md
- README_ko.md
- docs/VERSION_MANIFEST.md
- memory/2026-07-30.md

## Test Plan
- [ ] `bun scripts/audit.ts` passes
- [ ] CHANGELOG.md updated under `[Unreleased]`

## Security Checklist
- [ ] No secrets, credentials, or API keys committed
- [ ] No `.env` files staged (use `.env.sample` for templates)
- [ ] Dependencies unchanged or reviewed for new CVEs

## Notes
None

---