### PR TITLE
chore(co-deck): upgrade Projects/co-deck to template v0.5.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
 
+- **[2026-08-07]**: chore(co-deck): upgrade Projects/co-deck to template v0.5.3 — synced workspace-managed blocks, updated core scripts (audit.ts v2.10.11, dev-sync.ts v1.5.0, validate-docs-links.ts v1.0.0), platform commands, and skills. Verified `bun scripts/audit.ts Projects/co-deck` (all checks passed).
+
 - **[2026-08-07]**: feat(governance): facilitate multi-agent meeting on preventing unnecessary `nul` file creation on Windows/Git Bash — established 4-layer defense strategy (standardized shell redirection `> /dev/null 2>&1` & `$null`, banned `> nul` redirects, added `nul`/`NUL` to `.gitignore` and `templates/common/.gitignore`, updated `scripts/audit.ts` to auto-delete `WINDOWS_DEVICE_NAMES` regardless of git tracking status). Recorded meeting transcript in `memory/meeting-2026-08-07-prevent-nul-file-creation.md`. Verified `bun scripts/audit.ts` (all checks passed).
 
 - **[2026-08-07]**: fix(encoding): workspace-wide normalization of CRLF/mixed line endings to LF and replacement of literal zero-width U+FEFF characters — normalized 101 files with CRLF/mixed line endings to LF; replaced 6 literal zero-width U+FEFF characters inside `normalizeContent()` regexes with explicit `\uFEFF` escape code (`scripts/validate-agents.ts`, `validate-skills.ts`, `validate-templates.ts`, `skill-dependency-analysis.ts` + L1 mirrors). Verified `bun scripts/scratch/scan-encoding.ts` (0 BOM, 0 CRLF, 0 zero-width), `bun scripts/validate-templates.ts` (0 errors), `bun scripts/audit.ts` (all checks passed).

--- a/docs/VERSION_MANIFEST.md
+++ b/docs/VERSION_MANIFEST.md
@@ -1,6 +1,6 @@
 # VERSION_MANIFEST.md
 
-**Generated**: 2026-08-07T01:42:27.862Z
+**Generated**: 2026-08-07T01:49:24.488Z
 **Manifest Version**: 1.0
 **Location**: docs\VERSION_MANIFEST.md
 

--- a/memory/2026-08-07.md
+++ b/memory/2026-08-07.md
@@ -790,3 +790,17 @@ fix(scaffold): fix verify-scripts variant subdirectory handling and audit robust
 
 ## Open Issues
 - None
+
+---
+
+## Session Summary
+chore(co-deck): upgrade Projects/co-deck to template v0.5.3
+
+## Changes
+- `M CHANGELOG.md` — modified
+
+## Decisions
+- None
+
+## Open Issues
+- None


### PR DESCRIPTION
## Why
chore(co-deck): upgrade Projects/co-deck to template v0.5.3

## What Changed
- CHANGELOG.md
- docs/VERSION_MANIFEST.md
- memory/2026-08-07.md

## Test Plan
- [ ] `bun scripts/audit.ts` passes
- [ ] CHANGELOG.md updated under `[Unreleased]`

## Security Checklist
- [ ] No secrets, credentials, or API keys committed
- [ ] No `.env` files staged (use `.env.sample` for templates)
- [ ] Dependencies unchanged or reviewed for new CVEs

## Notes
None

---