### PR TITLE
fix(encoding): workspace-wide LF line ending normalization and U+FEFF cleanup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
 
+- **[2026-08-07]**: fix(encoding): workspace-wide normalization of CRLF/mixed line endings to LF and replacement of literal zero-width U+FEFF characters — normalized 101 files with CRLF/mixed line endings to LF; replaced 6 literal zero-width U+FEFF characters inside `normalizeContent()` regexes with explicit `\uFEFF` escape code (`scripts/validate-agents.ts`, `validate-skills.ts`, `validate-templates.ts`, `skill-dependency-analysis.ts` + L1 mirrors). Verified `bun scripts/scratch/scan-encoding.ts` (0 BOM, 0 CRLF, 0 zero-width), `bun scripts/validate-templates.ts` (0 errors), `bun scripts/audit.ts` (all checks passed).
+
 - **[2026-08-07]**: fix(scripts): resolve `PAIR MISSING` warnings in `scripts/SCRIPTS.md` registry — corrected non-pair descriptive text entries to `—` for 4 TypeScript scripts (`validators/schema-validator.ts`, `hooks/gateguard-fact-force.ts`, `hooks/post-write-lifecycle-check.ts`, `lib/encoding-utils.ts`), reducing `verify-scripts.ts` warnings from 7 to 3 (only scheduled deprecations remain). Verified `bun scripts/verify-scripts.ts --verify` (142 scripts verified).
 
 - **[2026-08-07]**: feat(templates/co-game): add Arcade & Puzzle ECS reference components and systems (`arcade-puzzle-template.ts`) + unit test suite (`arcade-puzzle-template.test.ts`) covering GridSystem, CollisionSystem, and ScoreManager (13 tests passing, 0 fails). Verified `bun test templates/co-game/tests/` (13 pass), `bun scripts/validate-templates.ts` (0 errors), `bun scripts/audit.ts` (all checks passed).

--- a/docs/VERSION_MANIFEST.md
+++ b/docs/VERSION_MANIFEST.md
@@ -1,6 +1,6 @@
 # VERSION_MANIFEST.md
 
-**Generated**: 2026-08-07T00:11:49.613Z
+**Generated**: 2026-08-07T00:21:37.629Z
 **Manifest Version**: 1.0
 **Location**: docs\VERSION_MANIFEST.md
 
@@ -166,7 +166,7 @@
 | security-plugin.ts | 1.0.0 | scripts/helpers/plugins/security-plugin.ts | N/A |
 | security-validator.ts | 1.0.1 | scripts/helpers/security-validator.ts | fs, path |
 | setup-github-branch-protection.ts | 1.0.1 | scripts/setup-github-branch-protection.ts | bun |
-| skill-dependency-analysis.ts | 1.0.0 | scripts/skill-dependency-analysis.ts | N/A |
+| skill-dependency-analysis.ts | 1.0.1 | scripts/skill-dependency-analysis.ts | N/A |
 | skill-lifecycle-audit.ts | 1.2.0 | scripts/skill-lifecycle-audit.ts | N/A |
 | spec-register.ts | 1.0.1 | scripts/spec-register.ts | N/A |
 | ssrf.ts | 1.1.0 | scripts/lib/ssrf.ts | N/A |
@@ -191,7 +191,7 @@
 | types.ts | 1.0.0 | scripts/validators/types.ts | N/A |
 | update-variant-lifecycle.ts | 1.0.1 | scripts/helpers/update-variant-lifecycle.ts | N/A |
 | upgrade-project.ts | 1.7.0 | scripts/upgrade-project.ts | N/A |
-| validate-agents.ts | 1.0.1 | scripts/validate-agents.ts | N/A |
+| validate-agents.ts | 1.0.2 | scripts/validate-agents.ts | N/A |
 | validate-doc-folder.ts | 1.0.0 | scripts/validate-doc-folder.ts | fs, path |
 | validate-docs-links.ts | 1.0.0 | scripts/validate-docs-links.ts | fs, path |
 | validate-md-language.ts | 1.4.4 | scripts/validate-md-language.ts | fs |
@@ -199,8 +199,8 @@
 | validate-output.ts | 1.0.1 | scripts/helpers/validate-output.ts | N/A |
 | validate-platform-parity.ts | 1.1.1 | scripts/helpers/validate-platform-parity.ts | fs, path |
 | validate-pm-extends.ts | 0.3.1 | scripts/validate-pm-extends.ts | N/A |
-| validate-skills.ts | 1.0.2 | scripts/validate-skills.ts | N/A |
-| validate-templates.ts | 1.5.14 | scripts/validate-templates.ts | js-yaml |
+| validate-skills.ts | 1.0.3 | scripts/validate-skills.ts | N/A |
+| validate-templates.ts | 1.5.15 | scripts/validate-templates.ts | js-yaml |
 | validation-policy.ts | 1.0.0 | scripts/helpers/registries/validation-policy.ts | N/A |
 | variant-feature.ts | 1.0.0 | scripts/variant-feature.ts | N/A |
 | variant-governance-rules.ts | 1.1.1 | scripts/helpers/variant-governance-rules.ts | N/A |

--- a/memory/2026-08-07.md
+++ b/memory/2026-08-07.md
@@ -166,6 +166,21 @@ fix(scripts): resolve PAIR MISSING warnings in `scripts/SCRIPTS.md` registry
 ---
 
 ## Session Summary
+fix(encoding): workspace-wide normalization of CRLF/mixed line endings to LF and zero-width U+FEFF cleanup
+
+## Changes
+- Normalized line endings across 101 files from CRLF/mixed to LF
+- Replaced 6 literal U+FEFF characters in regexes with explicit `\uFEFF` escape string in `validate-agents.ts`, `validate-skills.ts`, `validate-templates.ts`, `skill-dependency-analysis.ts`, and L1 template copies
+
+## Decisions
+- All text files in workspace enforced as UTF-8 without BOM and LF line endings per Risk #3 & ADR-0021
+
+## Open Issues
+- None
+
+---
+
+## Session Summary
 fix(templates): resolve project-review findings across co-design, co-develop, co-game, and co-security
 
 ## Changes
@@ -210,6 +225,226 @@ fix(scripts): resolve PAIR MISSING warnings in SCRIPTS.md registry
 - `M CHANGELOG.md` — modified
 - `memory/2026-08-07.md` — modified
 - `scripts/SCRIPTS.md` — modified
+
+## Decisions
+- None
+
+## Open Issues
+- None
+
+---
+
+## Session Summary
+fix(encoding): workspace-wide LF line ending normalization and U+FEFF cleanup
+
+## Changes
+- `M .agents/skills/explain-me/scripts/validate_report.py` — modified
+- `.agents/skills/explain-me/templates/publish/dot-gitignore` — modified
+- `.claude/commands/changelog.md` — modified
+- `.claude/commands/new-task.md` — modified
+- `.claude/launch.json` — modified
+- `.claude/post-checkout.log` — modified
+- `.claude/skills/explain-me/scripts/validate_report.py` — modified
+- `.claude/skills/explain-me/templates/publish/dot-gitignore` — modified
+- `.clauderules` — modified
+- `.cursorrules` — modified
+- `.gemini/skills/explain-me/scripts/validate_report.py` — modified
+- `.gemini/skills/explain-me/templates/publish/dot-gitignore` — modified
+- `.gitattributes` — modified
+- `.githooks/commit-msg` — modified
+- `.githooks/post-checkout` — modified
+- `.githooks/pre-commit` — modified
+- `.githooks/pre-push` — modified
+- `.githooks/pre-rebase` — modified
+- `.github/CODEOWNERS` — modified
+- `.gitignore` — modified
+- `.gitleaks.toml` — modified
+- `CHANGELOG.md` — modified
+- `LICENSE` — modified
+- `NOTICES` — modified
+- `docs/constitution/04-i18n.md` — modified
+- `docs/constitution/05.6-agent-lifecycle.md` — modified
+- `docs/templates/common.lifecycle.json` — modified
+- `docs/templates/lifecycle-governance.json` — modified
+- `docs/templates/variant-contract.json` — modified
+- `docs/templates/variant.schema.json` — modified
+- `memory/2026-08-07.md` — modified
+- `scripts/agent-list.ts` — modified
+- `scripts/agent-verify.ts` — modified
+- `scripts/analyze-git-history.ts` — modified
+- `scripts/archive-memory.ts` — modified
+- `scripts/clear-pm-approval.ts` — modified
+- `scripts/dispatch-serial.ts` — modified
+- `scripts/fix-parse-agent.sed` — modified
+- `scripts/helpers/lifecycle-governance.ts` — modified
+- `scripts/helpers/template-utils.ts` — modified
+- `scripts/lib/error-handling.ts` — modified
+- `scripts/lib/platform-context.ts` — modified
+- `scripts/list-template-versions.ts` — modified
+- `scripts/skill-dependency-analysis.ts` — modified
+- `scripts/sync-md.ts` — modified
+- `scripts/validate-agents.ts` — modified
+- `scripts/validate-doc-folder.ts` — modified
+- `scripts/validate-skills.ts` — modified
+- `scripts/validate-templates.ts` — modified
+- `scripts/verify-skills.ts` — modified
+- `scripts/verify-template-integrity.ts` — modified
+- `skills/explain-me/scripts/validate_report.py` — modified
+- `skills/explain-me/templates/publish/dot-gitignore` — modified
+- `templates/co-consult/python/driver_tree.py` — modified
+- `templates/co-consult/python/kpi.py` — modified
+- `templates/co-consult/python/normalize.py` — modified
+- `templates/co-consult/python/requirements.txt` — modified
+- `templates/co-consult/python/validate.py` — modified
+- `templates/co-deck/.agents/skills/handbook/templates/.gitignore` — modified
+- `templates/co-deck/.claude/skills/handbook/templates/.gitignore` — modified
+- `templates/co-deck/.gemini/skills/handbook/templates/.gitignore` — modified
+- `templates/co-deck/.gitattributes` — modified
+- `templates/co-deck/scripts/co-deck/tests/extract_slidedata.test.mjs` — modified
+- `templates/co-deck/skills/handbook/templates/.gitignore` — modified
+- `templates/common/.claude/commands/changelog.md` — modified
+- `templates/common/.claude/commands/new-task.md` — modified
+- `templates/common/.gitattributes` — modified
+- `templates/common/.githooks/commit-msg` — modified
+- `templates/common/.githooks/post-checkout` — modified
+- `templates/common/.gitignore` — modified
+- `templates/common/scripts/agent-list.ts` — modified
+- `templates/common/scripts/agent-verify.ts` — modified
+- `templates/common/scripts/analyze-git-history.ts` — modified
+- `templates/common/scripts/archive-memory.ts` — modified
+- `templates/common/scripts/clear-pm-approval.ts` — modified
+- `templates/common/scripts/dispatch-serial.ts` — modified
+- `templates/common/scripts/helpers/template-utils.ts` — modified
+- `templates/common/scripts/lib/error-handling.ts` — modified
+- `templates/common/scripts/lib/platform-context.ts` — modified
+- `templates/common/scripts/sync-md.ts` — modified
+- `templates/common/scripts/validate-agents.ts` — modified
+- `templates/common/scripts/validate-doc-folder.ts` — modified
+- `templates/common/scripts/validate-skills.ts` — modified
+- `templates/common/scripts/verify-skills.ts` — modified
+- `scripts/scratch/` — modified
+
+## Decisions
+- None
+
+## Open Issues
+- None
+
+---
+
+## Session Summary
+fix(encoding): workspace-wide LF line ending normalization and U+FEFF cleanup
+
+## Changes
+- `M .agents/skills/explain-me/scripts/validate_report.py` — modified
+- `.agents/skills/explain-me/templates/publish/dot-gitignore` — modified
+- `.claude/commands/changelog.md` — modified
+- `.claude/commands/new-task.md` — modified
+- `.claude/launch.json` — modified
+- `.claude/post-checkout.log` — modified
+- `.claude/skills/explain-me/scripts/validate_report.py` — modified
+- `.claude/skills/explain-me/templates/publish/dot-gitignore` — modified
+- `.clauderules` — modified
+- `.cursorrules` — modified
+- `.gemini/skills/explain-me/scripts/validate_report.py` — modified
+- `.gemini/skills/explain-me/templates/publish/dot-gitignore` — modified
+- `.gitattributes` — modified
+- `.githooks/commit-msg` — modified
+- `.githooks/post-checkout` — modified
+- `.githooks/pre-commit` — modified
+- `.githooks/pre-push` — modified
+- `.githooks/pre-rebase` — modified
+- `.github/CODEOWNERS` — modified
+- `.gitignore` — modified
+- `.gitleaks.toml` — modified
+- `CHANGELOG.md` — modified
+- `LICENSE` — modified
+- `NOTICES` — modified
+- `docs/VERSION_MANIFEST.md` — modified
+- `docs/constitution/04-i18n.md` — modified
+- `docs/constitution/05.6-agent-lifecycle.md` — modified
+- `docs/templates/common.lifecycle.json` — modified
+- `docs/templates/lifecycle-governance.json` — modified
+- `docs/templates/variant-contract.json` — modified
+- `docs/templates/variant.schema.json` — modified
+- `memory/2026-08-07.md` — modified
+- `scripts/agent-list.ts` — modified
+- `scripts/agent-verify.ts` — modified
+- `scripts/analyze-git-history.ts` — modified
+- `scripts/archive-memory.ts` — modified
+- `scripts/clear-pm-approval.ts` — modified
+- `scripts/dispatch-serial.ts` — modified
+- `scripts/fix-parse-agent.sed` — modified
+- `scripts/helpers/lifecycle-governance.ts` — modified
+- `scripts/helpers/template-utils.ts` — modified
+- `scripts/lib/error-handling.ts` — modified
+- `scripts/lib/platform-context.ts` — modified
+- `scripts/list-template-versions.ts` — modified
+- `scripts/skill-dependency-analysis.ts` — modified
+- `scripts/sync-md.ts` — modified
+- `scripts/validate-agents.ts` — modified
+- `scripts/validate-doc-folder.ts` — modified
+- `scripts/validate-skills.ts` — modified
+- `scripts/validate-templates.ts` — modified
+- `scripts/verify-skills.ts` — modified
+- `scripts/verify-template-integrity.ts` — modified
+- `skills/explain-me/scripts/validate_report.py` — modified
+- `skills/explain-me/templates/publish/dot-gitignore` — modified
+- `templates/co-consult/python/driver_tree.py` — modified
+- `templates/co-consult/python/kpi.py` — modified
+- `templates/co-consult/python/normalize.py` — modified
+- `templates/co-consult/python/requirements.txt` — modified
+- `templates/co-consult/python/validate.py` — modified
+- `templates/co-deck/.agents/skills/handbook/templates/.gitignore` — modified
+- `templates/co-deck/.claude/skills/handbook/templates/.gitignore` — modified
+- `templates/co-deck/.gemini/skills/handbook/templates/.gitignore` — modified
+- `templates/co-deck/.gitattributes` — modified
+- `templates/co-deck/scripts/co-deck/tests/extract_slidedata.test.mjs` — modified
+- `templates/co-deck/skills/handbook/templates/.gitignore` — modified
+- `templates/common/.claude/commands/changelog.md` — modified
+- `templates/common/.claude/commands/new-task.md` — modified
+- `templates/common/.gitattributes` — modified
+- `templates/common/.githooks/commit-msg` — modified
+- `templates/common/.githooks/post-checkout` — modified
+- `templates/common/.gitignore` — modified
+- `templates/common/scripts/agent-list.ts` — modified
+- `templates/common/scripts/agent-verify.ts` — modified
+- `templates/common/scripts/analyze-git-history.ts` — modified
+- `templates/common/scripts/archive-memory.ts` — modified
+- `templates/common/scripts/clear-pm-approval.ts` — modified
+- `templates/common/scripts/dispatch-serial.ts` — modified
+- `templates/common/scripts/helpers/template-utils.ts` — modified
+- `templates/common/scripts/lib/error-handling.ts` — modified
+- `templates/common/scripts/lib/platform-context.ts` — modified
+- `templates/common/scripts/sync-md.ts` — modified
+- `templates/common/scripts/validate-agents.ts` — modified
+- `templates/common/scripts/validate-doc-folder.ts` — modified
+- `templates/common/scripts/validate-skills.ts` — modified
+- `templates/common/scripts/verify-skills.ts` — modified
+
+## Decisions
+- None
+
+## Open Issues
+- None
+
+---
+
+## Session Summary
+fix(encoding): workspace-wide LF line ending normalization and U+FEFF cleanup
+
+## Changes
+- `CHANGELOG.md` — modified
+- `docs/VERSION_MANIFEST.md` — modified
+- `memory/2026-08-07.md` — modified
+- `scripts/SCRIPTS.md` — modified
+- `scripts/skill-dependency-analysis.ts` — modified
+- `scripts/validate-agents.ts` — modified
+- `scripts/validate-skills.ts` — modified
+- `scripts/validate-templates.ts` — modified
+- `templates/common/scripts/SCRIPTS.md` — modified
+- `templates/common/scripts/validate-agents.ts` — modified
+- `templates/common/scripts/validate-skills.ts` — modified
 
 ## Decisions
 - None

--- a/scripts/SCRIPTS.md
+++ b/scripts/SCRIPTS.md
@@ -156,7 +156,7 @@ bun run <alias>                     # via package.json alias (preferred for CI)
 | `render-pdf-deck.ts` | L0 | 1.0.0 | active | —| —| L0+L1 | —|
 | `retry-handler.ts` | L0 | 1.0.1 | active | —| —| L0+L1 | —|
 | `setup-github-branch-protection.ts` | L0 | 1.0.1 | active | `--repo`, `--branch`, `--check` (repeatable), `--dry-run` | —| L0+L1 | —|
-| `skill-dependency-analysis.ts` | L0 | 1.0.0 | active | —| —| L0 | —|
+| `skill-dependency-analysis.ts` | L0 | 1.0.1 | active | —| —| L0 | —|
 | `spec-register.ts` | L0 | 1.0.1 | active | `--file`, `--source`, `--update`, `--status`, `--list`, `--ref` | —| L0 | —|
 | `skill-lifecycle-audit.ts` | L0 | 1.2.0 | active | —| —| L0+L1 | —|
 | `sync-agent-status.ts` | L0 | 1.0.1 | active | —| —| L0+L1 | —|
@@ -174,13 +174,13 @@ bun run <alias>                     # via package.json alias (preferred for CI)
 | `ticket.ts` | L0 | 1.0.0 | active | —| —| L0 | —|
 | `upgrade-project.ts` | L0 | 1.7.0 | active | `--variant`, `--platform`, `--dry-run`, `--prune-removed`, `--rollback` | —| L0 | —|
 | `variant-feature.ts` | L0 | 1.0.0 | active | `--variant`, `--feature`, `--type` | —| L0 | —|
-| `validate-agents.ts` | L0 | 1.0.1 | active | —| —| L0+L1 | —|
+| `validate-agents.ts` | L0 | 1.0.2 | active | —| —| L0+L1 | —|
 | `validate-doc-folder.ts` | L0 | 1.0.0 | active | —| —| L0+L1 | —|
 | `validate-docs-links.ts` | L0 | 1.0.0 | active | —| —| L0+L1 | —|
 | `validate-md-language.ts` | L0 | 1.4.4 | active | —| —| L0+L1 | —|
 | `validate-model-registry.ts` | L0 | 1.0.3 | active | —| —| L0+L1 | —|
-| `validate-skills.ts` | L0 | 1.0.2 | active | —| —| L0+L1 | —|
-| `validate-templates.ts` | L0 | 1.5.14 | active | —| —| L0 | —|
+| `validate-skills.ts` | L0 | 1.0.3 | active | —| —| L0+L1 | —|
+| `validate-templates.ts` | L0 | 1.5.15 | active | —| —| L0 | —|
 | `verify-agent-deliverables.ts` | L0 | 1.0.1 | active | —| —| L0+L1 | —|
 | `verify-memory.ts` | L0 | 1.0.1 | active | —| —| L0+L1 | —|
 | `verify-new-project-tests.ts` | L0 | 1.0.3 | active | —| —| L0 | —|

--- a/scripts/skill-dependency-analysis.ts
+++ b/scripts/skill-dependency-analysis.ts
@@ -1,7 +1,7 @@
 #!/usr/bin/env bun
 /**
  * Skill Dependency Analysis Script (SC-02)
- * @version 1.0.0
+ * @version 1.0.1
  * Analyzes /skill invocation references within SKILL.md files to detect:
  *   - Circular dependencies (A → B → A)
  *   - Orphaned references (skill calls a non-existent or archived skill)
@@ -53,7 +53,7 @@ interface AnalysisIssue {
 }
 
 function normalizeContent(raw: string): string {
-  return raw.replace(/^﻿/, '').replace(/\r\n/g, '\n').replace(/\r/g, '\n');
+  return raw.replace(/^\uFEFF/, '').replace(/\r\n/g, '\n').replace(/\r/g, '\n');
 }
 
 function parseStatus(content: string): string {

--- a/scripts/validate-agents.ts
+++ b/scripts/validate-agents.ts
@@ -1,7 +1,7 @@
 #!/usr/bin/env bun
 /**
  * Agent Lifecycle Validation Script
- * @version 1.0.1
+ * @version 1.0.2
  *
  * Validates all agents/*.md files for required lifecycle frontmatter
  * and checks governance records in docs/lifecycle/agents/*.md
@@ -92,7 +92,7 @@ function warn(file: string, check: string, msg: string, fix?: string) {
 
 // Normalize content: strip BOM and normalize line endings
 function normalizeContent(raw: string): string {
-  return raw.replace(/^﻿/, '').replace(/\r\n/g, '\n').replace(/\r/g, '\n');
+  return raw.replace(/^\uFEFF/, '').replace(/\r\n/g, '\n').replace(/\r/g, '\n');
 }
 
 // Parse frontmatter fields from markdown

--- a/scripts/validate-skills.ts
+++ b/scripts/validate-skills.ts
@@ -1,7 +1,7 @@
 #!/usr/bin/env bun
 /**
  * Skill Lifecycle Validation Script
- * @version 1.0.2
+ * @version 1.0.3
  */
 // Validates skills/*/SKILL.md files for required frontmatter
 // and checks governance records in docs/lifecycle/skills/*.md
@@ -87,7 +87,7 @@ function warn(file: string, check: string, msg: string, fix?: string) {
 
 // Normalize content: strip BOM and normalize line endings
 function normalizeContent(raw: string): string {
-  return raw.replace(/^﻿/, '').replace(/\r\n/g, '\n').replace(/\r/g, '\n');
+  return raw.replace(/^\uFEFF/, '').replace(/\r\n/g, '\n').replace(/\r/g, '\n');
 }
 
 // Parse frontmatter fields from markdown

--- a/scripts/validate-templates.ts
+++ b/scripts/validate-templates.ts
@@ -1,7 +1,7 @@
 #!/usr/bin/env bun
 /**
  * Template Lifecycle Validation Script
- * @version 1.5.14
+ * @version 1.5.15
  *
  * Validates template variants for structural integrity.
  * Follows the same pattern as agent-lifecycle-audit.ts
@@ -373,7 +373,7 @@ function checkVariantManifests(): Map<string, VariantManifest> {
 
 // Normalize content: strip BOM and normalize line endings
 function normalizeContent(raw: string): string {
-  return raw.replace(/^﻿/, '').replace(/\r\n/g, '\n').replace(/\r/g, '\n');
+  return raw.replace(/^\uFEFF/, '').replace(/\r\n/g, '\n').replace(/\r/g, '\n');
 }
 
 // Parse frontmatter fields from markdown (handles BOM, CRLF, multi-line values, YAML blocks, @resolved-from: header)

--- a/templates/common/scripts/SCRIPTS.md
+++ b/templates/common/scripts/SCRIPTS.md
@@ -174,12 +174,12 @@ bun run <alias>                     # via package.json alias (preferred for CI)
 | `ticket.ts` | L0 | 1.0.0 | active | —| —| L0 | —|
 | `upgrade-project.ts` | L0 | 1.7.0 | active | `--variant`, `--platform`, `--dry-run`, `--prune-removed`, `--rollback` | —| L0 | —|
 | `variant-feature.ts` | L0 | 1.0.0 | active | `--variant`, `--feature`, `--type` | —| L0 | —|
-| `validate-agents.ts` | L0 | 1.0.1 | active | —| —| L0+L1 | —|
+| `validate-agents.ts` | L0 | 1.0.2 | active | —| —| L0+L1 | —|
 | `validate-doc-folder.ts` | L0 | 1.0.0 | active | —| —| L0+L1 | —|
 | `validate-docs-links.ts` | L0 | 1.0.0 | active | —| —| L0+L1 | —|
 | `validate-md-language.ts` | L0 | 1.4.4 | active | —| —| L0+L1 | —|
 | `validate-model-registry.ts` | L0 | 1.0.3 | active | —| —| L0+L1 | —|
-| `validate-skills.ts` | L0 | 1.0.2 | active | —| —| L0+L1 | —|
+| `validate-skills.ts` | L0 | 1.0.3 | active | —| —| L0+L1 | —|
 | `validate-templates.ts` | L0 | 1.5.13 | active | —| —| L0 | —|
 | `verify-agent-deliverables.ts` | L0 | 1.0.1 | active | —| —| L0+L1 | —|
 | `verify-memory.ts` | L0 | 1.0.1 | active | —| —| L0+L1 | —|

--- a/templates/common/scripts/validate-agents.ts
+++ b/templates/common/scripts/validate-agents.ts
@@ -1,7 +1,7 @@
 #!/usr/bin/env bun
 /**
  * Agent Lifecycle Validation Script
- * @version 1.0.1
+ * @version 1.0.2
  *
  * Validates all agents/*.md files for required lifecycle frontmatter
  * and checks governance records in docs/lifecycle/agents/*.md
@@ -92,7 +92,7 @@ function warn(file: string, check: string, msg: string, fix?: string) {
 
 // Normalize content: strip BOM and normalize line endings
 function normalizeContent(raw: string): string {
-  return raw.replace(/^﻿/, '').replace(/\r\n/g, '\n').replace(/\r/g, '\n');
+  return raw.replace(/^\uFEFF/, '').replace(/\r\n/g, '\n').replace(/\r/g, '\n');
 }
 
 // Parse frontmatter fields from markdown

--- a/templates/common/scripts/validate-skills.ts
+++ b/templates/common/scripts/validate-skills.ts
@@ -1,7 +1,7 @@
 #!/usr/bin/env bun
 /**
  * Skill Lifecycle Validation Script
- * @version 1.0.2
+ * @version 1.0.3
  */
 // Validates skills/*/SKILL.md files for required frontmatter
 // and checks governance records in docs/lifecycle/skills/*.md
@@ -87,7 +87,7 @@ function warn(file: string, check: string, msg: string, fix?: string) {
 
 // Normalize content: strip BOM and normalize line endings
 function normalizeContent(raw: string): string {
-  return raw.replace(/^﻿/, '').replace(/\r\n/g, '\n').replace(/\r/g, '\n');
+  return raw.replace(/^\uFEFF/, '').replace(/\r\n/g, '\n').replace(/\r/g, '\n');
 }
 
 // Parse frontmatter fields from markdown


### PR DESCRIPTION
## Why
Enforce UTF-8 without BOM and LF line endings across the entire workspace repository (Risk #3 & ADR-0021), resolving CRLF, mixed line endings, and literal zero-width U+FEFF characters in source files.

## What Changed
- Normalized line endings across 101 tracked text files from CRLF/mixed to LF.
- Replaced 6 literal zero-width U+FEFF characters in `normalizeContent()` regexes with explicit `\uFEFF` escape strings (`scripts/validate-agents.ts`, `validate-skills.ts`, `validate-templates.ts`, `skill-dependency-analysis.ts` + L1 mirrors).
- Updated `CHANGELOG.md` and `memory/2026-08-07.md`.

## Test Plan
- [x] `bun scripts/scratch/scan-encoding.ts` passes cleanly (0 BOM, 0 CRLF, 0 zero-width)
- [x] `bun scripts/validate-templates.ts` passes cleanly (0 errors)
- [x] `bun scripts/audit.ts` passes cleanly (all checks passed)

## Security Checklist
- [x] No secrets, credentials, or API keys committed
- [x] No `.env` files staged
- [x] Dependencies unchanged or reviewed for new CVEs

## Notes
None
