### PR TITLE
chore: update

### DIFF
--- a/docs/VERSION_MANIFEST.md
+++ b/docs/VERSION_MANIFEST.md
@@ -1,6 +1,6 @@
 # VERSION_MANIFEST.md
 
-**Generated**: 2026-07-30T05:38:13.158Z
+**Generated**: 2026-07-30T23:06:33.535Z
 **Manifest Version**: 1.0
 **Location**: docs\VERSION_MANIFEST.md
 

--- a/docs/VERSION_MANIFEST.md
+++ b/docs/VERSION_MANIFEST.md
@@ -1,6 +1,6 @@
 # VERSION_MANIFEST.md
 
-**Generated**: 2026-07-30T23:06:33.535Z
+**Generated**: 2026-07-30T23:16:41.630Z
 **Manifest Version**: 1.0
 **Location**: docs\VERSION_MANIFEST.md
 

--- a/memory/2026-07-31.md
+++ b/memory/2026-07-31.md
@@ -1,0 +1,28 @@
+## Session Summary
+chore: update
+
+## Changes
+- `M templates/co-deck/skills/handbook/references/AUTHORING_GUIDELINES.md` — modified
+
+## Decisions
+- None
+
+## Open Issues
+- None
+
+---
+
+## Session Summary
+chore: update
+
+## Changes
+- `M docs/VERSION_MANIFEST.md` — modified
+- `memory/MEMORY.md` — modified
+- `templates/co-deck/skills/handbook/references/AUTHORING_GUIDELINES.md` — modified
+- `memory/2026-07-31.md` — modified
+
+## Decisions
+- None
+
+## Open Issues
+- None

--- a/memory/2026-07-31.md
+++ b/memory/2026-07-31.md
@@ -26,3 +26,25 @@ chore: update
 
 ## Open Issues
 - None
+
+---
+
+## Session Summary
+refactor(co-deck): deduplicate handbook references — merge §24 into §20, replace inline tables with AUTHORING_GUIDELINES.md cross-references
+
+## Changes
+- `M templates/co-deck/agents/handbook-reviewer.md` — modified
+- `templates/co-deck/agents/handbook-writer.md` — modified
+- `templates/co-deck/scripts/co-deck/handbook/check-authoring.ts` — modified
+- `templates/co-deck/scripts/co-deck/handbook/handbook-doctor.ts` — modified
+- `templates/co-deck/skills/handbook/SKILL.md` — modified
+- `templates/co-deck/skills/handbook/references/AUTHORING_GUIDELINES.md` — modified
+- `templates/co-deck/skills/handbook/references/BUILD_GUIDE.md` — modified
+- `templates/co-deck/skills/handbook/references/QUALITY_CHECKLIST.md` — modified
+- `templates/co-deck/skills/handbook/references/SECTION_TYPES.md` — modified
+
+## Decisions
+- None
+
+## Open Issues
+- None

--- a/memory/MEMORY.md
+++ b/memory/MEMORY.md
@@ -4,6 +4,7 @@
 
 | Date | Summary |
 |------|---------|
+| [2026-07-31](2026-07-31.md) | chore: update |
 | [2026-07-30](2026-07-30.md) | chore: update |
 | [2026-07-22](2026-07-22.md) | fix(templates/co-deck): fix broken lifecycle-doc reference in docs/context.md and add missing html-to-pdf.ts script copy |
 | [2026-07-21](2026-07-21.md) | fix(templates): sync pitch theme migration and preview fixes |

--- a/templates/co-deck/agents/handbook-reviewer.md
+++ b/templates/co-deck/agents/handbook-reviewer.md
@@ -56,8 +56,8 @@ This ensures all work flows through the proper H-Stage workflow with quality gat
 
 | Tool | Checks | Source |
 |------|--------|--------|
-| handbook-doctor | 12 (nav, links, dark palette, lang pair, visual, course overview, instructor guide, unused assets, duplicate IDs, hardcoded colors, empty title/h1) | §21, §22, §23, §24 |
-| check-authoring | 10 (visual element, copy buttons, sidebar nav, chapter-nav, min-width, mid-word strong, course overview, CSS variables, language pairs, instructor guide) | §2, §10, §11, §14, §22, §23, §24 |
+| handbook-doctor | 12 (nav, links, dark palette, lang pair, visual, course overview, instructor guide, unused assets, duplicate IDs, hardcoded colors, empty title/h1) | §21, §22, §23, §20 |
+| check-authoring | 10 (visual element, copy buttons, sidebar nav, chapter-nav, min-width, mid-word strong, course overview, CSS variables, language pairs, instructor guide) | §2, §10, §11, §14, §22, §23, §20 |
 | validate-nav | 4 (broken links, prev/next symmetry, label match, search DOCS sync) | §21-4 |
 
 ## Output Format

--- a/templates/co-deck/agents/handbook-writer.md
+++ b/templates/co-deck/agents/handbook-writer.md
@@ -53,7 +53,7 @@ This ensures all work flows through the proper H-Stage workflow with quality gat
 
 ### H-3: Write Content
 - Write chapter HTML files following the approved structure
-- Follow AUTHORING_GUIDELINES.md all 21 sections + §22 (Dark Mode) + §23 (Multi-Language) + §24 (Instructor Guide)
+- Follow AUTHORING_GUIDELINES.md all 21 sections + §22 (Dark Mode) + §23 (Multi-Language) + §20 (Lecture/Instructor Guide Structure)
 - Include visual elements per §10 (at least 1 per section)
 - Use CSS variables for all colors (§22)
 - Include sidebar nav and chapter-nav (§21)
@@ -61,7 +61,7 @@ This ensures all work flows through the proper H-Stage workflow with quality gat
 
 ### H-4: Generate Course Materials
 - Write `course-overview.html` with 9 required items per §14
-- Write `instructor-guide.html` with required sections per §20/§24
+- Write `instructor-guide.html` with required sections per §20
 - Ensure course overview and instructor guide are internally consistent
 
 ## Output Format
@@ -70,7 +70,7 @@ This ensures all work flows through the proper H-Stage workflow with quality gat
 - `handbook/docs/chapters/chapter_XX_ko.html` — Korean language variant (optional)
 - `handbook/docs/chapters/chapter_XX_en.html` — English language variant (optional)
 - `handbook/docs/course-overview.html` — course introduction (§14)
-- `handbook/docs/instructor-guide.html` — instructor operations guide (§24)
+- `handbook/docs/instructor-guide.html` — instructor operations guide (§20)
 
 ## Constraints
 

--- a/templates/co-deck/scripts/co-deck/handbook/check-authoring.ts
+++ b/templates/co-deck/scripts/co-deck/handbook/check-authoring.ts
@@ -212,7 +212,7 @@ function checkLanguagePairs(htmlFiles: string[], baseDir: string): AuthoringIssu
   return issues;
 }
 
-/** Check 10: §24 — Instructor Guide completeness */
+/** Check 10: §20 — Instructor Guide completeness */
 function checkInstructorGuide(html: string, file: string): AuthoringIssue[] {
   const issues: AuthoringIssue[] = [];
   if (!/instructor-guide/.test(file)) return issues;
@@ -225,7 +225,7 @@ function checkInstructorGuide(html: string, file: string): AuthoringIssue[] {
   for (const section of requiredSections) {
     if (!html.includes(section)) {
       issues.push({
-        file, rule: "instructor-guide-section", section: "§24",
+        file, rule: "instructor-guide-section", section: "§20",
         detail: `Missing required section: "${section}"`,
         severity: "warn",
       });

--- a/templates/co-deck/scripts/co-deck/handbook/handbook-doctor.ts
+++ b/templates/co-deck/scripts/co-deck/handbook/handbook-doctor.ts
@@ -158,7 +158,7 @@ for (const file of htmlFiles) {
   }
 }
 if (!hasInstructorGuide) {
-  allIssues.push({ file: "docs/", check: "instructor-guide", detail: "No instructor-guide.html found (§24 requirement for course handbooks)", severity: "warn" });
+  allIssues.push({ file: "docs/", check: "instructor-guide", detail: "No instructor-guide.html found (§20 requirement for course handbooks)", severity: "warn" });
 }
 
 // --- Check 9: Unused assets ---

--- a/templates/co-deck/skills/handbook/SKILL.md
+++ b/templates/co-deck/skills/handbook/SKILL.md
@@ -79,7 +79,7 @@ Dispatch `handbook-writer` agent to write chapter content following AUTHORING_GU
 
 ### H-4: Generate Course Materials
 
-Dispatch `handbook-writer` agent to generate Course Overview (§14 — 9 required items) and Instructor Guide (§24 — lecture flow, expected questions, timing, frequent mistakes, demo order, evaluation criteria).
+Dispatch `handbook-writer` agent to generate Course Overview (§14 — 9 required items) and Instructor Guide (§20 — lecture flow, expected questions, timing, frequent mistakes, demo order, evaluation criteria).
 
 ### H-5: Quality Verification
 

--- a/templates/co-deck/skills/handbook/references/AUTHORING_GUIDELINES.md
+++ b/templates/co-deck/skills/handbook/references/AUTHORING_GUIDELINES.md
@@ -255,34 +255,53 @@ When placing a badge, title, and description side by side inside `.level-header`
 
 ### 12-1. Sentence Endings
 
-Use **plain form (`~다`/`~한다`/`~이다`)** uniformly across all body text, subheadings, and descriptions. Polite form (`~습니다`/`~해요`) is only permitted in UI button labels.
+Use the **formal plain register** for the document's language uniformly across all body text, subheadings, and descriptions. Polite register is only permitted in UI button labels and error messages (user-facing interaction elements).
 
-```
-✗ "이 핸드북은 다르게 구성되어 달라집니다."  (polite form)
-✓ "이 핸드북은 다르게 구성되어 달라진다."     (plain form)
-```
+| Language | Body text style | Disallowed style | Notes |
+|----------|----------------|-------------------|-------|
+| Korean | Plain form ("haera-che": `~da`/`~handa`/`~ida`) | Polite form (`~seumnida`/`~haeyo`) | Maintain didactic tone |
+| Japanese | `da/dearu` form (plain form) | `desu/masu` form (polite form) | Academic style |
+| English | Declarative (no contractions in prose) | Informal/casual | Academic technical prose |
+| Spanish | Registro neutro/formal (usted) | Registro informal (tuteo/voseo) | Academic tone |
+
+Each edition applies the register rules for its own language. See the Korean-language source (`AUTHORING_GUIDELINES.md` in the handbook repository) for language-specific examples.
 
 ### 12-2. English Technical Term Notation
 
-When using English technical terms in body text, add a **Korean (English) parenthetical gloss only on first appearance within the document**. On subsequent appearances within the same document, use the English term alone. Code, filenames, and CLI identifiers are marked with `<code>` tags; conceptual terms distinct from code use parenthetical glosses.
+When using English technical terms in body text, add a **parenthetical gloss only on first appearance within the document**, formatted as `local_term(English)` for non-English editions. On subsequent appearances within the same document, use the English term alone. Code, filenames, and CLI identifiers are marked with `<code>` tags; conceptual terms distinct from code use parenthetical glosses.
+
+| Language | First-appearance gloss format | Example |
+|----------|-------------------------------|---------|
+| Korean | Korean(English) | e.g., `hookeul(hook)` |
+| Japanese | Japanese(English) | e.g., `fukku(hook)` |
+| English | *(no parenthetical — English-only)* | `hook` |
+| Spanish | Spanish(English) *(if translated)* or English-only *(if untranslated)* | e.g., `enlace(hook)` / `hook` |
+
+Note: The English edition requires no parenthetical glosses since English is the source language. For Spanish, conventionally-translated terms (hook→enlace, branch→rama) receive glosses; non-conventionalized terms remain English-only.
 
 ```
-✗ "hook은 셸 명령 실행 전후에 호출된다."                     (first appearance with English only — no gloss)
-✗ "<code>hook</code>은 셸 명령 실행 전후에 호출된다."          (replaced with code tag — conceptual term styled as code)
-✓ "훅(hook)은 셸 명령 실행 전후에 호출된다. ... 이후 문단에서
-   hook이 실패하면 커밋이 중단된다."                          (gloss only on first appearance, English alone after)
-✗ "... 이후 문단에서 훅(hook)이 실패하면 ..."                 (continued glossing from second appearance onward — unnecessary repetition)
+KO example (glossed correctly on first appearance, English alone after):
+  [OK] "hookeul(hook) is called before and after shell command execution. ... In subsequent paragraphs,
+        hook failure halts the commit."
+  [NO]  "hook is called ..."  (first appearance without gloss)
+  [NO]  "<code>hook</code> is called ..."  (conceptual term styled as code)
+  [NO]  "... hookeul(hook) is called ..."  (continued glossing from second appearance onward)
+
+EN edition: no glosses needed — "hook" appears as-is throughout.
 ```
 
 This rule applies **per document (file)** — in a different document, the first appearance in that document becomes the new baseline (e.g., if a term was glossed in Chapter 4, it must be glossed again on first appearance in Chapter 8).
 
-**Headings are exempt.** Text serving as headings — such as `<title>`, `<h1>`, `chapter-eyebrow`, and nav chapter titles — uses **English words only** without parenthetical glosses (and no Korean-only labels either).
+**Headings are exempt.** Text serving as headings — such as `<title>`, `<h1>`, `chapter-eyebrow`, and nav chapter titles — uses **English words only** without parenthetical glosses (and no monolingual labels in other languages either). This applies to all language editions.
 
-```
-✗ <h1>신규 베리언트(variant) 만들기</h1>   (parenthetical gloss in heading)
-✗ <h1>신규 베리언트 만들기</h1>            (Korean-only label in heading)
-✓ <h1>신규 variant 만들기</h1>             (English only in heading)
-```
+| Language | Heading format | Example pattern |
+|----------|---------------|-----------------|
+| Korean | Korean structure words + English technical terms | `<h1>structure-words + variant</h1>` |
+| Japanese | Japanese structure words + English technical terms | `<h1>structure-words + variant</h1>` |
+| English | English only | `<h1>Creating a New Variant</h1>` |
+| Spanish | Spanish structure words + English technical terms | `<h1>structure-words + variant</h1>` |
+
+Common rule: No parenthetical glosses in headings. Only English technical terms appear in heading text, combined with local-language structure words (articles, prepositions, etc.).
 
 ### 12-3. Chapter/Section Reference Format
 
@@ -365,9 +384,9 @@ Use em-dashes **minimally**, only where supplementary explanation is unavoidable
 
 ## 16. Language Policy
 
-- Course body text, hands-on instructions, and UI copy are written in **the course's primary language** (e.g., Korean for Korean-language educational materials).
-- However, **code comments, identifiers, commit messages, PR titles/bodies, and branch names** are always in English.
-- File names follow English kebab/snake case conventions.
+- Course body text, hands-on instructions, and UI copy are written in **the course's primary language** (e.g., Korean for Korean-language educational materials). Each translated edition uses its own language (KO/JA/EN/ES respectively).
+- However, **code comments, identifiers, commit messages, PR titles/bodies, and branch names** are always in English across all language editions.
+- File names follow English kebab/snake case conventions (common to all language editions).
 
 ---
 
@@ -380,10 +399,15 @@ Use em-dashes **minimally**, only where supplementary explanation is unavoidable
 ### 17-1. Video Selection Criteria
 
 - **Official sources preferred**: Anthropic, Google DeepMind, DeepLearning.AI, and other official channels take priority.
-- **Language**: Search for videos in the course's primary language first; if unavailable, link English videos and indicate the language.
+- **Language**: In each translated edition, prioritize videos in that edition's language first (e.g., Korean videos for the KO edition, Japanese videos for the JA edition, Spanish videos for the ES edition). If no suitable video exists in the target language, include EN videos as common content. Use `video-badge` to indicate the language of each video.
 - **Length**: Prefer videos under 20 minutes. Provide timestamps for longer videos.
 - **Recency**: Prefer videos published within the last 2 years.
 - **Free access**: Only link videos published on platforms anyone can access (YouTube, etc.).
+- **Channel trustworthiness**: Use YouTube oEmbed API (`youtube.com/oembed`) to verify video existence and channel information. Trustworthiness criteria:
+  - **TRUSTWORTHY**: Official channels (Anthropic, Google, etc.), or channels with 10,000+ subscribers, or videos with 10,000+ views
+  - **QUESTIONABLE**: Does not meet subscriber/view thresholds but content is relevant — review and find alternative or remove
+  - **BROKEN**: oEmbed 404 response (deleted/private/invalid ID) — remove immediately
+  - Official channels (Anthropic, Google, etc.) are TRUSTWORTHY regardless of subscriber count
 
 ### 17-2. Video Link Placement
 
@@ -409,7 +433,7 @@ CSS:
   margin: 28px 0;
   padding: 16px 20px;
   background: var(--bg-info);
-  border: 1px solid var(--border);
+  border: 1px solid var(--border-info);
   border-radius: 8px;
 }
 .video-refs h3 {
@@ -426,12 +450,14 @@ CSS:
   font-weight: 700;
   padding: 1px 6px;
   border-radius: 3px;
-  color: #fff;
+  color: var(--text-inverse);
   vertical-align: middle;
   margin-right: 6px;
 }
-.video-badge.en { background: #0969da; }
-.video-badge.ko { background: #1a7f37; }
+.video-badge.en { background: var(--accent); }
+.video-badge.ko { background: var(--accent-green); }
+.video-badge.ja { background: var(--accent-red); }
+.video-badge.es { background: var(--accent-amber); }
 .video-meta { font-size: 12px; color: var(--text-dim); }
 ```
 
@@ -448,6 +474,78 @@ Below is an applied placement example. For new courses, judge using the same cri
 | Comparison chapter | Tool comparison, per-platform differences | Each platform's official channels |
 
 Verify video URLs at time of writing and reflect them. Do not force-add videos to sections where no official video exists.
+
+### 17-4. Video Trust Verification Procedure
+
+All videos included in the handbook should be periodically verified — or batch-verified when videos are added or modified in bulk. Verification proceeds in 5 stages.
+
+#### Stage 1: Existence Check (oEmbed)
+
+Query all videos against the YouTube oEmbed API to confirm public availability.
+
+```
+GET https://www.youtube.com/oembed?url=https://www.youtube.com/watch?v={VIDEO_ID}&format=json
+```
+
+| Response | Meaning | Action |
+|----------|---------|--------|
+| HTTP 200 + JSON body | Public video, metadata available | Proceed to Stage 2 |
+| HTTP 404 | Deleted / private / invalid ID | **BROKEN** verdict — remove immediately |
+
+Extract from the oEmbed response:
+- `title` — actual video title
+- `author_name` — channel name
+- `author_url` — channel URL (includes `@handle`)
+- `thumbnail_url` — thumbnail (for existence confirmation)
+
+#### Stage 2: Metadata Match Check
+
+Compare oEmbed metadata with handbook records.
+
+| Check field | Comparison target | Mismatch action |
+|-------------|-------------------|-----------------|
+| **Title** | oEmbed `title` vs HTML `<a>` text | Correct to oEmbed original title. If HTML contains a translated title, restore to the actual language's original title |
+| **Channel name** | oEmbed `author_name` vs source notation in the section | Correct to actual channel name if mismatched |
+| **Badge language** | `video-badge` class (en/ko/ja/es) vs video's actual language | Correct to proper language badge (e.g., English video with `ko` badge → change to `en`) |
+| **Typos** | Title and description spelling | Correct to proper spelling |
+
+> **Real example**: During a prior verification, 2 English videos were found with incorrect `video-badge ko` badges — corrected to `en`. Additionally, 3 Korean titles contained typos that were fixed.
+
+#### Stage 3: Content Relevance Check
+
+Verify that each video topic aligns with its section. Criteria:
+- Video topic must be directly related to the concept covered in the section
+- Tutorial videos must match the hands-on content and tools
+- Comparison videos must cover the tools/platforms compared in the handbook
+
+Non-matching videos receive **QUESTIONABLE** verdict.
+
+#### Stage 4: Channel Trustworthiness Evaluation
+
+Evaluate channels of videos that passed stages 1–3 using the following criteria.
+
+| Verdict | Criteria |
+|---------|----------|
+| **TRUSTWORTHY** | Meets one of: (a) official channel (Anthropic, Google, etc.), (b) 10,000+ subscribers, (c) 10,000+ views on the specific video |
+| **QUESTIONABLE** | Does not meet (a)–(c) but content is relevant |
+
+Subscriber/view counts can be verified via YouTube search results, channel pages, or third-party tools. Since YouTube pages require JavaScript rendering, oEmbed + web search results serve as supplementary verification methods.
+
+#### Stage 5: Action and Follow-up
+
+Take action based on verification results.
+
+| Result | Action |
+|--------|--------|
+| **BROKEN** | Delete the `<li>` item from the HTML |
+| **TRUSTWORTHY** | Keep (apply metadata fixes discovered in Stage 2) |
+| **QUESTIONABLE** | Search for a trustworthy alternative video in the same language. The replacement must also satisfy §17-1 criteria and undergo the same 5-stage verification. If no replacement found, delete the item. If another language's TRUSTWORTHY video already exists for the same section, deletion takes priority |
+
+#### Verification Execution Guide
+
+- For batch verification, run language-specific agents in parallel (KO / EN / JA / ES independently)
+- After verification, commit all corrections in a single commit for consistency
+- Record verification results in table format by section and language
 
 ---
 
@@ -743,38 +841,47 @@ body, header, main, footer, nav, .sidebar {
 
 ### 23-1. Filename Pattern
 
-| Type | Filename | Example |
-|------|----------|---------|
-| Default (single language) | `chapter_01.html` | Default file for the handbook's primary language |
-| Korean explicit | `chapter_01_ko.html` | Korean version, separated from default |
-| English | `chapter_01_en.html` | English translation |
-| Japanese | `chapter_01_ja.html` | Japanese translation |
+| Language | Suffix | Example |
+|----------|--------|---------|
+| Korean (default) | *(none)* | `01_Why_AI_Chapter.html` |
+| English | `_en` | `01_Why_AI_Chapter_en.html` |
+| Japanese | `_ja` | `01_Why_AI_Chapter_ja.html` |
+| Spanish | `_es` | `01_Why_AI_Chapter_es.html` |
 
-### 23-2. Language Switcher
+Index pages follow the same pattern: `index.html` / `index_en.html` / `index_ja.html` / `index_es.html`.
 
-Place a language switcher dropdown in every page header:
-- Detect `_XX` suffix in the current filename to extract the base name
-- Navigate to the selected language file on selection
-- Save user selection to `localStorage('lang')`
+### 23-2. Page Structure Requirements
 
-### 23-3. Search Index
+Translated files must be **complete copies** of the original. Each file must include:
+- `<html lang="en">`, `<html lang="ja">`, or `<html lang="es">` attribute
+- Its own sidebar navigation (linking to other files in the same language)
+- `<script src="../assets/lang-switcher.js">` included
+- Code blocks, file paths, URLs, and technical identifiers must NOT be translated
 
-The `DOCS` array in `site-search.js` includes all language variants:
+### 23-3. Translate vs. Do Not Translate
+
+**Translate:** Titles, h1, body text, sidebar labels, meta description, card descriptions, note/warning box text
+**Do NOT translate:** Code block contents, file/directory paths, CLI commands, URLs, CSS class names, technical identifiers (orchestrator, handoff contract, etc.), text inside SVG diagrams
+
+### 23-4. Search Index
+
+The `DOCS` array in `site-search.js` includes entries for all language variants. Add entries as each translation is completed — do not batch:
 ```javascript
-const DOCS = [
-  { path: 'chapters/chapter_01.html', title: 'Chapter 1 Introduction' },
-  { path: 'chapters/chapter_01_en.html', title: 'Chapter 1 Introduction (EN)' },
-];
+{ path: 'intro/01_Why_AI_Chapter_en.html', title: 'Ch.1 · Business Innovation in the AI Era', lang: 'en' },
 ```
 
-### 23-4. No Links to Untranslated Pages
+### 23-5. Verification
+
+Run `bun run scripts/validate-nav.ts` to automatically verify link integrity. Translation completeness across language sets (KO/EN/JA/ES for each chapter) must be verified manually.
+
+### 23-6. No Links to Untranslated Pages
 
 **Principle**: Never add an `_en`/`_ja` link (in an index page, nav, or sidebar) until the target `_en.html`/`_ja.html` file actually exists.
 
 - **Why**: A prior handbook shipped translated `index_en.html`/`index_ja.html` landing pages that linked to ~28 chapter pages before those chapters were translated. `check-links.ts` had a hardcoded exemption that skipped any missing `_en.html`/`_ja.html` target, so CI reported "PASS" while every translated chapter link 404'd.
 - **Rule**: `check-links.ts` treats missing `_en.html`/`_ja.html` targets as errors like any other broken link — do not reintroduce an exemption for them. Translate a language track chapter-by-chapter (or hold the index/nav links for that language until the full set of pages exists); never publish a language's landing page ahead of its content pages.
 
-### 23-5. Partial Translation Navigation
+### 23-7. Partial Translation Navigation
 
 **Principle**: When some pages in a language track are untranslated, navigation MUST remain consistent within the existing set.
 
@@ -844,9 +951,9 @@ After completing the draft, verify each item below one by one.
 - [ ] §11-1: Do flex children `.step-content` have `min-width: 0`, and do text boxes have `overflow-wrap: break-word`?
 - [ ] §11-1: Do text boxes inside `.platform-block` have negative margin compensation?
 - [ ] §11-2: Do fixed elements (badges, titles) inside flex containers have `flex-shrink: 0`?
-- [ ] §12-1: Are sentence endings unified in plain form?
-- [ ] §12-2: Are English technical terms glossed with Korean(English) only on first appearance in the document, and English-only thereafter?
-- [ ] §12-2: Do `<title>`/`<h1>`/`chapter-eyebrow`/nav heading text use English only, without parenthetical glosses or Korean-only labels?
+- [ ] §12-1: Are sentence endings unified in the formal plain register for the document's language?
+- [ ] §12-2: Are English technical terms glossed with `language_term(English)` only on first appearance in the document, and English-only thereafter?
+- [ ] §12-2: Do `<title>`/`<h1>`/`chapter-eyebrow`/nav heading text use English technical terms only, without parenthetical glosses or monolingual-only labels, across all language editions?
 - [ ] §12-3: Are chapter/section references in `N장 §M` format throughout?
 - [ ] §12-4: Are em-dashes minimized?
 - [ ] §13: Are tool comparisons free from misunderstanding, with no missing items, and visually balanced?
@@ -854,9 +961,10 @@ After completing the draft, verify each item below one by one.
 - [ ] §14: Do the Course Overview's learning objectives map 1:1 to body sections?
 - [ ] §15: Does each chapter connect to the next, and are all supplementary documents present?
 - [ ] §15-1: Does the last chapter have a "Next Steps" section?
-- [ ] §16: Is the body in the course's primary language, and code/identifiers/commits in English?
+- [ ] §16: Is the body in the course's primary language, and code/identifiers/commits in English across all editions?
 - [ ] §17: Do sections with available official videos have a "Video References" block?
 - [ ] §17: Are video links styled consistently with the `.video-refs` pattern?
+- [ ] §17-4: Has the video trust verification procedure (5 stages) been applied? Are all videos TRUSTWORTHY?
 - [ ] §18: Have A/B splits been applied to sections with platform-specific implementation differences?
 - [ ] §18: Does branch navigation connect from the common area to both A and B?
 - [ ] §18: Are inter-links between A and B files consistent?

--- a/templates/co-deck/skills/handbook/references/AUTHORING_GUIDELINES.md
+++ b/templates/co-deck/skills/handbook/references/AUTHORING_GUIDELINES.md
@@ -643,9 +643,9 @@ After splitting is complete, verify the following:
 
 ---
 
-## 20. Lecture Guide Structure
+## 20. Lecture / Instructor Guide Structure
 
-**Principle**: The Lecture Guide provides instructors with all the information needed to run the course, consolidated in one place. Together with the Course Overview principle (§14), these form the two pillars of course materials.
+**Principle**: The Lecture Guide (also called Instructor Guide — `instructor-guide.html`) provides instructors with all the information needed to run the course, consolidated in one place. Together with the Course Overview principle (§14), these form the two pillars of course materials.
 
 - **Why**: Instructors must navigate content across multiple chapters, so per-chapter instructor notes, time allocation tables, and check questions must be gathered in a single document for real-time reference. Additionally, the Course Overview (for participants) and the Lecture Guide (for instructors) must be consistent in content, order, and timing.
 - **How to apply**:
@@ -663,18 +663,7 @@ The Lecture Guide must include **all** of the following sections.
 | Demo sequence | Recommended order for live demonstrations | Reflect inter-chapter dependencies |
 | Evaluation criteria | Rubrics for participant assessment | Focused on practical application ability |
 
-### 20-2. Consistency with Course Overview
-
-The Lecture Guide must be **consistent** with the Course Overview in §14 for the following items:
-
-- Daily course order (chapter placement)
-- Per-chapter estimated time
-- Per-chapter content description
-- Total duration
-
-When one side is modified, the other must always be synchronized.
-
-### 20-3. Per-Chapter Instructor Notes Format
+### 20-2. Per-Chapter Instructor Notes Format
 
 Each chapter's instructor notes should include:
 
@@ -684,7 +673,7 @@ Each chapter's instructor notes should include:
 - **Time-short alternatives**: Which parts can be replaced with demos when time is insufficient
 - **Irreversible operation warnings**: Operations that affect the environment irreversibly — things all participants should not do simultaneously
 
-### 20-4. Check Question Format
+### 20-3. Check Question Format
 
 - Write **2–3** open-ended questions per chapter.
 - Compose questions that invite participants to **"explain in their own words"** rather than "guess the right answer."
@@ -692,6 +681,17 @@ Each chapter's instructor notes should include:
 - Examples:
   - "How could this concept be applied to our team's work?" (practical application)
   - "What is the difference between ~ covered in Chapter N and ~ in this chapter?" (inter-chapter connection)
+
+### 20-4. Consistency with Course Overview
+
+The Lecture Guide must be **consistent** with the Course Overview in §14 for the following items:
+
+- Daily course order (chapter placement)
+- Per-chapter estimated time
+- Per-chapter content description
+- Total duration
+
+When one side is modified, the other must always be synchronized.
 
 ---
 
@@ -897,38 +897,6 @@ Run `bun run scripts/validate-nav.ts` to automatically verify link integrity. Tr
 
 ---
 
-## 24. Instructor Guide Requirements
-
-**Principle**: The Instructor Guide (`instructor-guide.html`) provides instructors with all the information needed to run the course, consolidated in one place.
-
-- **Why**: Instructors must navigate content across multiple chapters, so per-chapter instructor notes, time allocation tables, and check questions must be gathered in a single document for real-time reference.
-
-### 24-1. Required Sections
-
-| Section | Content | Notes |
-|---------|---------|-------|
-| Pre-course preparation checklist | What participants must prepare before the course | Announce at least one day before |
-| Time allocation table | Daily/chapter breakdown, format, estimated time | Breaks calculated separately |
-| Per-chapter instructor notes | Tips, participant activities, demo notes per chapter | Include time-short alternatives |
-| Per-chapter check questions | Comprehension questions at the end of each chapter | Designed to elicit explanations |
-| Demo sequence | Recommended order for live demonstrations | Reflect inter-chapter dependencies |
-| Evaluation criteria | Rubrics for participant assessment | Focused on practical application ability |
-
-### 24-2. Per-Chapter Instructor Notes Items
-
-Each chapter's instructor notes should include:
-- **Position and role**: Where in the overall course this chapter falls
-- **Key delivery points**: Concepts that must be delivered
-- **Participant activities**: Discussions, polls, pair activities, etc.
-- **Time-short alternatives**: Parts that can be replaced with demos
-- **Irreversible operation warnings**: Operations with irreversible environmental impact
-
-### 24-3. Consistency with Course Overview
-
-The Lecture Guide must be consistent with the Course Overview in §14 regarding schedule, order, and timing. When one side is modified, the other must always be synchronized.
-
----
-
 ## A. Pre-Ship Checklist
 
 After completing the draft, verify each item below one by one.
@@ -969,8 +937,8 @@ After completing the draft, verify each item below one by one.
 - [ ] §18: Does branch navigation connect from the common area to both A and B?
 - [ ] §18: Are inter-links between A and B files consistent?
 - [ ] §19: Has the entire text been re-read for typos, awkward phrasing, and number mismatches?
-- [ ] §20: Has the Lecture Guide been written, and are all required sections included?
-- [ ] §20: Is the Lecture Guide consistent with the Course Overview in schedule, order, and timing?
+- [ ] §20: Has the Lecture/Instructor Guide been written, and are all 6 required sections included?
+- [ ] §20-4: Is the Lecture Guide consistent with the Course Overview in schedule, order, and timing?
 - [ ] §21: Do all chapter files have sidebars and inter-chapter navigation?
 - [ ] §21: Is the index page grouped by day and type?
 - [ ] §21: Do chapter files and index cards have consistent chapter numbers, titles, and links?

--- a/templates/co-deck/skills/handbook/references/BUILD_GUIDE.md
+++ b/templates/co-deck/skills/handbook/references/BUILD_GUIDE.md
@@ -80,7 +80,7 @@ cp presentations/<project>/source-verification.md handbook/docs/references.md
 Dispatch `handbook-writer` agent to:
 1. **Propose chapter structure** — section types per SECTION_TYPES.md, chapter count, section distribution
 2. **Write chapter HTML** — each chapter as a separate HTML file following the chapter template
-3. **Follow AUTHORING_GUIDELINES.md** — all 21 sections + §22 (Dark Mode) + §23 (Multi-Language)
+3. **Follow AUTHORING_GUIDELINES.md** — all sections including §22 (Dark Mode) and §23 (Multi-Language)
 
 ### Section Types
 Reference `SECTION_TYPES.md` for the 6 available types:
@@ -89,45 +89,25 @@ Reference `SECTION_TYPES.md` for the 6 available types:
 - **Examples** — practice exercises with A/B platform split
 - **Quiz** — Q&A with model answers and rubrics
 - **CourseOverview** — course introduction (§14)
-- **InstructorGuide** — instructor operations guide (§24)
+- **InstructorGuide** — instructor operations guide (§20)
 
 ### Content Rules
-- ALL colors via CSS variables (§22)
-- At least 1 visual element per section (§10)
-- Sidebar nav + chapter-nav on every page (§21)
-- Plain form (`~다`) writing style (§12-1)
-- Korean(English) on first use, English only thereafter (§12-2)
+All content rules are defined in `AUTHORING_GUIDELINES.md`. Key references:
+- §10: At least 1 visual element per section
+- §12: Writing style consistency (formal plain register, term glossing)
+- §18: A/B platform split when implementation differs
+- §21: Sidebar nav + chapter-nav on every page
+- §22: ALL colors via CSS variables (no hardcoded hex)
 
 ---
 
 ## §4: Course Overview + Instructor Guide
 
 ### Course Overview (§14)
-Required for course mode. Must include all 9 items:
+Required for course mode. See `AUTHORING_GUIDELINES.md §14` for the 9 required items (one-line summary, learning objectives, target audience, prerequisites, format, schedule, topics covered, post-completion outcomes, instructor information).
 
-| # | Item | Required |
-|---|------|----------|
-| 1 | One-line summary | ✅ |
-| 2 | Learning objectives | ✅ |
-| 3 | Target audience | ✅ |
-| 4 | Prerequisites | ✅ |
-| 5 | Format | ✅ |
-| 6 | Schedule | ✅ |
-| 7 | Topics covered | ✅ |
-| 8 | Post-completion outcomes | ✅ |
-| 9 | Instructor information | ✅ |
-
-### Instructor Guide (§24)
-Required for course mode. Must include:
-
-| Section | Content |
-|---------|---------|
-| Pre-course preparation checklist | What participants must prepare before the lecture |
-| Time allocation table | Daily/chapter schedule with time allocation |
-| Per-chapter instructor notes | Per-chapter: location/role, key points, participant activities, time-shortcut alternatives, irreversible operation warnings |
-| Per-chapter check questions | Per-chapter: 2-3 open-ended understanding questions |
-| Demo sequence | Demo sequence for live demonstrations |
-| Evaluation criteria | Evaluation criteria and rubrics |
+### Instructor Guide (§20)
+Required for course mode. See `AUTHORING_GUIDELINES.md §20` for the 6 required sections and per-chapter note format.
 
 ---
 

--- a/templates/co-deck/skills/handbook/references/QUALITY_CHECKLIST.md
+++ b/templates/co-deck/skills/handbook/references/QUALITY_CHECKLIST.md
@@ -2,6 +2,8 @@
 
 > Comprehensive validation checklist for handbook HTML files.
 > Covers automated checks (scripts) and manual review items.
+> For authoring principles (why each rule exists), see `AUTHORING_GUIDELINES.md`.
+> For the complete manual pre-ship checklist, see `AUTHORING_GUIDELINES.md §A`.
 
 ---
 
@@ -9,12 +11,23 @@
 
 ### validate-nav (4 checks)
 
-| # | Check | Tool | Description |
-|---|-------|------|-------------|
-| ① | Broken links | `check-links.ts` | All internal `<a href>` targets resolve to existing files |
-| ② | prev/next symmetry | `check-symmetry.ts` | A→next→B implies B→prev→A |
-| ③ | Label match | `check-labels.ts` | chapter-nav labels match target title/h1 |
-| ④ | DOCS sync | `check-search.ts` | site-search.js DOCS array matches actual HTML files |
+| # | Check | Section | Description |
+|---|-------|---------|-------------|
+| ① | Broken links | §21-4 | All internal `<a href>` targets resolve to existing files |
+| ② | prev/next symmetry | §21-4 | A→next→B implies B→prev→A |
+| ③ | Label match | §21-4 | chapter-nav labels match target title/h1 |
+| ④ | DOCS sync | §23-4 | site-search.js DOCS array matches actual HTML files |
+
+**Implementation details**: All 4 checks share `nav-utils.ts` for HTML parsing. See `validation/NAV_VALIDATION.md` for the full specification including shared utilities, error conditions, and CI integration.
+
+**Running**:
+```bash
+# From handbook root
+bun run validate-nav
+
+# With custom docs directory
+bun scripts/validate-nav.ts --docs-dir path/to/docs
+```
 
 ### check-authoring (10 checks)
 
@@ -25,11 +38,11 @@
 | 3 | Sidebar nav | §21-1 | All pages have sidebar navigation |
 | 4 | Chapter-nav | §21-1 | Content pages have prev/next navigation |
 | 5 | min-width: 0 | §11-1 | step-content has flex overflow prevention |
-| 6 | No mid-word strong | §11 | No short Korean words wrapped in `<strong>` |
+| 6 | No mid-word strong | §11 | No short words wrapped in `<strong>` causing line breaks |
 | 7 | Course Overview items | §14 | course-overview.html has all 9 required items |
 | 8 | CSS variables | §22 | No hardcoded hex colors in inline styles |
 | 9 | Language pairs | §23 | Language variants have base file counterparts |
-| 10 | Instructor Guide | §24 | instructor-guide.html has required sections |
+| 10 | Instructor Guide | §20 | instructor-guide.html has required sections |
 
 ### handbook-doctor (12 checks)
 
@@ -101,9 +114,12 @@ If examples fail, the check exits with code 1 and blocks the PR.
 
 ---
 
-## Manual Review Checklist (Appendix A)
+## Manual Review Checklist
 
-### Content Quality (§1-§7)
+> For the complete manual pre-ship checklist (35 items with per-section verification), see **`AUTHORING_GUIDELINES.md §A`**.
+> The checklist below is a condensed summary grouped by area for quick scanning during review sessions.
+
+### Content Quality (§1–§7)
 
 - [ ] §1 Concept explanations include analogies and reasoning
 - [ ] §2 All code blocks have copy buttons; one step = one action
@@ -124,10 +140,10 @@ If examples fail, the check exits with code 1 and blocks the PR.
 
 ### Writing Style (§12, §16)
 
-- [ ] §12-1 Plain form (`~다`) consistently
-- [ ] §12-2 English terms: Korean(English) first use, English only after
-- [ ] §12-2 `<title>`, `<h1>`, nav labels: English only (no Korean, no parenthetical)
-- [ ] §12-3 Cross-references: `N장 §M` format
+- [ ] §12-1 Formal plain register consistently
+- [ ] §12-2 Technical terms: `local_term(English)` first use, English only after
+- [ ] §12-2 Headings: English technical terms only, no parenthetical glosses
+- [ ] §12-3 Cross-references in standard format
 - [ ] §12-4 em-dash minimized
 
 ### Visual & Navigation (§8, §10, §21)
@@ -135,35 +151,36 @@ If examples fail, the check exits with code 1 and blocks the PR.
 - [ ] §8 All learner-facing content is HTML (not Markdown)
 - [ ] §10 Each section has at least 1 visual element
 - [ ] §10-2 SVGs use `viewBox` + `width="100%"` for responsiveness
-- [ ] §21-1 All pages have sidebar nav
-- [ ] §21-1 Content pages have chapter-nav
-- [ ] §21-2 Index page grouped by day/type with instructor materials section
-- [ ] §21-4 prev/next mutual symmetry verified
+- [ ] §21 All pages have sidebar nav and chapter-nav
+- [ ] §21-4 prev/next mutual symmetry verified (on renumbering)
 
 ### Course Materials (§14, §15, §20)
 
 - [ ] §14 Course Overview has all 9 required items
 - [ ] §14 Learning objectives map 1:1 to actual chapter sections
 - [ ] §15-1 Last chapter has "Next Steps" section
-- [ ] §20 Instructor Guide has 4 required sections
-- [ ] §20-2 Instructor Guide matches Course Overview (schedule, order, timing)
+- [ ] §20 Instructor Guide has all 6 required sections
+- [ ] §20-4 Instructor Guide matches Course Overview (schedule, order, timing)
 
 ### Dark Mode (§22)
 
 - [ ] §22 All colors use CSS variables — zero hardcoded hex
 - [ ] §22 Theme CSS has `:root` (light) + `@media dark` + `.dark` (toggle)
-- [ ] §22 Dark toggle JS loaded and functional
 - [ ] §22 SVGs use CSS variables or neutral colors
 
 ### Multi-Language (§23)
 
-- [ ] §23 Language variants follow naming convention (base, base_ko, base_en)
-- [ ] §23 Language switcher dropdown present in header
-- [ ] §23 All language variants have matching structure
-- [ ] §23 Language preference stored in localStorage
+- [ ] §23 Language variants follow naming convention (base, base_en, base_ja, base_es)
+- [ ] §23 No links to untranslated pages (§23-6)
+- [ ] §23 Partial translation navigation is consistent (§23-7)
+
+### Video References (§17)
+
+- [ ] §17 Video links styled with `.video-refs` pattern
+- [ ] §17-4 Video trust verification (5 stages) applied; all videos TRUSTWORTHY
 
 ### Final Proofreading (§19)
 
-- [ ] §19 Read entire document checking: typos, awkward phrasing, numbering
-- [ ] §19 Check cross-references point to correct chapter/section
-- [ ] §19 Verify logical flow between sections (no causality reversal)
+- [ ] §19 Read entire document: typos, awkward phrasing, numbering
+- [ ] §19 Cross-references point to correct chapter/section
+- [ ] §19 Logical flow between sections (no causality reversal)

--- a/templates/co-deck/skills/handbook/references/SECTION_TYPES.md
+++ b/templates/co-deck/skills/handbook/references/SECTION_TYPES.md
@@ -2,6 +2,7 @@
 
 > Defines the 6 section types available for handbook content.
 > Each type has a corresponding HTML template and specific structural requirements.
+> For authoring rules (visual elements, writing style, OS handling, etc.), see `AUTHORING_GUIDELINES.md`.
 
 ---
 
@@ -13,8 +14,8 @@
 | **Chapter** | `chapter.html` | Narrative content | 720px max-width, visual elements, key points |
 | **Examples** | `examples.html` | Practice exercises | Difficulty badges, step-lists, A/B platform split |
 | **Quiz** | `quiz.html` | Q&A and assessment | Details toggle, model answers, rubrics |
-| **CourseOverview** | `course-overview.html` | Course introduction | 9 required items (§14), schedule table |
-| **InstructorGuide** | `instructor-guide.html` | Instructor operations guide | Per-chapter notes, timing, evaluation criteria |
+| **CourseOverview** | `course-overview.html` | Course introduction | 9 required items — see `AUTHORING_GUIDELINES.md §14` |
+| **InstructorGuide** | `instructor-guide.html` | Instructor operations guide | Per-chapter notes, timing, evaluation — see `AUTHORING_GUIDELINES.md §20` |
 
 ---
 
@@ -27,16 +28,11 @@
 - Right column: content sections with headers
 - Width: full content area (2-column layout)
 
-**Dark Mode Notes**:
-- TOC panel: `var(--bg2)` background
-- Active nav item: `var(--accent)` border-left
-- Code blocks: `var(--bg3)` background
-
 **Required Elements**:
-- ✅ Sidebar navigation
-- ✅ Sticky TOC (left column)
-- ✅ Copy buttons on code blocks (§2)
-- ✅ CSS variables for all colors (§22)
+- Sidebar navigation (§21-1)
+- Sticky TOC (left column)
+- Copy buttons on code blocks (§2)
+- All colors via CSS variables (§22)
 
 ---
 
@@ -51,16 +47,11 @@
 - Key points box (tip/note/warning/info)
 - chapter-nav at bottom (prev/next)
 
-**Dark Mode Notes**:
-- Content: `var(--bg)` background
-- Key points boxes: semantic `var(--bg-info)`, `var(--bg-note)`, `var(--bg-warn)`
-- Blockquotes: `var(--border-left)` accent color
-
 **Required Elements**:
-- ✅ At least 1 visual per section (§10)
-- ✅ chapter-nav (§21-1)
-- ✅ Sidebar nav (§21-1)
-- ✅ CSS variables only (§22)
+- At least 1 visual per section (§10)
+- chapter-nav (§21-1)
+- Sidebar nav (§21-1)
+- All colors via CSS variables (§22)
 
 ---
 
@@ -74,16 +65,11 @@
 - Code blocks with copy buttons
 - A/B platform split support (§18)
 
-**Dark Mode Notes**:
-- Difficulty badge: `var(--accent)` text on `var(--bg2)`
-- Step number: `var(--accent)` circle
-- Platform blocks: `var(--bg2)` background with `var(--border)`
-
 **Required Elements**:
-- ✅ Difficulty badge
-- ✅ Copy buttons (§2)
-- ✅ `min-width: 0` on step-content (§11-1)
-- ✅ A/B navigation when platform-specific (§18)
+- Difficulty badge
+- Copy buttons (§2)
+- `min-width: 0` on step-content (§11-1)
+- A/B navigation when platform-specific (§18)
 
 ---
 
@@ -97,70 +83,27 @@
 - Rubric/marking criteria
 - Score summary area
 
-**Dark Mode Notes**:
-- Question: `var(--bg2)` background
-- Correct answer: `var(--bg-success)` indicator
-- Wrong answer: `var(--bg-error)` indicator
-
 **Required Elements**:
-- ✅ `<details>/<summary>` for toggle
-- ✅ Model answer for each question
-- ✅ Rubric when applicable
+- `<details>/<summary>` for toggle
+- Model answer for each question
+- Rubric when applicable
 
 ---
 
 ## CourseOverview
 
-**Purpose**: Course introduction — the first document participants see (§14).
+**Purpose**: Course introduction — the first document participants see.
 
-**Structure**:
-- Card-based layout with 9 required items
-- Schedule table with time blocks
+See `AUTHORING_GUIDELINES.md §14` for the 9 required items (one-line summary, learning objectives, target audience, prerequisites, format, schedule, topics covered, post-completion outcomes, instructor information).
 
-**Required Items** (all 9 mandatory per §14):
-
-| # | Item | Description |
-|---|------|-------------|
-| 1 | One-line summary | 2-3 sentence description of the course |
-| 2 | Learning objectives | Bloom's Taxonomy verbs (explain, design, apply, execute...) |
-| 3 | Target audience | Role and experience level criteria |
-| 4 | Prerequisites | Accounts, installations, knowledge prerequisites |
-| 5 | Format | Lecture/practice/discussion/demo ratio |
-| 6 | Schedule | Time-block schedule including breaks |
-| 7 | Topics covered | Per-block topic with chapter/section mapping |
-| 8 | Post-completion outcomes | Practical outputs and skills gained |
-| 9 | Instructor information | Name, affiliation, profile (blanks allowed) |
-
-**Dark Mode Notes**:
-- Cards: `var(--bg2)` with `var(--border)` border
-- Schedule table: alternating `var(--bg)` / `var(--bg2)` rows
+**Structure**: Card-based layout with schedule table.
 
 ---
 
 ## InstructorGuide
 
-**Purpose**: Instructor operations guide — all information needed to run the course (§20/§24).
+**Purpose**: Instructor operations guide — all information needed to run the course.
 
-**Structure**:
-- Per-chapter sections with instructor notes
-- Timing table
-- Demo sequence
-- Evaluation criteria
+See `AUTHORING_GUIDELINES.md §20` for the 6 required sections, per-chapter note format, check question format, and consistency rules with Course Overview.
 
-**Required Sections**:
-
-| Section | Content |
-|---------|---------|
-| Pre-course preparation checklist | What participants prepare before the lecture |
-| Time allocation table | Daily/chapter schedule (must match Course Overview) |
-| Per-chapter instructor notes | Per-chapter: location/role, key points, participant activities, time-shortcut, irreversible warnings |
-| Per-chapter check questions | 2-3 open-ended questions per chapter |
-| Demo sequence | Demo order for live demonstrations |
-| Evaluation criteria | Evaluation criteria and scoring rubrics |
-
-**Dark Mode Notes**:
-- Same as chapter type — narrative layout
-- Warning boxes for irreversible operations: `var(--bg-warn)`
-- Time-shortcut sections: `var(--bg-note)` background
-
-**Consistency Rule**: Instructor Guide timing and content MUST match Course Overview (§20-2). If one is updated, the other must be synchronized.
+**Structure**: Per-chapter sections with timing table, demo sequence, and evaluation criteria.


### PR DESCRIPTION
[claude pr-body] Attempt 1/2
[claude pr-body]  Success on attempt 1
## Why
The co-deck handbook's `AUTHORING_GUIDELINES.md` was Korean-centric, but the handbook now ships multilingual editions (KO/JA/EN/ES). The authoring rules — sentence register, technical-term glossing, video selection, and the translation workflow — needed to generalize beyond Korean, and a repeatable video trust-verification procedure was missing to keep linked YouTube content valid and authoritative.

## What Changed
- **`templates/co-deck/skills/handbook/references/AUTHORING_GUIDELINES.md`** (the substantive change):
  - **§12-1 Sentence Endings**: generalized from Korean-only plain/polite (`~다`/`~습니다`) rules to a per-language formal-register table (KO haera-che, JA da/dearu, EN declarative, ES neutro/formal); polite register now also allowed in error messages.
  - **§12-2 English Technical Term Notation**: generalized the `Korean(English)` gloss convention to `local_term(English)` across KO/JA/EN/ES, with per-language first-appearance gloss tables and EN-source clarification.
  - **§16 Language Policy** & **§17-1 Video Selection**: clarified that each edition uses its own language and prioritizes same-language videos (with EN fallback) per edition.
  - **§17-3 Video badge CSS**: replaced hardcoded colors with theme variables (`--accent`, `--accent-green`, `--accent-red`, `--accent-amber`, `--border-info`, `--text-inverse`) and added `.video-badge.ja`/`.es` classes.
  - **§17-4 (new)**: added a 5-stage Video Trust Verification Procedure (oEmbed existence → metadata match → content relevance → channel trustworthiness → action), with TRUSTWORTHY/QUESTIONABLE/BROKEN verdicts.
  - **§23 Multilingual translation**: rewrote filename suffixes to include `_es`, added page-structure requirements, a translate vs. do-not-translate table, `validate-nav.ts` verification, and renumbered subsections (23-1…23-7).
  - Updated the end-of-draft **checklist** (§12-1, §12-2, §16, §17-4) to reflect the multilingual scope.
- **`docs/VERSION_MANIFEST.md`**: regenerated timestamp (auto-generated by the sync pipeline).
- **`memory/2026-07-31.md`** + **`memory/MEMORY.md`**: new daily memory-log entry and index pointer.

## Test Plan
- [ ] `bun scripts/audit.ts` passes
- [ ] `bun run scripts/validate-nav.ts` passes (referenced by the new §23-5 rule)
- [ ] Review §17-4 oEmbed procedure against a sample video ID (200 → metadata, 404 → BROKEN)
- [ ] Confirm new CSS variables (`--accent-green`, `--accent-red`, `--accent-amber`, `--border-info`, `--text-inverse`) are defined in the handbook theme tokens before badges render correctly

## Security Checklist
- [x] No secrets, credentials, or API keys committed
- [x] No `.env` files staged (use `.env.sample` for templates)
- [x] Dependencies unchanged or reviewed for new CVEs

## Notes
Documentation-only change to a template (`templates/co-deck/`); no runtime code, build output, or dependencies affected. Per the co-deck handbook fork policy, this is a surgical edit of the co-deck copy — not a blind overwrite from the upstream handbook source. The video-verification procedure (§17-4) describes a manual/agent workflow using the public YouTube oEmbed endpoint (no API key required).