### PR TITLE
refactor(skills): add layer context auto-detection (L0 vs L1/L2) to update-bun-packages skill v1.1.0

### DIFF
--- a/.agents/skills/update-bun-packages/SKILL.md
+++ b/.agents/skills/update-bun-packages/SKILL.md
@@ -3,11 +3,11 @@ name: update-bun-packages
 status: active
 scope: common
 description: >
-  Scans, updates, and upgrades Bun dependencies and packages across the AI workspace,
-  templates/common, and template variants while ensuring lockfile consistency and security compliance.
+  Scans, updates, and upgrades Bun dependencies and packages across the AI workspace (L0)
+  or standalone project (L1/L2) while ensuring lockfile consistency and security compliance.
   Use when: updating bun dependencies, upgrading packages, checking outdated packages in workspace or templates.
 owner: pm
-version: 1.0.0
+version: 1.1.0
 last_reviewed: 2026-08-07
 metadata:
   type: process
@@ -21,13 +21,10 @@ metadata:
 
 ## Overview
 
-This skill provides a structured methodology for auditing, updating, and upgrading Bun packages and dependencies across all layers of the workspace hierarchy:
-- **Tier 1 (Workspace Root)**: `package.json` and `bun.lock` in the workspace root (`c:\git\ai_workspace\`).
-- **Tier 2 (Common Template)**: `templates/common/package.json`.
-- **Tier 2 Variant Overlays**: `templates/co-*/package.json` (e.g. `templates/co-deck/package.json`).
-- **Tier 3 (Generated Projects)**: `Projects/*/package.json`.
+This skill provides a layer-aware methodology for auditing, updating, and upgrading Bun packages and dependencies. It automatically detects whether it is running in **L0 (Workspace Maintainer)** or **L1/L2 (Standalone Project)** context and adapts its scope accordingly:
 
-It ensures non-breaking semver updates pass through smoothly, major version upgrades undergo compatibility review, and security/license compliance is maintained throughout the update cycle.
+- **L0 Mode (Workspace Maintainer)**: Audits workspace root `package.json`, `templates/common/package.json`, and variant overlay `templates/co-*/package.json`, then propagates changes via `bun run propagate:apply`.
+- **L1/L2 Mode (Standalone Project)**: Audits local project `./package.json` (and `./scripts/package.json` if present) without referencing non-existent template paths or attempting L0-only template propagation.
 
 ---
 
@@ -35,20 +32,48 @@ It ensures non-breaking semver updates pass through smoothly, major version upgr
 
 - **Routine Maintenance**: Regular dependency updates (patch & minor releases).
 - **Security Patches**: Upgrading vulnerable packages reported by security advisories (`gitleaks`, `bun audit`, CVEs).
-- **Template Synchronization**: Aligning package versions between workspace root (`package.json`) and `templates/common/package.json`.
-- **Bun Version Upgrades**: Refreshing `@types/bun` or `bun-types` after upgrading Bun runtime.
+- **Template Synchronization (L0 Mode)**: Aligning package versions between workspace root (`package.json`) and `templates/common/package.json`.
+- **Project Dependency Refresh (L1/L2 Mode)**: Refreshing dependencies in scaffolded or variant-based projects.
+
+---
+
+## Step 0: Layer Context Auto-Detection
+
+Before scanning, determine the execution context by checking for the existence of `templates/common/`:
+
+```bash
+# Check execution layer
+if [ -d "templates/common" ]; then
+  MODE="L0_WORKSPACE_ROOT"
+else
+  MODE="L1_L2_STANDALONE_PROJECT"
+fi
+```
+
+- **If `MODE == L0_WORKSPACE_ROOT`**: Follow L0 Workspace Root steps below.
+- **If `MODE == L1_L2_STANDALONE_PROJECT`**: Follow L1/L2 Standalone Project steps below.
 
 ---
 
 ## Step 1: Scan & Audit Outdated Packages
 
-1. **Locate Target `package.json` Files**:
-   - Workspace Root: `package.json`
-   - Common Template: `templates/common/package.json`
-   - Variant Overlays: `templates/co-*/package.json`
+### L0 Workspace Root Mode
+1. **Target Locations**:
+   - Workspace Root: `./package.json`
+   - Common Template: `./templates/common/package.json`
+   - Variant Overlays: `./templates/co-*/package.json`
 
-2. **Check for Outdated Dependencies**:
-   Run `bun outdated` in the workspace root or inspect target directories:
+2. **Run Outdated Scan**:
+   ```bash
+   $OutputEncoding = [Console]::OutputEncoding = [System.Text.Encoding]::UTF8; bun outdated
+   ```
+
+### L1/L2 Standalone Project Mode
+1. **Target Locations**:
+   - Project Root: `./package.json`
+   - Script Subdirectory (if present): `./scripts/package.json`
+
+2. **Run Outdated Scan**:
    ```bash
    $OutputEncoding = [Console]::OutputEncoding = [System.Text.Encoding]::UTF8; bun outdated
    ```
@@ -56,69 +81,79 @@ It ensures non-breaking semver updates pass through smoothly, major version upgr
 3. **Categorize Update Types**:
    - **Patch updates** (`x.y.Z` → `x.y.Z+1`): Bug fixes, non-breaking. Auto-approved.
    - **Minor updates** (`x.Y.z` → `x.Y+1.z`): New features, backward-compatible. Auto-approved after testing.
-   - **Major updates** (`X.y.z` → `X+1.y.z`): Breaking API changes. Require manual review and code updates.
+   - **Major updates** (`X.y.z` → `X+1.y.z`): Breaking API changes. Require manual code compatibility review.
 
 ---
 
 ## Step 2: Security & Compatibility Assessment
 
 1. **License Audit**:
-   Ensure all new or updated packages use OSI-approved licenses (MIT, Apache-2.0, BSD-2-Clause, BSD-3-Clause, ISC, MPL-2.0, LGPL-2.1+). Avoid GPL-3.0/AGPL-3.0/SSPL unless explicitly authorized per Coding Guidelines §8.5.
+   Ensure all new or updated packages use OSI-approved licenses (MIT, Apache-2.0, BSD-2-Clause, BSD-3-Clause, ISC, MPL-2.0, LGPL-2.1+). Avoid GPL-3.0/AGPL-3.0/SSPL per Coding Guidelines §8.5.
 
-2. **Core Workspace Contracts**:
-   Preserve essential workspace dependencies:
+2. **Core System Contracts**:
+   Preserve essential type safety and build tooling:
    - `bun-types` / `@types/node` (TypeScript type safety)
    - `js-yaml` (YAML frontmatter parsing)
    - `gitleaks` (Secret scanning)
 
 3. **Breaking Change Verification**:
-   If upgrading major versions, search the codebase for imports of the target package using `grep_search` to verify function signatures and API compatibility before editing `package.json`.
+   If upgrading major versions, search for target package imports using `grep_search` to verify API compatibility before modifying `package.json`.
 
 ---
 
 ## Step 3: Execute Package Updates & Lockfile Sync
 
+### L0 Workspace Root Mode
 1. **Execute Bun Update**:
-   - For workspace root:
-     ```bash
-     $OutputEncoding = [Console]::OutputEncoding = [System.Text.Encoding]::UTF8; bun update
-     ```
-   - For specific package upgrades:
-     ```bash
-     $OutputEncoding = [Console]::OutputEncoding = [System.Text.Encoding]::UTF8; bun add <package-name>@latest
-     ```
-
-2. **Sync `templates/common/package.json`**:
-   Ensure dependencies shared between workspace root and `templates/common/package.json` maintain version alignment.
-
+   ```bash
+   $OutputEncoding = [Console]::OutputEncoding = [System.Text.Encoding]::UTF8; bun update
+   ```
+2. **Align Common Template**:
+   Sync shared dependency version strings in `./templates/common/package.json`.
 3. **Propagate to Templates**:
-   Run the propagation tool to copy updated scripts and settings to `templates/common/`:
    ```bash
    $OutputEncoding = [Console]::OutputEncoding = [System.Text.Encoding]::UTF8; bun run propagate:apply
    ```
+
+### L1/L2 Standalone Project Mode
+1. **Execute Bun Update**:
+   ```bash
+   $OutputEncoding = [Console]::OutputEncoding = [System.Text.Encoding]::UTF8; bun update
+   ```
+2. **Lockfile Refresh**:
+   ```bash
+   $OutputEncoding = [Console]::OutputEncoding = [System.Text.Encoding]::UTF8; bun install
+   ```
+3. *(Skip L0 `propagate:apply` — L1/L2 projects operate independently).*
 
 ---
 
 ## Step 4: Verification & Quality Gate
 
-1. **Run Workspace Audit**:
-   Verify documentation, script versions, and platform parity:
+### L0 Workspace Root Mode
+1. Run full workspace audit:
    ```bash
    $OutputEncoding = [Console]::OutputEncoding = [System.Text.Encoding]::UTF8; bun scripts/audit.ts
    ```
-
-2. **Run Template Validation**:
+2. Validate template integrity:
    ```bash
    $OutputEncoding = [Console]::OutputEncoding = [System.Text.Encoding]::UTF8; bun scripts/validate-templates.ts
    ```
-
-3. **Run Integration Tests**:
+3. Run integration test suite:
    ```bash
    $OutputEncoding = [Console]::OutputEncoding = [System.Text.Encoding]::UTF8; bun test
    ```
-
-4. **Execute `/sync` Pipeline**:
-   Commit, push, and open a PR for the package updates:
+4. Execute `/sync` pipeline:
    ```bash
    $OutputEncoding = [Console]::OutputEncoding = [System.Text.Encoding]::UTF8; bun scripts/dev-sync.ts --body-file ".git/sync-pr-body.md" "chore(deps): update bun packages and sync templates"
+   ```
+
+### L1/L2 Standalone Project Mode
+1. Run local project QA gate / tests:
+   ```bash
+   $OutputEncoding = [Console]::OutputEncoding = [System.Text.Encoding]::UTF8; bun test
+   ```
+2. Execute local `/sync` pipeline:
+   ```bash
+   $OutputEncoding = [Console]::OutputEncoding = [System.Text.Encoding]::UTF8; bun scripts/dev-sync.ts --body-file ".git/sync-pr-body.md" "chore(deps): update bun packages"
    ```

--- a/.claude/skills/update-bun-packages/SKILL.md
+++ b/.claude/skills/update-bun-packages/SKILL.md
@@ -3,11 +3,11 @@ name: update-bun-packages
 status: active
 scope: common
 description: >
-  Scans, updates, and upgrades Bun dependencies and packages across the AI workspace,
-  templates/common, and template variants while ensuring lockfile consistency and security compliance.
+  Scans, updates, and upgrades Bun dependencies and packages across the AI workspace (L0)
+  or standalone project (L1/L2) while ensuring lockfile consistency and security compliance.
   Use when: updating bun dependencies, upgrading packages, checking outdated packages in workspace or templates.
 owner: pm
-version: 1.0.0
+version: 1.1.0
 last_reviewed: 2026-08-07
 metadata:
   type: process
@@ -21,13 +21,10 @@ metadata:
 
 ## Overview
 
-This skill provides a structured methodology for auditing, updating, and upgrading Bun packages and dependencies across all layers of the workspace hierarchy:
-- **Tier 1 (Workspace Root)**: `package.json` and `bun.lock` in the workspace root (`c:\git\ai_workspace\`).
-- **Tier 2 (Common Template)**: `templates/common/package.json`.
-- **Tier 2 Variant Overlays**: `templates/co-*/package.json` (e.g. `templates/co-deck/package.json`).
-- **Tier 3 (Generated Projects)**: `Projects/*/package.json`.
+This skill provides a layer-aware methodology for auditing, updating, and upgrading Bun packages and dependencies. It automatically detects whether it is running in **L0 (Workspace Maintainer)** or **L1/L2 (Standalone Project)** context and adapts its scope accordingly:
 
-It ensures non-breaking semver updates pass through smoothly, major version upgrades undergo compatibility review, and security/license compliance is maintained throughout the update cycle.
+- **L0 Mode (Workspace Maintainer)**: Audits workspace root `package.json`, `templates/common/package.json`, and variant overlay `templates/co-*/package.json`, then propagates changes via `bun run propagate:apply`.
+- **L1/L2 Mode (Standalone Project)**: Audits local project `./package.json` (and `./scripts/package.json` if present) without referencing non-existent template paths or attempting L0-only template propagation.
 
 ---
 
@@ -35,20 +32,48 @@ It ensures non-breaking semver updates pass through smoothly, major version upgr
 
 - **Routine Maintenance**: Regular dependency updates (patch & minor releases).
 - **Security Patches**: Upgrading vulnerable packages reported by security advisories (`gitleaks`, `bun audit`, CVEs).
-- **Template Synchronization**: Aligning package versions between workspace root (`package.json`) and `templates/common/package.json`.
-- **Bun Version Upgrades**: Refreshing `@types/bun` or `bun-types` after upgrading Bun runtime.
+- **Template Synchronization (L0 Mode)**: Aligning package versions between workspace root (`package.json`) and `templates/common/package.json`.
+- **Project Dependency Refresh (L1/L2 Mode)**: Refreshing dependencies in scaffolded or variant-based projects.
+
+---
+
+## Step 0: Layer Context Auto-Detection
+
+Before scanning, determine the execution context by checking for the existence of `templates/common/`:
+
+```bash
+# Check execution layer
+if [ -d "templates/common" ]; then
+  MODE="L0_WORKSPACE_ROOT"
+else
+  MODE="L1_L2_STANDALONE_PROJECT"
+fi
+```
+
+- **If `MODE == L0_WORKSPACE_ROOT`**: Follow L0 Workspace Root steps below.
+- **If `MODE == L1_L2_STANDALONE_PROJECT`**: Follow L1/L2 Standalone Project steps below.
 
 ---
 
 ## Step 1: Scan & Audit Outdated Packages
 
-1. **Locate Target `package.json` Files**:
-   - Workspace Root: `package.json`
-   - Common Template: `templates/common/package.json`
-   - Variant Overlays: `templates/co-*/package.json`
+### L0 Workspace Root Mode
+1. **Target Locations**:
+   - Workspace Root: `./package.json`
+   - Common Template: `./templates/common/package.json`
+   - Variant Overlays: `./templates/co-*/package.json`
 
-2. **Check for Outdated Dependencies**:
-   Run `bun outdated` in the workspace root or inspect target directories:
+2. **Run Outdated Scan**:
+   ```bash
+   $OutputEncoding = [Console]::OutputEncoding = [System.Text.Encoding]::UTF8; bun outdated
+   ```
+
+### L1/L2 Standalone Project Mode
+1. **Target Locations**:
+   - Project Root: `./package.json`
+   - Script Subdirectory (if present): `./scripts/package.json`
+
+2. **Run Outdated Scan**:
    ```bash
    $OutputEncoding = [Console]::OutputEncoding = [System.Text.Encoding]::UTF8; bun outdated
    ```
@@ -56,69 +81,79 @@ It ensures non-breaking semver updates pass through smoothly, major version upgr
 3. **Categorize Update Types**:
    - **Patch updates** (`x.y.Z` → `x.y.Z+1`): Bug fixes, non-breaking. Auto-approved.
    - **Minor updates** (`x.Y.z` → `x.Y+1.z`): New features, backward-compatible. Auto-approved after testing.
-   - **Major updates** (`X.y.z` → `X+1.y.z`): Breaking API changes. Require manual review and code updates.
+   - **Major updates** (`X.y.z` → `X+1.y.z`): Breaking API changes. Require manual code compatibility review.
 
 ---
 
 ## Step 2: Security & Compatibility Assessment
 
 1. **License Audit**:
-   Ensure all new or updated packages use OSI-approved licenses (MIT, Apache-2.0, BSD-2-Clause, BSD-3-Clause, ISC, MPL-2.0, LGPL-2.1+). Avoid GPL-3.0/AGPL-3.0/SSPL unless explicitly authorized per Coding Guidelines §8.5.
+   Ensure all new or updated packages use OSI-approved licenses (MIT, Apache-2.0, BSD-2-Clause, BSD-3-Clause, ISC, MPL-2.0, LGPL-2.1+). Avoid GPL-3.0/AGPL-3.0/SSPL per Coding Guidelines §8.5.
 
-2. **Core Workspace Contracts**:
-   Preserve essential workspace dependencies:
+2. **Core System Contracts**:
+   Preserve essential type safety and build tooling:
    - `bun-types` / `@types/node` (TypeScript type safety)
    - `js-yaml` (YAML frontmatter parsing)
    - `gitleaks` (Secret scanning)
 
 3. **Breaking Change Verification**:
-   If upgrading major versions, search the codebase for imports of the target package using `grep_search` to verify function signatures and API compatibility before editing `package.json`.
+   If upgrading major versions, search for target package imports using `grep_search` to verify API compatibility before modifying `package.json`.
 
 ---
 
 ## Step 3: Execute Package Updates & Lockfile Sync
 
+### L0 Workspace Root Mode
 1. **Execute Bun Update**:
-   - For workspace root:
-     ```bash
-     $OutputEncoding = [Console]::OutputEncoding = [System.Text.Encoding]::UTF8; bun update
-     ```
-   - For specific package upgrades:
-     ```bash
-     $OutputEncoding = [Console]::OutputEncoding = [System.Text.Encoding]::UTF8; bun add <package-name>@latest
-     ```
-
-2. **Sync `templates/common/package.json`**:
-   Ensure dependencies shared between workspace root and `templates/common/package.json` maintain version alignment.
-
+   ```bash
+   $OutputEncoding = [Console]::OutputEncoding = [System.Text.Encoding]::UTF8; bun update
+   ```
+2. **Align Common Template**:
+   Sync shared dependency version strings in `./templates/common/package.json`.
 3. **Propagate to Templates**:
-   Run the propagation tool to copy updated scripts and settings to `templates/common/`:
    ```bash
    $OutputEncoding = [Console]::OutputEncoding = [System.Text.Encoding]::UTF8; bun run propagate:apply
    ```
+
+### L1/L2 Standalone Project Mode
+1. **Execute Bun Update**:
+   ```bash
+   $OutputEncoding = [Console]::OutputEncoding = [System.Text.Encoding]::UTF8; bun update
+   ```
+2. **Lockfile Refresh**:
+   ```bash
+   $OutputEncoding = [Console]::OutputEncoding = [System.Text.Encoding]::UTF8; bun install
+   ```
+3. *(Skip L0 `propagate:apply` — L1/L2 projects operate independently).*
 
 ---
 
 ## Step 4: Verification & Quality Gate
 
-1. **Run Workspace Audit**:
-   Verify documentation, script versions, and platform parity:
+### L0 Workspace Root Mode
+1. Run full workspace audit:
    ```bash
    $OutputEncoding = [Console]::OutputEncoding = [System.Text.Encoding]::UTF8; bun scripts/audit.ts
    ```
-
-2. **Run Template Validation**:
+2. Validate template integrity:
    ```bash
    $OutputEncoding = [Console]::OutputEncoding = [System.Text.Encoding]::UTF8; bun scripts/validate-templates.ts
    ```
-
-3. **Run Integration Tests**:
+3. Run integration test suite:
    ```bash
    $OutputEncoding = [Console]::OutputEncoding = [System.Text.Encoding]::UTF8; bun test
    ```
-
-4. **Execute `/sync` Pipeline**:
-   Commit, push, and open a PR for the package updates:
+4. Execute `/sync` pipeline:
    ```bash
    $OutputEncoding = [Console]::OutputEncoding = [System.Text.Encoding]::UTF8; bun scripts/dev-sync.ts --body-file ".git/sync-pr-body.md" "chore(deps): update bun packages and sync templates"
+   ```
+
+### L1/L2 Standalone Project Mode
+1. Run local project QA gate / tests:
+   ```bash
+   $OutputEncoding = [Console]::OutputEncoding = [System.Text.Encoding]::UTF8; bun test
+   ```
+2. Execute local `/sync` pipeline:
+   ```bash
+   $OutputEncoding = [Console]::OutputEncoding = [System.Text.Encoding]::UTF8; bun scripts/dev-sync.ts --body-file ".git/sync-pr-body.md" "chore(deps): update bun packages"
    ```

--- a/.gemini/skills/update-bun-packages/SKILL.md
+++ b/.gemini/skills/update-bun-packages/SKILL.md
@@ -3,11 +3,11 @@ name: update-bun-packages
 status: active
 scope: common
 description: >
-  Scans, updates, and upgrades Bun dependencies and packages across the AI workspace,
-  templates/common, and template variants while ensuring lockfile consistency and security compliance.
+  Scans, updates, and upgrades Bun dependencies and packages across the AI workspace (L0)
+  or standalone project (L1/L2) while ensuring lockfile consistency and security compliance.
   Use when: updating bun dependencies, upgrading packages, checking outdated packages in workspace or templates.
 owner: pm
-version: 1.0.0
+version: 1.1.0
 last_reviewed: 2026-08-07
 metadata:
   type: process
@@ -21,13 +21,10 @@ metadata:
 
 ## Overview
 
-This skill provides a structured methodology for auditing, updating, and upgrading Bun packages and dependencies across all layers of the workspace hierarchy:
-- **Tier 1 (Workspace Root)**: `package.json` and `bun.lock` in the workspace root (`c:\git\ai_workspace\`).
-- **Tier 2 (Common Template)**: `templates/common/package.json`.
-- **Tier 2 Variant Overlays**: `templates/co-*/package.json` (e.g. `templates/co-deck/package.json`).
-- **Tier 3 (Generated Projects)**: `Projects/*/package.json`.
+This skill provides a layer-aware methodology for auditing, updating, and upgrading Bun packages and dependencies. It automatically detects whether it is running in **L0 (Workspace Maintainer)** or **L1/L2 (Standalone Project)** context and adapts its scope accordingly:
 
-It ensures non-breaking semver updates pass through smoothly, major version upgrades undergo compatibility review, and security/license compliance is maintained throughout the update cycle.
+- **L0 Mode (Workspace Maintainer)**: Audits workspace root `package.json`, `templates/common/package.json`, and variant overlay `templates/co-*/package.json`, then propagates changes via `bun run propagate:apply`.
+- **L1/L2 Mode (Standalone Project)**: Audits local project `./package.json` (and `./scripts/package.json` if present) without referencing non-existent template paths or attempting L0-only template propagation.
 
 ---
 
@@ -35,20 +32,48 @@ It ensures non-breaking semver updates pass through smoothly, major version upgr
 
 - **Routine Maintenance**: Regular dependency updates (patch & minor releases).
 - **Security Patches**: Upgrading vulnerable packages reported by security advisories (`gitleaks`, `bun audit`, CVEs).
-- **Template Synchronization**: Aligning package versions between workspace root (`package.json`) and `templates/common/package.json`.
-- **Bun Version Upgrades**: Refreshing `@types/bun` or `bun-types` after upgrading Bun runtime.
+- **Template Synchronization (L0 Mode)**: Aligning package versions between workspace root (`package.json`) and `templates/common/package.json`.
+- **Project Dependency Refresh (L1/L2 Mode)**: Refreshing dependencies in scaffolded or variant-based projects.
+
+---
+
+## Step 0: Layer Context Auto-Detection
+
+Before scanning, determine the execution context by checking for the existence of `templates/common/`:
+
+```bash
+# Check execution layer
+if [ -d "templates/common" ]; then
+  MODE="L0_WORKSPACE_ROOT"
+else
+  MODE="L1_L2_STANDALONE_PROJECT"
+fi
+```
+
+- **If `MODE == L0_WORKSPACE_ROOT`**: Follow L0 Workspace Root steps below.
+- **If `MODE == L1_L2_STANDALONE_PROJECT`**: Follow L1/L2 Standalone Project steps below.
 
 ---
 
 ## Step 1: Scan & Audit Outdated Packages
 
-1. **Locate Target `package.json` Files**:
-   - Workspace Root: `package.json`
-   - Common Template: `templates/common/package.json`
-   - Variant Overlays: `templates/co-*/package.json`
+### L0 Workspace Root Mode
+1. **Target Locations**:
+   - Workspace Root: `./package.json`
+   - Common Template: `./templates/common/package.json`
+   - Variant Overlays: `./templates/co-*/package.json`
 
-2. **Check for Outdated Dependencies**:
-   Run `bun outdated` in the workspace root or inspect target directories:
+2. **Run Outdated Scan**:
+   ```bash
+   $OutputEncoding = [Console]::OutputEncoding = [System.Text.Encoding]::UTF8; bun outdated
+   ```
+
+### L1/L2 Standalone Project Mode
+1. **Target Locations**:
+   - Project Root: `./package.json`
+   - Script Subdirectory (if present): `./scripts/package.json`
+
+2. **Run Outdated Scan**:
    ```bash
    $OutputEncoding = [Console]::OutputEncoding = [System.Text.Encoding]::UTF8; bun outdated
    ```
@@ -56,69 +81,79 @@ It ensures non-breaking semver updates pass through smoothly, major version upgr
 3. **Categorize Update Types**:
    - **Patch updates** (`x.y.Z` → `x.y.Z+1`): Bug fixes, non-breaking. Auto-approved.
    - **Minor updates** (`x.Y.z` → `x.Y+1.z`): New features, backward-compatible. Auto-approved after testing.
-   - **Major updates** (`X.y.z` → `X+1.y.z`): Breaking API changes. Require manual review and code updates.
+   - **Major updates** (`X.y.z` → `X+1.y.z`): Breaking API changes. Require manual code compatibility review.
 
 ---
 
 ## Step 2: Security & Compatibility Assessment
 
 1. **License Audit**:
-   Ensure all new or updated packages use OSI-approved licenses (MIT, Apache-2.0, BSD-2-Clause, BSD-3-Clause, ISC, MPL-2.0, LGPL-2.1+). Avoid GPL-3.0/AGPL-3.0/SSPL unless explicitly authorized per Coding Guidelines §8.5.
+   Ensure all new or updated packages use OSI-approved licenses (MIT, Apache-2.0, BSD-2-Clause, BSD-3-Clause, ISC, MPL-2.0, LGPL-2.1+). Avoid GPL-3.0/AGPL-3.0/SSPL per Coding Guidelines §8.5.
 
-2. **Core Workspace Contracts**:
-   Preserve essential workspace dependencies:
+2. **Core System Contracts**:
+   Preserve essential type safety and build tooling:
    - `bun-types` / `@types/node` (TypeScript type safety)
    - `js-yaml` (YAML frontmatter parsing)
    - `gitleaks` (Secret scanning)
 
 3. **Breaking Change Verification**:
-   If upgrading major versions, search the codebase for imports of the target package using `grep_search` to verify function signatures and API compatibility before editing `package.json`.
+   If upgrading major versions, search for target package imports using `grep_search` to verify API compatibility before modifying `package.json`.
 
 ---
 
 ## Step 3: Execute Package Updates & Lockfile Sync
 
+### L0 Workspace Root Mode
 1. **Execute Bun Update**:
-   - For workspace root:
-     ```bash
-     $OutputEncoding = [Console]::OutputEncoding = [System.Text.Encoding]::UTF8; bun update
-     ```
-   - For specific package upgrades:
-     ```bash
-     $OutputEncoding = [Console]::OutputEncoding = [System.Text.Encoding]::UTF8; bun add <package-name>@latest
-     ```
-
-2. **Sync `templates/common/package.json`**:
-   Ensure dependencies shared between workspace root and `templates/common/package.json` maintain version alignment.
-
+   ```bash
+   $OutputEncoding = [Console]::OutputEncoding = [System.Text.Encoding]::UTF8; bun update
+   ```
+2. **Align Common Template**:
+   Sync shared dependency version strings in `./templates/common/package.json`.
 3. **Propagate to Templates**:
-   Run the propagation tool to copy updated scripts and settings to `templates/common/`:
    ```bash
    $OutputEncoding = [Console]::OutputEncoding = [System.Text.Encoding]::UTF8; bun run propagate:apply
    ```
+
+### L1/L2 Standalone Project Mode
+1. **Execute Bun Update**:
+   ```bash
+   $OutputEncoding = [Console]::OutputEncoding = [System.Text.Encoding]::UTF8; bun update
+   ```
+2. **Lockfile Refresh**:
+   ```bash
+   $OutputEncoding = [Console]::OutputEncoding = [System.Text.Encoding]::UTF8; bun install
+   ```
+3. *(Skip L0 `propagate:apply` — L1/L2 projects operate independently).*
 
 ---
 
 ## Step 4: Verification & Quality Gate
 
-1. **Run Workspace Audit**:
-   Verify documentation, script versions, and platform parity:
+### L0 Workspace Root Mode
+1. Run full workspace audit:
    ```bash
    $OutputEncoding = [Console]::OutputEncoding = [System.Text.Encoding]::UTF8; bun scripts/audit.ts
    ```
-
-2. **Run Template Validation**:
+2. Validate template integrity:
    ```bash
    $OutputEncoding = [Console]::OutputEncoding = [System.Text.Encoding]::UTF8; bun scripts/validate-templates.ts
    ```
-
-3. **Run Integration Tests**:
+3. Run integration test suite:
    ```bash
    $OutputEncoding = [Console]::OutputEncoding = [System.Text.Encoding]::UTF8; bun test
    ```
-
-4. **Execute `/sync` Pipeline**:
-   Commit, push, and open a PR for the package updates:
+4. Execute `/sync` pipeline:
    ```bash
    $OutputEncoding = [Console]::OutputEncoding = [System.Text.Encoding]::UTF8; bun scripts/dev-sync.ts --body-file ".git/sync-pr-body.md" "chore(deps): update bun packages and sync templates"
+   ```
+
+### L1/L2 Standalone Project Mode
+1. Run local project QA gate / tests:
+   ```bash
+   $OutputEncoding = [Console]::OutputEncoding = [System.Text.Encoding]::UTF8; bun test
+   ```
+2. Execute local `/sync` pipeline:
+   ```bash
+   $OutputEncoding = [Console]::OutputEncoding = [System.Text.Encoding]::UTF8; bun scripts/dev-sync.ts --body-file ".git/sync-pr-body.md" "chore(deps): update bun packages"
    ```

--- a/docs/VERSION_MANIFEST.md
+++ b/docs/VERSION_MANIFEST.md
@@ -1,6 +1,6 @@
 # VERSION_MANIFEST.md
 
-**Generated**: 2026-08-07T01:06:57.714Z
+**Generated**: 2026-08-07T01:12:23.235Z
 **Manifest Version**: 1.0
 **Location**: docs\VERSION_MANIFEST.md
 
@@ -65,7 +65,7 @@
 | team-builder | 1.1.0 | skills/team-builder/SKILL.md | workspace | build new agent team, create agent team, agent team setup, team builder | pm |
 | ticket-run | 1.0.0 | skills/ticket-run/SKILL.md | workspace | ticket-run, process ticket queue, run next ticket | automation-engineer |
 | translate | 1.0.0 | skills/translate/SKILL.md | workspace | translate, translation, localize, Korean translation | pm |
-| update-bun-packages | 1.0.0 | skills/update-bun-packages/SKILL.md | workspace | update bun packages, upgrade bun packages, bun update, update dependencies, upgrade dependencies | pm |
+| update-bun-packages | 1.1.0 | skills/update-bun-packages/SKILL.md | workspace | update bun packages, upgrade bun packages, bun update, update dependencies, upgrade dependencies | pm |
 | upgrade-project | 1.1.0 | skills/upgrade-project/SKILL.md | workspace | upgrade project, upgrade template, sync project with template, refresh project, update project infrastructure | pm |
 | validate-docs-links | 1.0.0 | skills/validate-docs-links/SKILL.md | workspace | validate links, check links, broken links, docs validation | pm |
 | variant-feature | 1.0.0 | skills/variant-feature/SKILL.md | workspace | add feature to variant, extend variant, variant feature, add agent to variant, add skill to variant | scaffolding-expert |

--- a/memory/2026-08-07.md
+++ b/memory/2026-08-07.md
@@ -628,3 +628,24 @@ feat(skills): add update-bun-packages skill for workspace and template dependenc
 
 ## Open Issues
 - None
+
+---
+
+## Session Summary
+refactor(skills): add layer context auto-detection (L0 vs L1/L2) to update-bun-packages skill v1.1.0
+
+## Changes
+- `M .agents/skills/update-bun-packages/SKILL.md` — modified
+- `.claude/skills/update-bun-packages/SKILL.md` — modified
+- `.gemini/skills/update-bun-packages/SKILL.md` — modified
+- `skills/update-bun-packages/SKILL.md` — modified
+- `templates/common/.agents/skills/update-bun-packages/SKILL.md` — modified
+- `templates/common/.claude/skills/update-bun-packages/SKILL.md` — modified
+- `templates/common/.gemini/skills/update-bun-packages/SKILL.md` — modified
+- `templates/common/skills/update-bun-packages/SKILL.md` — modified
+
+## Decisions
+- None
+
+## Open Issues
+- None

--- a/skills/update-bun-packages/SKILL.md
+++ b/skills/update-bun-packages/SKILL.md
@@ -3,11 +3,11 @@ name: update-bun-packages
 status: active
 scope: common
 description: >
-  Scans, updates, and upgrades Bun dependencies and packages across the AI workspace,
-  templates/common, and template variants while ensuring lockfile consistency and security compliance.
+  Scans, updates, and upgrades Bun dependencies and packages across the AI workspace (L0)
+  or standalone project (L1/L2) while ensuring lockfile consistency and security compliance.
   Use when: updating bun dependencies, upgrading packages, checking outdated packages in workspace or templates.
 owner: pm
-version: 1.0.0
+version: 1.1.0
 last_reviewed: 2026-08-07
 metadata:
   type: process
@@ -21,13 +21,10 @@ metadata:
 
 ## Overview
 
-This skill provides a structured methodology for auditing, updating, and upgrading Bun packages and dependencies across all layers of the workspace hierarchy:
-- **Tier 1 (Workspace Root)**: `package.json` and `bun.lock` in the workspace root (`c:\git\ai_workspace\`).
-- **Tier 2 (Common Template)**: `templates/common/package.json`.
-- **Tier 2 Variant Overlays**: `templates/co-*/package.json` (e.g. `templates/co-deck/package.json`).
-- **Tier 3 (Generated Projects)**: `Projects/*/package.json`.
+This skill provides a layer-aware methodology for auditing, updating, and upgrading Bun packages and dependencies. It automatically detects whether it is running in **L0 (Workspace Maintainer)** or **L1/L2 (Standalone Project)** context and adapts its scope accordingly:
 
-It ensures non-breaking semver updates pass through smoothly, major version upgrades undergo compatibility review, and security/license compliance is maintained throughout the update cycle.
+- **L0 Mode (Workspace Maintainer)**: Audits workspace root `package.json`, `templates/common/package.json`, and variant overlay `templates/co-*/package.json`, then propagates changes via `bun run propagate:apply`.
+- **L1/L2 Mode (Standalone Project)**: Audits local project `./package.json` (and `./scripts/package.json` if present) without referencing non-existent template paths or attempting L0-only template propagation.
 
 ---
 
@@ -35,20 +32,48 @@ It ensures non-breaking semver updates pass through smoothly, major version upgr
 
 - **Routine Maintenance**: Regular dependency updates (patch & minor releases).
 - **Security Patches**: Upgrading vulnerable packages reported by security advisories (`gitleaks`, `bun audit`, CVEs).
-- **Template Synchronization**: Aligning package versions between workspace root (`package.json`) and `templates/common/package.json`.
-- **Bun Version Upgrades**: Refreshing `@types/bun` or `bun-types` after upgrading Bun runtime.
+- **Template Synchronization (L0 Mode)**: Aligning package versions between workspace root (`package.json`) and `templates/common/package.json`.
+- **Project Dependency Refresh (L1/L2 Mode)**: Refreshing dependencies in scaffolded or variant-based projects.
+
+---
+
+## Step 0: Layer Context Auto-Detection
+
+Before scanning, determine the execution context by checking for the existence of `templates/common/`:
+
+```bash
+# Check execution layer
+if [ -d "templates/common" ]; then
+  MODE="L0_WORKSPACE_ROOT"
+else
+  MODE="L1_L2_STANDALONE_PROJECT"
+fi
+```
+
+- **If `MODE == L0_WORKSPACE_ROOT`**: Follow L0 Workspace Root steps below.
+- **If `MODE == L1_L2_STANDALONE_PROJECT`**: Follow L1/L2 Standalone Project steps below.
 
 ---
 
 ## Step 1: Scan & Audit Outdated Packages
 
-1. **Locate Target `package.json` Files**:
-   - Workspace Root: `package.json`
-   - Common Template: `templates/common/package.json`
-   - Variant Overlays: `templates/co-*/package.json`
+### L0 Workspace Root Mode
+1. **Target Locations**:
+   - Workspace Root: `./package.json`
+   - Common Template: `./templates/common/package.json`
+   - Variant Overlays: `./templates/co-*/package.json`
 
-2. **Check for Outdated Dependencies**:
-   Run `bun outdated` in the workspace root or inspect target directories:
+2. **Run Outdated Scan**:
+   ```bash
+   $OutputEncoding = [Console]::OutputEncoding = [System.Text.Encoding]::UTF8; bun outdated
+   ```
+
+### L1/L2 Standalone Project Mode
+1. **Target Locations**:
+   - Project Root: `./package.json`
+   - Script Subdirectory (if present): `./scripts/package.json`
+
+2. **Run Outdated Scan**:
    ```bash
    $OutputEncoding = [Console]::OutputEncoding = [System.Text.Encoding]::UTF8; bun outdated
    ```
@@ -56,69 +81,79 @@ It ensures non-breaking semver updates pass through smoothly, major version upgr
 3. **Categorize Update Types**:
    - **Patch updates** (`x.y.Z` → `x.y.Z+1`): Bug fixes, non-breaking. Auto-approved.
    - **Minor updates** (`x.Y.z` → `x.Y+1.z`): New features, backward-compatible. Auto-approved after testing.
-   - **Major updates** (`X.y.z` → `X+1.y.z`): Breaking API changes. Require manual review and code updates.
+   - **Major updates** (`X.y.z` → `X+1.y.z`): Breaking API changes. Require manual code compatibility review.
 
 ---
 
 ## Step 2: Security & Compatibility Assessment
 
 1. **License Audit**:
-   Ensure all new or updated packages use OSI-approved licenses (MIT, Apache-2.0, BSD-2-Clause, BSD-3-Clause, ISC, MPL-2.0, LGPL-2.1+). Avoid GPL-3.0/AGPL-3.0/SSPL unless explicitly authorized per Coding Guidelines §8.5.
+   Ensure all new or updated packages use OSI-approved licenses (MIT, Apache-2.0, BSD-2-Clause, BSD-3-Clause, ISC, MPL-2.0, LGPL-2.1+). Avoid GPL-3.0/AGPL-3.0/SSPL per Coding Guidelines §8.5.
 
-2. **Core Workspace Contracts**:
-   Preserve essential workspace dependencies:
+2. **Core System Contracts**:
+   Preserve essential type safety and build tooling:
    - `bun-types` / `@types/node` (TypeScript type safety)
    - `js-yaml` (YAML frontmatter parsing)
    - `gitleaks` (Secret scanning)
 
 3. **Breaking Change Verification**:
-   If upgrading major versions, search the codebase for imports of the target package using `grep_search` to verify function signatures and API compatibility before editing `package.json`.
+   If upgrading major versions, search for target package imports using `grep_search` to verify API compatibility before modifying `package.json`.
 
 ---
 
 ## Step 3: Execute Package Updates & Lockfile Sync
 
+### L0 Workspace Root Mode
 1. **Execute Bun Update**:
-   - For workspace root:
-     ```bash
-     $OutputEncoding = [Console]::OutputEncoding = [System.Text.Encoding]::UTF8; bun update
-     ```
-   - For specific package upgrades:
-     ```bash
-     $OutputEncoding = [Console]::OutputEncoding = [System.Text.Encoding]::UTF8; bun add <package-name>@latest
-     ```
-
-2. **Sync `templates/common/package.json`**:
-   Ensure dependencies shared between workspace root and `templates/common/package.json` maintain version alignment.
-
+   ```bash
+   $OutputEncoding = [Console]::OutputEncoding = [System.Text.Encoding]::UTF8; bun update
+   ```
+2. **Align Common Template**:
+   Sync shared dependency version strings in `./templates/common/package.json`.
 3. **Propagate to Templates**:
-   Run the propagation tool to copy updated scripts and settings to `templates/common/`:
    ```bash
    $OutputEncoding = [Console]::OutputEncoding = [System.Text.Encoding]::UTF8; bun run propagate:apply
    ```
+
+### L1/L2 Standalone Project Mode
+1. **Execute Bun Update**:
+   ```bash
+   $OutputEncoding = [Console]::OutputEncoding = [System.Text.Encoding]::UTF8; bun update
+   ```
+2. **Lockfile Refresh**:
+   ```bash
+   $OutputEncoding = [Console]::OutputEncoding = [System.Text.Encoding]::UTF8; bun install
+   ```
+3. *(Skip L0 `propagate:apply` — L1/L2 projects operate independently).*
 
 ---
 
 ## Step 4: Verification & Quality Gate
 
-1. **Run Workspace Audit**:
-   Verify documentation, script versions, and platform parity:
+### L0 Workspace Root Mode
+1. Run full workspace audit:
    ```bash
    $OutputEncoding = [Console]::OutputEncoding = [System.Text.Encoding]::UTF8; bun scripts/audit.ts
    ```
-
-2. **Run Template Validation**:
+2. Validate template integrity:
    ```bash
    $OutputEncoding = [Console]::OutputEncoding = [System.Text.Encoding]::UTF8; bun scripts/validate-templates.ts
    ```
-
-3. **Run Integration Tests**:
+3. Run integration test suite:
    ```bash
    $OutputEncoding = [Console]::OutputEncoding = [System.Text.Encoding]::UTF8; bun test
    ```
-
-4. **Execute `/sync` Pipeline**:
-   Commit, push, and open a PR for the package updates:
+4. Execute `/sync` pipeline:
    ```bash
    $OutputEncoding = [Console]::OutputEncoding = [System.Text.Encoding]::UTF8; bun scripts/dev-sync.ts --body-file ".git/sync-pr-body.md" "chore(deps): update bun packages and sync templates"
+   ```
+
+### L1/L2 Standalone Project Mode
+1. Run local project QA gate / tests:
+   ```bash
+   $OutputEncoding = [Console]::OutputEncoding = [System.Text.Encoding]::UTF8; bun test
+   ```
+2. Execute local `/sync` pipeline:
+   ```bash
+   $OutputEncoding = [Console]::OutputEncoding = [System.Text.Encoding]::UTF8; bun scripts/dev-sync.ts --body-file ".git/sync-pr-body.md" "chore(deps): update bun packages"
    ```

--- a/templates/common/.agents/skills/update-bun-packages/SKILL.md
+++ b/templates/common/.agents/skills/update-bun-packages/SKILL.md
@@ -3,11 +3,11 @@ name: update-bun-packages
 status: active
 scope: common
 description: >
-  Scans, updates, and upgrades Bun dependencies and packages across the AI workspace,
-  templates/common, and template variants while ensuring lockfile consistency and security compliance.
+  Scans, updates, and upgrades Bun dependencies and packages across the AI workspace (L0)
+  or standalone project (L1/L2) while ensuring lockfile consistency and security compliance.
   Use when: updating bun dependencies, upgrading packages, checking outdated packages in workspace or templates.
 owner: pm
-version: 1.0.0
+version: 1.1.0
 last_reviewed: 2026-08-07
 metadata:
   type: process
@@ -21,13 +21,10 @@ metadata:
 
 ## Overview
 
-This skill provides a structured methodology for auditing, updating, and upgrading Bun packages and dependencies across all layers of the workspace hierarchy:
-- **Tier 1 (Workspace Root)**: `package.json` and `bun.lock` in the workspace root (`c:\git\ai_workspace\`).
-- **Tier 2 (Common Template)**: `templates/common/package.json`.
-- **Tier 2 Variant Overlays**: `templates/co-*/package.json` (e.g. `templates/co-deck/package.json`).
-- **Tier 3 (Generated Projects)**: `Projects/*/package.json`.
+This skill provides a layer-aware methodology for auditing, updating, and upgrading Bun packages and dependencies. It automatically detects whether it is running in **L0 (Workspace Maintainer)** or **L1/L2 (Standalone Project)** context and adapts its scope accordingly:
 
-It ensures non-breaking semver updates pass through smoothly, major version upgrades undergo compatibility review, and security/license compliance is maintained throughout the update cycle.
+- **L0 Mode (Workspace Maintainer)**: Audits workspace root `package.json`, `templates/common/package.json`, and variant overlay `templates/co-*/package.json`, then propagates changes via `bun run propagate:apply`.
+- **L1/L2 Mode (Standalone Project)**: Audits local project `./package.json` (and `./scripts/package.json` if present) without referencing non-existent template paths or attempting L0-only template propagation.
 
 ---
 
@@ -35,20 +32,48 @@ It ensures non-breaking semver updates pass through smoothly, major version upgr
 
 - **Routine Maintenance**: Regular dependency updates (patch & minor releases).
 - **Security Patches**: Upgrading vulnerable packages reported by security advisories (`gitleaks`, `bun audit`, CVEs).
-- **Template Synchronization**: Aligning package versions between workspace root (`package.json`) and `templates/common/package.json`.
-- **Bun Version Upgrades**: Refreshing `@types/bun` or `bun-types` after upgrading Bun runtime.
+- **Template Synchronization (L0 Mode)**: Aligning package versions between workspace root (`package.json`) and `templates/common/package.json`.
+- **Project Dependency Refresh (L1/L2 Mode)**: Refreshing dependencies in scaffolded or variant-based projects.
+
+---
+
+## Step 0: Layer Context Auto-Detection
+
+Before scanning, determine the execution context by checking for the existence of `templates/common/`:
+
+```bash
+# Check execution layer
+if [ -d "templates/common" ]; then
+  MODE="L0_WORKSPACE_ROOT"
+else
+  MODE="L1_L2_STANDALONE_PROJECT"
+fi
+```
+
+- **If `MODE == L0_WORKSPACE_ROOT`**: Follow L0 Workspace Root steps below.
+- **If `MODE == L1_L2_STANDALONE_PROJECT`**: Follow L1/L2 Standalone Project steps below.
 
 ---
 
 ## Step 1: Scan & Audit Outdated Packages
 
-1. **Locate Target `package.json` Files**:
-   - Workspace Root: `package.json`
-   - Common Template: `templates/common/package.json`
-   - Variant Overlays: `templates/co-*/package.json`
+### L0 Workspace Root Mode
+1. **Target Locations**:
+   - Workspace Root: `./package.json`
+   - Common Template: `./templates/common/package.json`
+   - Variant Overlays: `./templates/co-*/package.json`
 
-2. **Check for Outdated Dependencies**:
-   Run `bun outdated` in the workspace root or inspect target directories:
+2. **Run Outdated Scan**:
+   ```bash
+   $OutputEncoding = [Console]::OutputEncoding = [System.Text.Encoding]::UTF8; bun outdated
+   ```
+
+### L1/L2 Standalone Project Mode
+1. **Target Locations**:
+   - Project Root: `./package.json`
+   - Script Subdirectory (if present): `./scripts/package.json`
+
+2. **Run Outdated Scan**:
    ```bash
    $OutputEncoding = [Console]::OutputEncoding = [System.Text.Encoding]::UTF8; bun outdated
    ```
@@ -56,69 +81,79 @@ It ensures non-breaking semver updates pass through smoothly, major version upgr
 3. **Categorize Update Types**:
    - **Patch updates** (`x.y.Z` → `x.y.Z+1`): Bug fixes, non-breaking. Auto-approved.
    - **Minor updates** (`x.Y.z` → `x.Y+1.z`): New features, backward-compatible. Auto-approved after testing.
-   - **Major updates** (`X.y.z` → `X+1.y.z`): Breaking API changes. Require manual review and code updates.
+   - **Major updates** (`X.y.z` → `X+1.y.z`): Breaking API changes. Require manual code compatibility review.
 
 ---
 
 ## Step 2: Security & Compatibility Assessment
 
 1. **License Audit**:
-   Ensure all new or updated packages use OSI-approved licenses (MIT, Apache-2.0, BSD-2-Clause, BSD-3-Clause, ISC, MPL-2.0, LGPL-2.1+). Avoid GPL-3.0/AGPL-3.0/SSPL unless explicitly authorized per Coding Guidelines §8.5.
+   Ensure all new or updated packages use OSI-approved licenses (MIT, Apache-2.0, BSD-2-Clause, BSD-3-Clause, ISC, MPL-2.0, LGPL-2.1+). Avoid GPL-3.0/AGPL-3.0/SSPL per Coding Guidelines §8.5.
 
-2. **Core Workspace Contracts**:
-   Preserve essential workspace dependencies:
+2. **Core System Contracts**:
+   Preserve essential type safety and build tooling:
    - `bun-types` / `@types/node` (TypeScript type safety)
    - `js-yaml` (YAML frontmatter parsing)
    - `gitleaks` (Secret scanning)
 
 3. **Breaking Change Verification**:
-   If upgrading major versions, search the codebase for imports of the target package using `grep_search` to verify function signatures and API compatibility before editing `package.json`.
+   If upgrading major versions, search for target package imports using `grep_search` to verify API compatibility before modifying `package.json`.
 
 ---
 
 ## Step 3: Execute Package Updates & Lockfile Sync
 
+### L0 Workspace Root Mode
 1. **Execute Bun Update**:
-   - For workspace root:
-     ```bash
-     $OutputEncoding = [Console]::OutputEncoding = [System.Text.Encoding]::UTF8; bun update
-     ```
-   - For specific package upgrades:
-     ```bash
-     $OutputEncoding = [Console]::OutputEncoding = [System.Text.Encoding]::UTF8; bun add <package-name>@latest
-     ```
-
-2. **Sync `templates/common/package.json`**:
-   Ensure dependencies shared between workspace root and `templates/common/package.json` maintain version alignment.
-
+   ```bash
+   $OutputEncoding = [Console]::OutputEncoding = [System.Text.Encoding]::UTF8; bun update
+   ```
+2. **Align Common Template**:
+   Sync shared dependency version strings in `./templates/common/package.json`.
 3. **Propagate to Templates**:
-   Run the propagation tool to copy updated scripts and settings to `templates/common/`:
    ```bash
    $OutputEncoding = [Console]::OutputEncoding = [System.Text.Encoding]::UTF8; bun run propagate:apply
    ```
+
+### L1/L2 Standalone Project Mode
+1. **Execute Bun Update**:
+   ```bash
+   $OutputEncoding = [Console]::OutputEncoding = [System.Text.Encoding]::UTF8; bun update
+   ```
+2. **Lockfile Refresh**:
+   ```bash
+   $OutputEncoding = [Console]::OutputEncoding = [System.Text.Encoding]::UTF8; bun install
+   ```
+3. *(Skip L0 `propagate:apply` — L1/L2 projects operate independently).*
 
 ---
 
 ## Step 4: Verification & Quality Gate
 
-1. **Run Workspace Audit**:
-   Verify documentation, script versions, and platform parity:
+### L0 Workspace Root Mode
+1. Run full workspace audit:
    ```bash
    $OutputEncoding = [Console]::OutputEncoding = [System.Text.Encoding]::UTF8; bun scripts/audit.ts
    ```
-
-2. **Run Template Validation**:
+2. Validate template integrity:
    ```bash
    $OutputEncoding = [Console]::OutputEncoding = [System.Text.Encoding]::UTF8; bun scripts/validate-templates.ts
    ```
-
-3. **Run Integration Tests**:
+3. Run integration test suite:
    ```bash
    $OutputEncoding = [Console]::OutputEncoding = [System.Text.Encoding]::UTF8; bun test
    ```
-
-4. **Execute `/sync` Pipeline**:
-   Commit, push, and open a PR for the package updates:
+4. Execute `/sync` pipeline:
    ```bash
    $OutputEncoding = [Console]::OutputEncoding = [System.Text.Encoding]::UTF8; bun scripts/dev-sync.ts --body-file ".git/sync-pr-body.md" "chore(deps): update bun packages and sync templates"
+   ```
+
+### L1/L2 Standalone Project Mode
+1. Run local project QA gate / tests:
+   ```bash
+   $OutputEncoding = [Console]::OutputEncoding = [System.Text.Encoding]::UTF8; bun test
+   ```
+2. Execute local `/sync` pipeline:
+   ```bash
+   $OutputEncoding = [Console]::OutputEncoding = [System.Text.Encoding]::UTF8; bun scripts/dev-sync.ts --body-file ".git/sync-pr-body.md" "chore(deps): update bun packages"
    ```

--- a/templates/common/.claude/skills/update-bun-packages/SKILL.md
+++ b/templates/common/.claude/skills/update-bun-packages/SKILL.md
@@ -3,11 +3,11 @@ name: update-bun-packages
 status: active
 scope: common
 description: >
-  Scans, updates, and upgrades Bun dependencies and packages across the AI workspace,
-  templates/common, and template variants while ensuring lockfile consistency and security compliance.
+  Scans, updates, and upgrades Bun dependencies and packages across the AI workspace (L0)
+  or standalone project (L1/L2) while ensuring lockfile consistency and security compliance.
   Use when: updating bun dependencies, upgrading packages, checking outdated packages in workspace or templates.
 owner: pm
-version: 1.0.0
+version: 1.1.0
 last_reviewed: 2026-08-07
 metadata:
   type: process
@@ -21,13 +21,10 @@ metadata:
 
 ## Overview
 
-This skill provides a structured methodology for auditing, updating, and upgrading Bun packages and dependencies across all layers of the workspace hierarchy:
-- **Tier 1 (Workspace Root)**: `package.json` and `bun.lock` in the workspace root (`c:\git\ai_workspace\`).
-- **Tier 2 (Common Template)**: `templates/common/package.json`.
-- **Tier 2 Variant Overlays**: `templates/co-*/package.json` (e.g. `templates/co-deck/package.json`).
-- **Tier 3 (Generated Projects)**: `Projects/*/package.json`.
+This skill provides a layer-aware methodology for auditing, updating, and upgrading Bun packages and dependencies. It automatically detects whether it is running in **L0 (Workspace Maintainer)** or **L1/L2 (Standalone Project)** context and adapts its scope accordingly:
 
-It ensures non-breaking semver updates pass through smoothly, major version upgrades undergo compatibility review, and security/license compliance is maintained throughout the update cycle.
+- **L0 Mode (Workspace Maintainer)**: Audits workspace root `package.json`, `templates/common/package.json`, and variant overlay `templates/co-*/package.json`, then propagates changes via `bun run propagate:apply`.
+- **L1/L2 Mode (Standalone Project)**: Audits local project `./package.json` (and `./scripts/package.json` if present) without referencing non-existent template paths or attempting L0-only template propagation.
 
 ---
 
@@ -35,20 +32,48 @@ It ensures non-breaking semver updates pass through smoothly, major version upgr
 
 - **Routine Maintenance**: Regular dependency updates (patch & minor releases).
 - **Security Patches**: Upgrading vulnerable packages reported by security advisories (`gitleaks`, `bun audit`, CVEs).
-- **Template Synchronization**: Aligning package versions between workspace root (`package.json`) and `templates/common/package.json`.
-- **Bun Version Upgrades**: Refreshing `@types/bun` or `bun-types` after upgrading Bun runtime.
+- **Template Synchronization (L0 Mode)**: Aligning package versions between workspace root (`package.json`) and `templates/common/package.json`.
+- **Project Dependency Refresh (L1/L2 Mode)**: Refreshing dependencies in scaffolded or variant-based projects.
+
+---
+
+## Step 0: Layer Context Auto-Detection
+
+Before scanning, determine the execution context by checking for the existence of `templates/common/`:
+
+```bash
+# Check execution layer
+if [ -d "templates/common" ]; then
+  MODE="L0_WORKSPACE_ROOT"
+else
+  MODE="L1_L2_STANDALONE_PROJECT"
+fi
+```
+
+- **If `MODE == L0_WORKSPACE_ROOT`**: Follow L0 Workspace Root steps below.
+- **If `MODE == L1_L2_STANDALONE_PROJECT`**: Follow L1/L2 Standalone Project steps below.
 
 ---
 
 ## Step 1: Scan & Audit Outdated Packages
 
-1. **Locate Target `package.json` Files**:
-   - Workspace Root: `package.json`
-   - Common Template: `templates/common/package.json`
-   - Variant Overlays: `templates/co-*/package.json`
+### L0 Workspace Root Mode
+1. **Target Locations**:
+   - Workspace Root: `./package.json`
+   - Common Template: `./templates/common/package.json`
+   - Variant Overlays: `./templates/co-*/package.json`
 
-2. **Check for Outdated Dependencies**:
-   Run `bun outdated` in the workspace root or inspect target directories:
+2. **Run Outdated Scan**:
+   ```bash
+   $OutputEncoding = [Console]::OutputEncoding = [System.Text.Encoding]::UTF8; bun outdated
+   ```
+
+### L1/L2 Standalone Project Mode
+1. **Target Locations**:
+   - Project Root: `./package.json`
+   - Script Subdirectory (if present): `./scripts/package.json`
+
+2. **Run Outdated Scan**:
    ```bash
    $OutputEncoding = [Console]::OutputEncoding = [System.Text.Encoding]::UTF8; bun outdated
    ```
@@ -56,69 +81,79 @@ It ensures non-breaking semver updates pass through smoothly, major version upgr
 3. **Categorize Update Types**:
    - **Patch updates** (`x.y.Z` → `x.y.Z+1`): Bug fixes, non-breaking. Auto-approved.
    - **Minor updates** (`x.Y.z` → `x.Y+1.z`): New features, backward-compatible. Auto-approved after testing.
-   - **Major updates** (`X.y.z` → `X+1.y.z`): Breaking API changes. Require manual review and code updates.
+   - **Major updates** (`X.y.z` → `X+1.y.z`): Breaking API changes. Require manual code compatibility review.
 
 ---
 
 ## Step 2: Security & Compatibility Assessment
 
 1. **License Audit**:
-   Ensure all new or updated packages use OSI-approved licenses (MIT, Apache-2.0, BSD-2-Clause, BSD-3-Clause, ISC, MPL-2.0, LGPL-2.1+). Avoid GPL-3.0/AGPL-3.0/SSPL unless explicitly authorized per Coding Guidelines §8.5.
+   Ensure all new or updated packages use OSI-approved licenses (MIT, Apache-2.0, BSD-2-Clause, BSD-3-Clause, ISC, MPL-2.0, LGPL-2.1+). Avoid GPL-3.0/AGPL-3.0/SSPL per Coding Guidelines §8.5.
 
-2. **Core Workspace Contracts**:
-   Preserve essential workspace dependencies:
+2. **Core System Contracts**:
+   Preserve essential type safety and build tooling:
    - `bun-types` / `@types/node` (TypeScript type safety)
    - `js-yaml` (YAML frontmatter parsing)
    - `gitleaks` (Secret scanning)
 
 3. **Breaking Change Verification**:
-   If upgrading major versions, search the codebase for imports of the target package using `grep_search` to verify function signatures and API compatibility before editing `package.json`.
+   If upgrading major versions, search for target package imports using `grep_search` to verify API compatibility before modifying `package.json`.
 
 ---
 
 ## Step 3: Execute Package Updates & Lockfile Sync
 
+### L0 Workspace Root Mode
 1. **Execute Bun Update**:
-   - For workspace root:
-     ```bash
-     $OutputEncoding = [Console]::OutputEncoding = [System.Text.Encoding]::UTF8; bun update
-     ```
-   - For specific package upgrades:
-     ```bash
-     $OutputEncoding = [Console]::OutputEncoding = [System.Text.Encoding]::UTF8; bun add <package-name>@latest
-     ```
-
-2. **Sync `templates/common/package.json`**:
-   Ensure dependencies shared between workspace root and `templates/common/package.json` maintain version alignment.
-
+   ```bash
+   $OutputEncoding = [Console]::OutputEncoding = [System.Text.Encoding]::UTF8; bun update
+   ```
+2. **Align Common Template**:
+   Sync shared dependency version strings in `./templates/common/package.json`.
 3. **Propagate to Templates**:
-   Run the propagation tool to copy updated scripts and settings to `templates/common/`:
    ```bash
    $OutputEncoding = [Console]::OutputEncoding = [System.Text.Encoding]::UTF8; bun run propagate:apply
    ```
+
+### L1/L2 Standalone Project Mode
+1. **Execute Bun Update**:
+   ```bash
+   $OutputEncoding = [Console]::OutputEncoding = [System.Text.Encoding]::UTF8; bun update
+   ```
+2. **Lockfile Refresh**:
+   ```bash
+   $OutputEncoding = [Console]::OutputEncoding = [System.Text.Encoding]::UTF8; bun install
+   ```
+3. *(Skip L0 `propagate:apply` — L1/L2 projects operate independently).*
 
 ---
 
 ## Step 4: Verification & Quality Gate
 
-1. **Run Workspace Audit**:
-   Verify documentation, script versions, and platform parity:
+### L0 Workspace Root Mode
+1. Run full workspace audit:
    ```bash
    $OutputEncoding = [Console]::OutputEncoding = [System.Text.Encoding]::UTF8; bun scripts/audit.ts
    ```
-
-2. **Run Template Validation**:
+2. Validate template integrity:
    ```bash
    $OutputEncoding = [Console]::OutputEncoding = [System.Text.Encoding]::UTF8; bun scripts/validate-templates.ts
    ```
-
-3. **Run Integration Tests**:
+3. Run integration test suite:
    ```bash
    $OutputEncoding = [Console]::OutputEncoding = [System.Text.Encoding]::UTF8; bun test
    ```
-
-4. **Execute `/sync` Pipeline**:
-   Commit, push, and open a PR for the package updates:
+4. Execute `/sync` pipeline:
    ```bash
    $OutputEncoding = [Console]::OutputEncoding = [System.Text.Encoding]::UTF8; bun scripts/dev-sync.ts --body-file ".git/sync-pr-body.md" "chore(deps): update bun packages and sync templates"
+   ```
+
+### L1/L2 Standalone Project Mode
+1. Run local project QA gate / tests:
+   ```bash
+   $OutputEncoding = [Console]::OutputEncoding = [System.Text.Encoding]::UTF8; bun test
+   ```
+2. Execute local `/sync` pipeline:
+   ```bash
+   $OutputEncoding = [Console]::OutputEncoding = [System.Text.Encoding]::UTF8; bun scripts/dev-sync.ts --body-file ".git/sync-pr-body.md" "chore(deps): update bun packages"
    ```

--- a/templates/common/.gemini/skills/update-bun-packages/SKILL.md
+++ b/templates/common/.gemini/skills/update-bun-packages/SKILL.md
@@ -3,11 +3,11 @@ name: update-bun-packages
 status: active
 scope: common
 description: >
-  Scans, updates, and upgrades Bun dependencies and packages across the AI workspace,
-  templates/common, and template variants while ensuring lockfile consistency and security compliance.
+  Scans, updates, and upgrades Bun dependencies and packages across the AI workspace (L0)
+  or standalone project (L1/L2) while ensuring lockfile consistency and security compliance.
   Use when: updating bun dependencies, upgrading packages, checking outdated packages in workspace or templates.
 owner: pm
-version: 1.0.0
+version: 1.1.0
 last_reviewed: 2026-08-07
 metadata:
   type: process
@@ -21,13 +21,10 @@ metadata:
 
 ## Overview
 
-This skill provides a structured methodology for auditing, updating, and upgrading Bun packages and dependencies across all layers of the workspace hierarchy:
-- **Tier 1 (Workspace Root)**: `package.json` and `bun.lock` in the workspace root (`c:\git\ai_workspace\`).
-- **Tier 2 (Common Template)**: `templates/common/package.json`.
-- **Tier 2 Variant Overlays**: `templates/co-*/package.json` (e.g. `templates/co-deck/package.json`).
-- **Tier 3 (Generated Projects)**: `Projects/*/package.json`.
+This skill provides a layer-aware methodology for auditing, updating, and upgrading Bun packages and dependencies. It automatically detects whether it is running in **L0 (Workspace Maintainer)** or **L1/L2 (Standalone Project)** context and adapts its scope accordingly:
 
-It ensures non-breaking semver updates pass through smoothly, major version upgrades undergo compatibility review, and security/license compliance is maintained throughout the update cycle.
+- **L0 Mode (Workspace Maintainer)**: Audits workspace root `package.json`, `templates/common/package.json`, and variant overlay `templates/co-*/package.json`, then propagates changes via `bun run propagate:apply`.
+- **L1/L2 Mode (Standalone Project)**: Audits local project `./package.json` (and `./scripts/package.json` if present) without referencing non-existent template paths or attempting L0-only template propagation.
 
 ---
 
@@ -35,20 +32,48 @@ It ensures non-breaking semver updates pass through smoothly, major version upgr
 
 - **Routine Maintenance**: Regular dependency updates (patch & minor releases).
 - **Security Patches**: Upgrading vulnerable packages reported by security advisories (`gitleaks`, `bun audit`, CVEs).
-- **Template Synchronization**: Aligning package versions between workspace root (`package.json`) and `templates/common/package.json`.
-- **Bun Version Upgrades**: Refreshing `@types/bun` or `bun-types` after upgrading Bun runtime.
+- **Template Synchronization (L0 Mode)**: Aligning package versions between workspace root (`package.json`) and `templates/common/package.json`.
+- **Project Dependency Refresh (L1/L2 Mode)**: Refreshing dependencies in scaffolded or variant-based projects.
+
+---
+
+## Step 0: Layer Context Auto-Detection
+
+Before scanning, determine the execution context by checking for the existence of `templates/common/`:
+
+```bash
+# Check execution layer
+if [ -d "templates/common" ]; then
+  MODE="L0_WORKSPACE_ROOT"
+else
+  MODE="L1_L2_STANDALONE_PROJECT"
+fi
+```
+
+- **If `MODE == L0_WORKSPACE_ROOT`**: Follow L0 Workspace Root steps below.
+- **If `MODE == L1_L2_STANDALONE_PROJECT`**: Follow L1/L2 Standalone Project steps below.
 
 ---
 
 ## Step 1: Scan & Audit Outdated Packages
 
-1. **Locate Target `package.json` Files**:
-   - Workspace Root: `package.json`
-   - Common Template: `templates/common/package.json`
-   - Variant Overlays: `templates/co-*/package.json`
+### L0 Workspace Root Mode
+1. **Target Locations**:
+   - Workspace Root: `./package.json`
+   - Common Template: `./templates/common/package.json`
+   - Variant Overlays: `./templates/co-*/package.json`
 
-2. **Check for Outdated Dependencies**:
-   Run `bun outdated` in the workspace root or inspect target directories:
+2. **Run Outdated Scan**:
+   ```bash
+   $OutputEncoding = [Console]::OutputEncoding = [System.Text.Encoding]::UTF8; bun outdated
+   ```
+
+### L1/L2 Standalone Project Mode
+1. **Target Locations**:
+   - Project Root: `./package.json`
+   - Script Subdirectory (if present): `./scripts/package.json`
+
+2. **Run Outdated Scan**:
    ```bash
    $OutputEncoding = [Console]::OutputEncoding = [System.Text.Encoding]::UTF8; bun outdated
    ```
@@ -56,69 +81,79 @@ It ensures non-breaking semver updates pass through smoothly, major version upgr
 3. **Categorize Update Types**:
    - **Patch updates** (`x.y.Z` → `x.y.Z+1`): Bug fixes, non-breaking. Auto-approved.
    - **Minor updates** (`x.Y.z` → `x.Y+1.z`): New features, backward-compatible. Auto-approved after testing.
-   - **Major updates** (`X.y.z` → `X+1.y.z`): Breaking API changes. Require manual review and code updates.
+   - **Major updates** (`X.y.z` → `X+1.y.z`): Breaking API changes. Require manual code compatibility review.
 
 ---
 
 ## Step 2: Security & Compatibility Assessment
 
 1. **License Audit**:
-   Ensure all new or updated packages use OSI-approved licenses (MIT, Apache-2.0, BSD-2-Clause, BSD-3-Clause, ISC, MPL-2.0, LGPL-2.1+). Avoid GPL-3.0/AGPL-3.0/SSPL unless explicitly authorized per Coding Guidelines §8.5.
+   Ensure all new or updated packages use OSI-approved licenses (MIT, Apache-2.0, BSD-2-Clause, BSD-3-Clause, ISC, MPL-2.0, LGPL-2.1+). Avoid GPL-3.0/AGPL-3.0/SSPL per Coding Guidelines §8.5.
 
-2. **Core Workspace Contracts**:
-   Preserve essential workspace dependencies:
+2. **Core System Contracts**:
+   Preserve essential type safety and build tooling:
    - `bun-types` / `@types/node` (TypeScript type safety)
    - `js-yaml` (YAML frontmatter parsing)
    - `gitleaks` (Secret scanning)
 
 3. **Breaking Change Verification**:
-   If upgrading major versions, search the codebase for imports of the target package using `grep_search` to verify function signatures and API compatibility before editing `package.json`.
+   If upgrading major versions, search for target package imports using `grep_search` to verify API compatibility before modifying `package.json`.
 
 ---
 
 ## Step 3: Execute Package Updates & Lockfile Sync
 
+### L0 Workspace Root Mode
 1. **Execute Bun Update**:
-   - For workspace root:
-     ```bash
-     $OutputEncoding = [Console]::OutputEncoding = [System.Text.Encoding]::UTF8; bun update
-     ```
-   - For specific package upgrades:
-     ```bash
-     $OutputEncoding = [Console]::OutputEncoding = [System.Text.Encoding]::UTF8; bun add <package-name>@latest
-     ```
-
-2. **Sync `templates/common/package.json`**:
-   Ensure dependencies shared between workspace root and `templates/common/package.json` maintain version alignment.
-
+   ```bash
+   $OutputEncoding = [Console]::OutputEncoding = [System.Text.Encoding]::UTF8; bun update
+   ```
+2. **Align Common Template**:
+   Sync shared dependency version strings in `./templates/common/package.json`.
 3. **Propagate to Templates**:
-   Run the propagation tool to copy updated scripts and settings to `templates/common/`:
    ```bash
    $OutputEncoding = [Console]::OutputEncoding = [System.Text.Encoding]::UTF8; bun run propagate:apply
    ```
+
+### L1/L2 Standalone Project Mode
+1. **Execute Bun Update**:
+   ```bash
+   $OutputEncoding = [Console]::OutputEncoding = [System.Text.Encoding]::UTF8; bun update
+   ```
+2. **Lockfile Refresh**:
+   ```bash
+   $OutputEncoding = [Console]::OutputEncoding = [System.Text.Encoding]::UTF8; bun install
+   ```
+3. *(Skip L0 `propagate:apply` — L1/L2 projects operate independently).*
 
 ---
 
 ## Step 4: Verification & Quality Gate
 
-1. **Run Workspace Audit**:
-   Verify documentation, script versions, and platform parity:
+### L0 Workspace Root Mode
+1. Run full workspace audit:
    ```bash
    $OutputEncoding = [Console]::OutputEncoding = [System.Text.Encoding]::UTF8; bun scripts/audit.ts
    ```
-
-2. **Run Template Validation**:
+2. Validate template integrity:
    ```bash
    $OutputEncoding = [Console]::OutputEncoding = [System.Text.Encoding]::UTF8; bun scripts/validate-templates.ts
    ```
-
-3. **Run Integration Tests**:
+3. Run integration test suite:
    ```bash
    $OutputEncoding = [Console]::OutputEncoding = [System.Text.Encoding]::UTF8; bun test
    ```
-
-4. **Execute `/sync` Pipeline**:
-   Commit, push, and open a PR for the package updates:
+4. Execute `/sync` pipeline:
    ```bash
    $OutputEncoding = [Console]::OutputEncoding = [System.Text.Encoding]::UTF8; bun scripts/dev-sync.ts --body-file ".git/sync-pr-body.md" "chore(deps): update bun packages and sync templates"
+   ```
+
+### L1/L2 Standalone Project Mode
+1. Run local project QA gate / tests:
+   ```bash
+   $OutputEncoding = [Console]::OutputEncoding = [System.Text.Encoding]::UTF8; bun test
+   ```
+2. Execute local `/sync` pipeline:
+   ```bash
+   $OutputEncoding = [Console]::OutputEncoding = [System.Text.Encoding]::UTF8; bun scripts/dev-sync.ts --body-file ".git/sync-pr-body.md" "chore(deps): update bun packages"
    ```

--- a/templates/common/skills/update-bun-packages/SKILL.md
+++ b/templates/common/skills/update-bun-packages/SKILL.md
@@ -3,11 +3,11 @@ name: update-bun-packages
 status: active
 scope: common
 description: >
-  Scans, updates, and upgrades Bun dependencies and packages across the AI workspace,
-  templates/common, and template variants while ensuring lockfile consistency and security compliance.
+  Scans, updates, and upgrades Bun dependencies and packages across the AI workspace (L0)
+  or standalone project (L1/L2) while ensuring lockfile consistency and security compliance.
   Use when: updating bun dependencies, upgrading packages, checking outdated packages in workspace or templates.
 owner: pm
-version: 1.0.0
+version: 1.1.0
 last_reviewed: 2026-08-07
 metadata:
   type: process
@@ -21,13 +21,10 @@ metadata:
 
 ## Overview
 
-This skill provides a structured methodology for auditing, updating, and upgrading Bun packages and dependencies across all layers of the workspace hierarchy:
-- **Tier 1 (Workspace Root)**: `package.json` and `bun.lock` in the workspace root (`c:\git\ai_workspace\`).
-- **Tier 2 (Common Template)**: `templates/common/package.json`.
-- **Tier 2 Variant Overlays**: `templates/co-*/package.json` (e.g. `templates/co-deck/package.json`).
-- **Tier 3 (Generated Projects)**: `Projects/*/package.json`.
+This skill provides a layer-aware methodology for auditing, updating, and upgrading Bun packages and dependencies. It automatically detects whether it is running in **L0 (Workspace Maintainer)** or **L1/L2 (Standalone Project)** context and adapts its scope accordingly:
 
-It ensures non-breaking semver updates pass through smoothly, major version upgrades undergo compatibility review, and security/license compliance is maintained throughout the update cycle.
+- **L0 Mode (Workspace Maintainer)**: Audits workspace root `package.json`, `templates/common/package.json`, and variant overlay `templates/co-*/package.json`, then propagates changes via `bun run propagate:apply`.
+- **L1/L2 Mode (Standalone Project)**: Audits local project `./package.json` (and `./scripts/package.json` if present) without referencing non-existent template paths or attempting L0-only template propagation.
 
 ---
 
@@ -35,20 +32,48 @@ It ensures non-breaking semver updates pass through smoothly, major version upgr
 
 - **Routine Maintenance**: Regular dependency updates (patch & minor releases).
 - **Security Patches**: Upgrading vulnerable packages reported by security advisories (`gitleaks`, `bun audit`, CVEs).
-- **Template Synchronization**: Aligning package versions between workspace root (`package.json`) and `templates/common/package.json`.
-- **Bun Version Upgrades**: Refreshing `@types/bun` or `bun-types` after upgrading Bun runtime.
+- **Template Synchronization (L0 Mode)**: Aligning package versions between workspace root (`package.json`) and `templates/common/package.json`.
+- **Project Dependency Refresh (L1/L2 Mode)**: Refreshing dependencies in scaffolded or variant-based projects.
+
+---
+
+## Step 0: Layer Context Auto-Detection
+
+Before scanning, determine the execution context by checking for the existence of `templates/common/`:
+
+```bash
+# Check execution layer
+if [ -d "templates/common" ]; then
+  MODE="L0_WORKSPACE_ROOT"
+else
+  MODE="L1_L2_STANDALONE_PROJECT"
+fi
+```
+
+- **If `MODE == L0_WORKSPACE_ROOT`**: Follow L0 Workspace Root steps below.
+- **If `MODE == L1_L2_STANDALONE_PROJECT`**: Follow L1/L2 Standalone Project steps below.
 
 ---
 
 ## Step 1: Scan & Audit Outdated Packages
 
-1. **Locate Target `package.json` Files**:
-   - Workspace Root: `package.json`
-   - Common Template: `templates/common/package.json`
-   - Variant Overlays: `templates/co-*/package.json`
+### L0 Workspace Root Mode
+1. **Target Locations**:
+   - Workspace Root: `./package.json`
+   - Common Template: `./templates/common/package.json`
+   - Variant Overlays: `./templates/co-*/package.json`
 
-2. **Check for Outdated Dependencies**:
-   Run `bun outdated` in the workspace root or inspect target directories:
+2. **Run Outdated Scan**:
+   ```bash
+   $OutputEncoding = [Console]::OutputEncoding = [System.Text.Encoding]::UTF8; bun outdated
+   ```
+
+### L1/L2 Standalone Project Mode
+1. **Target Locations**:
+   - Project Root: `./package.json`
+   - Script Subdirectory (if present): `./scripts/package.json`
+
+2. **Run Outdated Scan**:
    ```bash
    $OutputEncoding = [Console]::OutputEncoding = [System.Text.Encoding]::UTF8; bun outdated
    ```
@@ -56,69 +81,79 @@ It ensures non-breaking semver updates pass through smoothly, major version upgr
 3. **Categorize Update Types**:
    - **Patch updates** (`x.y.Z` → `x.y.Z+1`): Bug fixes, non-breaking. Auto-approved.
    - **Minor updates** (`x.Y.z` → `x.Y+1.z`): New features, backward-compatible. Auto-approved after testing.
-   - **Major updates** (`X.y.z` → `X+1.y.z`): Breaking API changes. Require manual review and code updates.
+   - **Major updates** (`X.y.z` → `X+1.y.z`): Breaking API changes. Require manual code compatibility review.
 
 ---
 
 ## Step 2: Security & Compatibility Assessment
 
 1. **License Audit**:
-   Ensure all new or updated packages use OSI-approved licenses (MIT, Apache-2.0, BSD-2-Clause, BSD-3-Clause, ISC, MPL-2.0, LGPL-2.1+). Avoid GPL-3.0/AGPL-3.0/SSPL unless explicitly authorized per Coding Guidelines §8.5.
+   Ensure all new or updated packages use OSI-approved licenses (MIT, Apache-2.0, BSD-2-Clause, BSD-3-Clause, ISC, MPL-2.0, LGPL-2.1+). Avoid GPL-3.0/AGPL-3.0/SSPL per Coding Guidelines §8.5.
 
-2. **Core Workspace Contracts**:
-   Preserve essential workspace dependencies:
+2. **Core System Contracts**:
+   Preserve essential type safety and build tooling:
    - `bun-types` / `@types/node` (TypeScript type safety)
    - `js-yaml` (YAML frontmatter parsing)
    - `gitleaks` (Secret scanning)
 
 3. **Breaking Change Verification**:
-   If upgrading major versions, search the codebase for imports of the target package using `grep_search` to verify function signatures and API compatibility before editing `package.json`.
+   If upgrading major versions, search for target package imports using `grep_search` to verify API compatibility before modifying `package.json`.
 
 ---
 
 ## Step 3: Execute Package Updates & Lockfile Sync
 
+### L0 Workspace Root Mode
 1. **Execute Bun Update**:
-   - For workspace root:
-     ```bash
-     $OutputEncoding = [Console]::OutputEncoding = [System.Text.Encoding]::UTF8; bun update
-     ```
-   - For specific package upgrades:
-     ```bash
-     $OutputEncoding = [Console]::OutputEncoding = [System.Text.Encoding]::UTF8; bun add <package-name>@latest
-     ```
-
-2. **Sync `templates/common/package.json`**:
-   Ensure dependencies shared between workspace root and `templates/common/package.json` maintain version alignment.
-
+   ```bash
+   $OutputEncoding = [Console]::OutputEncoding = [System.Text.Encoding]::UTF8; bun update
+   ```
+2. **Align Common Template**:
+   Sync shared dependency version strings in `./templates/common/package.json`.
 3. **Propagate to Templates**:
-   Run the propagation tool to copy updated scripts and settings to `templates/common/`:
    ```bash
    $OutputEncoding = [Console]::OutputEncoding = [System.Text.Encoding]::UTF8; bun run propagate:apply
    ```
+
+### L1/L2 Standalone Project Mode
+1. **Execute Bun Update**:
+   ```bash
+   $OutputEncoding = [Console]::OutputEncoding = [System.Text.Encoding]::UTF8; bun update
+   ```
+2. **Lockfile Refresh**:
+   ```bash
+   $OutputEncoding = [Console]::OutputEncoding = [System.Text.Encoding]::UTF8; bun install
+   ```
+3. *(Skip L0 `propagate:apply` — L1/L2 projects operate independently).*
 
 ---
 
 ## Step 4: Verification & Quality Gate
 
-1. **Run Workspace Audit**:
-   Verify documentation, script versions, and platform parity:
+### L0 Workspace Root Mode
+1. Run full workspace audit:
    ```bash
    $OutputEncoding = [Console]::OutputEncoding = [System.Text.Encoding]::UTF8; bun scripts/audit.ts
    ```
-
-2. **Run Template Validation**:
+2. Validate template integrity:
    ```bash
    $OutputEncoding = [Console]::OutputEncoding = [System.Text.Encoding]::UTF8; bun scripts/validate-templates.ts
    ```
-
-3. **Run Integration Tests**:
+3. Run integration test suite:
    ```bash
    $OutputEncoding = [Console]::OutputEncoding = [System.Text.Encoding]::UTF8; bun test
    ```
-
-4. **Execute `/sync` Pipeline**:
-   Commit, push, and open a PR for the package updates:
+4. Execute `/sync` pipeline:
    ```bash
    $OutputEncoding = [Console]::OutputEncoding = [System.Text.Encoding]::UTF8; bun scripts/dev-sync.ts --body-file ".git/sync-pr-body.md" "chore(deps): update bun packages and sync templates"
+   ```
+
+### L1/L2 Standalone Project Mode
+1. Run local project QA gate / tests:
+   ```bash
+   $OutputEncoding = [Console]::OutputEncoding = [System.Text.Encoding]::UTF8; bun test
+   ```
+2. Execute local `/sync` pipeline:
+   ```bash
+   $OutputEncoding = [Console]::OutputEncoding = [System.Text.Encoding]::UTF8; bun scripts/dev-sync.ts --body-file ".git/sync-pr-body.md" "chore(deps): update bun packages"
    ```


### PR DESCRIPTION
## Why
Derive and implement multi-agent meeting decisions to prevent unnecessary physical `nul` file creation on Windows / Git Bash.

## What Changed
- Conducted multi-agent meeting (`pm`, `automation-engineer`, `security-expert`, `auditor`) and logged transcript in `memory/meeting-2026-08-07-prevent-nul-file-creation.md`.
- Added `nul` and `NUL` to `.gitignore` and `templates/common/.gitignore`.
- Updated `scripts/audit.ts` (and `templates/common/scripts/audit.ts`) to auto-delete `WINDOWS_DEVICE_NAMES` artifacts regardless of tracking status.
- Updated `CHANGELOG.md` and `memory/2026-08-07.md`.

## Test Plan
- [x] `bun scripts/audit.ts` passes cleanly (0 errors, auto-deletes any untracked `nul` file)
- [x] Transcripts & gitignore rules verified

## Security Checklist
- [x] No secrets, credentials, or API keys committed
- [x] No `.env` files staged
- [x] Dependencies unchanged

## Notes
None
