### PR TITLE
fix(githooks): add strict mode, replace python3 with language-guard.ts, fix /tmp/ path

### DIFF
--- a/.githooks/commit-msg
+++ b/.githooks/commit-msg
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+set -euo pipefail
 # commit-msg: auto-log memory + CHANGELOG on every direct git commit.
 # Receives the commit message file path as $1.
 # Runs AFTER pre-commit, so the message is guaranteed to be available.
@@ -12,14 +13,28 @@ COMMIT_BODY=$(tail -n +2 "$COMMIT_MSG_FILE" | sed -e '1,/^$/d' -e '/^#/d' | sed 
 echo "$COMMIT_MSG" | grep -qE "^Merge|^WIP|^fixup!|^squash!" && exit 0
 
 # ── Enforce English Only ───────────────────────────────────────────────────────
-if command -v python3 >/dev/null 2>&1; then
+# Uses language-guard.ts (Korean + Japanese + Chinese detection + code-block stripping).
+# Falls back to python3 Korean-only regex if bun is unavailable.
+if command -v bun >/dev/null 2>&1; then
+  if ! bun -e "
+    import { readFileSync } from 'fs';
+    import { hasNonEnglish } from './scripts/lib/language-guard.ts';
+    const text = readFileSync(process.argv[1], 'utf-8');
+    process.exit(hasNonEnglish(text) ? 1 : 0);
+  " "$COMMIT_MSG_FILE"; then
+    echo -e "\033[31m[FAIL]\033[0m Non-English characters detected in commit message."
+    echo "       CONSTITUTION.md mandates all commit messages must be in English."
+    exit 1
+  fi
+elif command -v python3 >/dev/null 2>&1; then
+  # Fallback: Korean-only regex (narrower than language-guard.ts)
   if ! python3 -c "import sys,re; data=open(sys.argv[1],encoding='utf-8').read(); sys.exit(1) if re.search(r'[가-힣ᄀ-ᇿ㄰-㆏]',data) else sys.exit(0)" "$COMMIT_MSG_FILE"; then
-    echo -e "\033[31m[FAIL]\033[0m Non-English characters (Korean) detected in commit message."
+    echo -e "\033[31m[FAIL]\033[0m Non-English characters detected in commit message."
     echo "       CONSTITUTION.md mandates all commit messages must be in English."
     exit 1
   fi
 else
-  echo "[WARN] python3 not found — Korean character check skipped. Install python3 to enforce." >&2
+  echo "[WARN] bun and python3 not found — non-English check skipped." >&2
 fi
 
 TODAY=$(date +%Y-%m-%d)

--- a/.githooks/post-checkout
+++ b/.githooks/post-checkout
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+set -euo pipefail
 # .githooks/post-checkout
 
 PREV_COMMIT=$1
@@ -31,7 +32,7 @@ fi
 # multiple branches in quick succession. The AI process only reads/analyzes and
 # writes to the log file, so file conflicts are unlikely — the lock primarily
 # prevents redundant parallel sessions.
-LOCK_FILE="/tmp/post-checkout-ai.lock"
+LOCK_FILE="$(git rev-parse --git-dir)/post-checkout-ai.lock"
 
 if [ -f "$LOCK_FILE" ]; then
   echo "[post-checkout] AI session already running, skipping."

--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -1,3 +1,6 @@
 #!/usr/bin/env bash
+set -euo pipefail
 # pre-commit wrapper: routes to TS logic
+
+command -v bun >/dev/null 2>&1 || { echo "[FAIL] bun not found. Install bun: https://bun.sh" >&2; exit 1; }
 bun run scripts/hooks/pre-commit.ts

--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -1,3 +1,6 @@
 #!/usr/bin/env bash
+set -euo pipefail
 # pre-push wrapper: routes to TS logic
+
+command -v bun >/dev/null 2>&1 || { echo "[FAIL] bun not found. Install bun: https://bun.sh" >&2; exit 1; }
 bun run scripts/hooks/pre-push.ts

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
 
+- **[2026-08-12]**: fix(githooks): add strict mode, replace python3 with language-guard.ts, fix /tmp/ path — added `set -euo pipefail` to all 4 git hooks (commit-msg, post-checkout, pre-commit, pre-push), replaced python3 Korean-only regex in commit-msg with `bun -e` calling `language-guard.ts` (covers Korean + Japanese + Chinese + code-block stripping, with python3 fallback), replaced hardcoded `/tmp/post-checkout-ai.lock` with `$(git rev-parse --git-dir)/post-checkout-ai.lock` (project-local), added `bun` availability guard to pre-commit and pre-push. All changes synced to `templates/common/.githooks/`.
+
 - **[2026-08-12]**: fix(templates): standardize variant contracts, fix inheritance paths, remove build artifacts — fixed co-news pm.md extends path (`../../../agents/pm.md` → `../../common/agents/pm.md`), added missing `agent_manifest` to co-export and co-news variant.json, fixed `createdAt` → `created_at` camelCase in co-news, deleted 4 `_pipeline_report.{json,md}` build artifacts from co-export and co-news, fixed common template gitleaks.toml placeholder title and added missing allowlist entries, enhanced variant.schema.json with optional properties (`variant_type`, `inherits_common`, `created_at`, `agents`, `skills`, `agent_manifest`, `skill_manifest`, `script_manifest`). Design doc: `docs/designs/project-review-fixes-design.md`.
 
 - **[2026-08-12]**: chore(templates/co-game): add projects/ from live project — copied `projects/pacman/` (src, tests, docs, config) and `projects/bubble-bobble/` (src, tests, maps) from `Projects/co-game/projects/` to `templates/co-game/projects/`, excluding node_modules, dist, and lock files (96 files).

--- a/docs/VERSION_MANIFEST.md
+++ b/docs/VERSION_MANIFEST.md
@@ -1,6 +1,6 @@
 # VERSION_MANIFEST.md
 
-**Generated**: 2026-08-12T06:33:49.228Z
+**Generated**: 2026-08-12T06:39:55.778Z
 **Manifest Version**: 1.0
 **Location**: docs\VERSION_MANIFEST.md
 

--- a/memory/2026-08-12.md
+++ b/memory/2026-08-12.md
@@ -213,3 +213,25 @@ fix(templates): standardize variant contracts, fix inheritance paths, remove bui
 
 ## Open Issues
 - None
+
+---
+
+## Session Summary
+fix(githooks): add strict mode, replace python3 with language-guard.ts, fix /tmp/ path
+
+## Changes
+- `.githooks/commit-msg` — modified
+- `.githooks/post-checkout` — modified
+- `.githooks/pre-commit` — modified
+- `.githooks/pre-push` — modified
+- `CHANGELOG.md` — modified
+- `templates/common/.githooks/commit-msg` — modified
+- `templates/common/.githooks/post-checkout` — modified
+- `templates/common/.githooks/pre-commit` — modified
+- `templates/common/.githooks/pre-push` — modified
+
+## Decisions
+- None
+
+## Open Issues
+- None

--- a/templates/common/.githooks/commit-msg
+++ b/templates/common/.githooks/commit-msg
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+set -euo pipefail
 # commit-msg: auto-log memory + CHANGELOG on every direct git commit.
 # Receives the commit message file path as $1.
 # Runs AFTER pre-commit, so the message is guaranteed to be available.
@@ -12,10 +13,28 @@ COMMIT_BODY=$(tail -n +2 "$COMMIT_MSG_FILE" | sed -e '1,/^$/d' -e '/^#/d' | sed 
 echo "$COMMIT_MSG" | grep -qE "^Merge|^WIP|^fixup!|^squash!" && exit 0
 
 # ── Enforce English Only ───────────────────────────────────────────────────────
-if ! python3 -c "import sys,re; data=open(sys.argv[1],encoding='utf-8').read(); sys.exit(1) if re.search(r'[가-힣ᄀ-ᇿ㄰-㆏]',data) else sys.exit(0)" "$COMMIT_MSG_FILE"; then
-  echo -e "\033[31m[FAIL]\033[0m Non-English characters (Korean) detected in commit message."
-  echo "       Workspace policy requires all commit messages must be in English."
-  exit 1
+# Uses language-guard.ts (Korean + Japanese + Chinese detection + code-block stripping).
+# Falls back to python3 Korean-only regex if bun is unavailable.
+if command -v bun >/dev/null 2>&1; then
+  if ! bun -e "
+    import { readFileSync } from 'fs';
+    import { hasNonEnglish } from './scripts/lib/language-guard.ts';
+    const text = readFileSync(process.argv[1], 'utf-8');
+    process.exit(hasNonEnglish(text) ? 1 : 0);
+  " "$COMMIT_MSG_FILE"; then
+    echo -e "\033[31m[FAIL]\033[0m Non-English characters detected in commit message."
+    echo "       Workspace policy requires all commit messages must be in English."
+    exit 1
+  fi
+elif command -v python3 >/dev/null 2>&1; then
+  # Fallback: Korean-only regex (narrower than language-guard.ts)
+  if ! python3 -c "import sys,re; data=open(sys.argv[1],encoding='utf-8').read(); sys.exit(1) if re.search(r'[가-힣ᄀ-ᇿ㄰-㆏]',data) else sys.exit(0)" "$COMMIT_MSG_FILE"; then
+    echo -e "\033[31m[FAIL]\033[0m Non-English characters detected in commit message."
+    echo "       Workspace policy requires all commit messages must be in English."
+    exit 1
+  fi
+else
+  echo "[WARN] bun and python3 not found — non-English check skipped." >&2
 fi
 
 TODAY=$(date +%Y-%m-%d)

--- a/templates/common/.githooks/post-checkout
+++ b/templates/common/.githooks/post-checkout
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+set -euo pipefail
 # .githooks/post-checkout
 
 PREV_COMMIT=$1
@@ -31,7 +32,7 @@ fi
 # multiple branches in quick succession. The AI process only reads/analyzes and
 # writes to the log file, so file conflicts are unlikely — the lock primarily
 # prevents redundant parallel sessions.
-LOCK_FILE="/tmp/post-checkout-ai.lock"
+LOCK_FILE="$(git rev-parse --git-dir)/post-checkout-ai.lock"
 
 if [ -f "$LOCK_FILE" ]; then
   echo "[post-checkout] AI session already running, skipping."

--- a/templates/common/.githooks/pre-commit
+++ b/templates/common/.githooks/pre-commit
@@ -1,3 +1,6 @@
 #!/usr/bin/env bash
+set -euo pipefail
 # pre-commit wrapper: routes to TS logic
+
+command -v bun >/dev/null 2>&1 || { echo "[FAIL] bun not found. Install bun: https://bun.sh" >&2; exit 1; }
 bun run scripts/hooks/pre-commit.ts

--- a/templates/common/.githooks/pre-push
+++ b/templates/common/.githooks/pre-push
@@ -1,3 +1,6 @@
 #!/usr/bin/env bash
+set -euo pipefail
 # pre-push wrapper: routes to TS logic
+
+command -v bun >/dev/null 2>&1 || { echo "[FAIL] bun not found. Install bun: https://bun.sh" >&2; exit 1; }
 bun run scripts/hooks/pre-push.ts


### PR DESCRIPTION
## Why
Git hooks lacked strict error handling (`set -euo pipefail`), making silent failures possible. The commit-msg hook depended on python3 for a Korean-only regex that missed Japanese/Chinese text and didn't strip code blocks. The post-checkout hook used a hardcoded `/tmp/` lock file path that doesn't work reliably across platforms. pre-commit and pre-push had no bun availability guard.

## What Changed
- Added `set -euo pipefail` to all 4 L0 hooks: `.githooks/commit-msg`, `.githooks/post-checkout`, `.githooks/pre-commit`, `.githooks/pre-push`
- Replaced python3 Korean-only regex in commit-msg with `bun -e` calling `scripts/lib/language-guard.ts` (covers Korean + Japanese + Chinese + code-block stripping); python3 retained as fallback if bun unavailable
- Changed post-checkout `LOCK_FILE` from `/tmp/post-checkout-ai.lock` to `$(git rev-parse --git-dir)/post-checkout-ai.lock` (project-local, cross-platform)
- Added `command -v bun` guard to pre-commit and pre-push (exits with clear error if bun not found)
- Synced all 4 changes to `templates/common/.githooks/` (L1 common template)

## Test Plan
- [ ] `bun scripts/audit.ts` passes
- [ ] Manual: create a branch — post-checkout lock file created inside `.git/`, not `/tmp/`
- [ ] Manual: commit with Korean characters in message — hook rejects with clear error
- [ ] Manual: `bun` not in PATH — pre-commit/pre-push exit with "bun not found" message

## Security Checklist
- [ ] No secrets, credentials, or API keys committed
- [ ] No `.env` files staged
- [ ] Dependencies unchanged

## Notes
- language-guard.ts is a library module (not a CLI script), so commit-msg uses `bun -e` with inline import rather than `bun run`
- python3 fallback preserved for environments without bun (narrower Korean-only detection)
- L1 hooks use "Workspace policy requires" wording (vs L0's "CONSTITUTION.md mandates") — preserved existing L1 wording

---
