### PR TITLE
docs(lifecycle): add agent governance records for 7 variants (59 files)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
 
+- **[2026-08-12]**: docs(lifecycle): add agent governance records for 7 variants (59 files) — created `docs/lifecycle/agents/` directories and agent governance records for all variants missing lifecycle documentation: co-consult (11 records), co-design (8), co-develop (7), co-game (13), co-news (7, beta phase), co-security (6), co-work (7). Each record follows the co-export template pattern (Overview, Phase History, Acceptance Criteria).
+
 - **[2026-08-12]**: chore: improve audit coverage, update propagation map, complete review fixes — added variant.json schema validation to `scripts/audit.ts` (validates required fields, name pattern, status enum, semver version, lifecycle fields, and conditional requirements per `docs/templates/variant.schema.json`; WARN-level per plan trade-off), added missing `co-export` and `co-news` to `scripts/propagation-map.json` governance-agents target_variants (all 9 variants now covered). Design doc: `docs/designs/project-review-fixes-design.md`.
 
 - **[2026-08-12]**: docs: fix stale .sh references, reconcile SCRIPTS.md versions, fix variant AGENTS.md headers — updated 2 stale `.sh` references to `.ts` in `docs/lifecycle/README.md` (`validate-doc-folder.sh` → `validate-doc-folder.ts`), synced 12 L1 SCRIPTS.md version entries to match L0 SSOT, added "curated subset" clarification to AGENTS.md §6 Skills table, fixed all 9 variant template AGENTS.md headers from "Workspace Root Agent Ecosystem" to variant-specific labels (e.g., "co-design Variant Agent Ecosystem"). Design doc: `docs/designs/project-review-fixes-design.md`.

--- a/docs/VERSION_MANIFEST.md
+++ b/docs/VERSION_MANIFEST.md
@@ -1,6 +1,6 @@
 # VERSION_MANIFEST.md
 
-**Generated**: 2026-08-12T13:29:07.581Z
+**Generated**: 2026-08-12T13:42:16.105Z
 **Manifest Version**: 1.0
 **Location**: docs\VERSION_MANIFEST.md
 

--- a/memory/2026-08-12.md
+++ b/memory/2026-08-12.md
@@ -440,3 +440,24 @@ chore: improve audit coverage, update propagation map, complete review fixes
 
 ## Open Issues
 - None
+
+---
+
+## Session Summary
+docs(lifecycle): add agent governance records for 7 variants (59 files)
+
+## Changes
+- `M CHANGELOG.md` — modified
+- `templates/co-consult/docs/lifecycle/` — modified
+- `templates/co-design/docs/lifecycle/` — modified
+- `templates/co-develop/docs/lifecycle/` — modified
+- `templates/co-game/docs/lifecycle/` — modified
+- `templates/co-news/docs/lifecycle/` — modified
+- `templates/co-security/docs/lifecycle/` — modified
+- `templates/co-work/docs/lifecycle/` — modified
+
+## Decisions
+- None
+
+## Open Issues
+- None

--- a/templates/co-consult/docs/lifecycle/agents/change-management-partner.md
+++ b/templates/co-consult/docs/lifecycle/agents/change-management-partner.md
@@ -1,0 +1,17 @@
+# Agent Governance Record — change-management-partner
+
+## Overview
+
+- **Agent Name**: change-management-partner
+- **Role**: Organizational transformation and stakeholder alignment specialist
+- **Phase**: production
+
+## Phase History
+
+- **2026-08-12**: Initial release — governance record created as part of lifecycle documentation standardization.
+
+## Acceptance Criteria
+
+- [x] Defined in `agents/change-management-partner.md`
+- [x] Follows standard agent structure
+- [x] Validated by `scripts/validate-agents.ts`

--- a/templates/co-consult/docs/lifecycle/agents/communications-lead.md
+++ b/templates/co-consult/docs/lifecycle/agents/communications-lead.md
@@ -1,0 +1,17 @@
+# Agent Governance Record — communications-lead
+
+## Overview
+
+- **Agent Name**: communications-lead
+- **Role**: Client-facing communications and strategic narrative producer
+- **Phase**: production
+
+## Phase History
+
+- **2026-08-12**: Initial release — governance record created as part of lifecycle documentation standardization.
+
+## Acceptance Criteria
+
+- [x] Defined in `agents/communications-lead.md`
+- [x] Follows standard agent structure
+- [x] Validated by `scripts/validate-agents.ts`

--- a/templates/co-consult/docs/lifecycle/agents/data-analyst.md
+++ b/templates/co-consult/docs/lifecycle/agents/data-analyst.md
@@ -1,0 +1,17 @@
+# Agent Governance Record — data-analyst
+
+## Overview
+
+- **Agent Name**: data-analyst
+- **Role**: Statistical analysis, data modeling, and business insights specialist
+- **Phase**: production
+
+## Phase History
+
+- **2026-08-12**: Initial release — governance record created as part of lifecycle documentation standardization.
+
+## Acceptance Criteria
+
+- [x] Defined in `agents/data-analyst.md`
+- [x] Follows standard agent structure
+- [x] Validated by `scripts/validate-agents.ts`

--- a/templates/co-consult/docs/lifecycle/agents/delivery-manager.md
+++ b/templates/co-consult/docs/lifecycle/agents/delivery-manager.md
@@ -1,0 +1,17 @@
+# Agent Governance Record — delivery-manager
+
+## Overview
+
+- **Agent Name**: delivery-manager
+- **Role**: Project delivery and operations coordination specialist
+- **Phase**: production
+
+## Phase History
+
+- **2026-08-12**: Initial release — governance record created as part of lifecycle documentation standardization.
+
+## Acceptance Criteria
+
+- [x] Defined in `agents/delivery-manager.md`
+- [x] Follows standard agent structure
+- [x] Validated by `scripts/validate-agents.ts`

--- a/templates/co-consult/docs/lifecycle/agents/industry-expert.md
+++ b/templates/co-consult/docs/lifecycle/agents/industry-expert.md
@@ -1,0 +1,17 @@
+# Agent Governance Record — industry-expert
+
+## Overview
+
+- **Agent Name**: industry-expert
+- **Role**: Industry-specific insights and competitive dynamics specialist
+- **Phase**: production
+
+## Phase History
+
+- **2026-08-12**: Initial release — governance record created as part of lifecycle documentation standardization.
+
+## Acceptance Criteria
+
+- [x] Defined in `agents/industry-expert.md`
+- [x] Follows standard agent structure
+- [x] Validated by `scripts/validate-agents.ts`

--- a/templates/co-consult/docs/lifecycle/agents/pm.md
+++ b/templates/co-consult/docs/lifecycle/agents/pm.md
@@ -1,0 +1,17 @@
+# Agent Governance Record — pm
+
+## Overview
+
+- **Agent Name**: pm
+- **Role**: Project Manager (PM) Agent — variant override extending common PM template
+- **Phase**: production
+
+## Phase History
+
+- **2026-08-12**: Initial release — governance record created as part of lifecycle documentation standardization.
+
+## Acceptance Criteria
+
+- [x] Defined in `agents/pm.md`
+- [x] Follows standard agent structure
+- [x] Validated by `scripts/validate-agents.ts`

--- a/templates/co-consult/docs/lifecycle/agents/sme.md
+++ b/templates/co-consult/docs/lifecycle/agents/sme.md
@@ -1,0 +1,17 @@
+# Agent Governance Record — sme
+
+## Overview
+
+- **Agent Name**: sme
+- **Role**: Functional expertise and solution design specialist
+- **Phase**: production
+
+## Phase History
+
+- **2026-08-12**: Initial release — governance record created as part of lifecycle documentation standardization.
+
+## Acceptance Criteria
+
+- [x] Defined in `agents/sme.md`
+- [x] Follows standard agent structure
+- [x] Validated by `scripts/validate-agents.ts`

--- a/templates/co-consult/docs/lifecycle/agents/solutions-architect.md
+++ b/templates/co-consult/docs/lifecycle/agents/solutions-architect.md
@@ -1,0 +1,17 @@
+# Agent Governance Record — solutions-architect
+
+## Overview
+
+- **Agent Name**: solutions-architect
+- **Role**: Technical solution design and implementation planning specialist
+- **Phase**: production
+
+## Phase History
+
+- **2026-08-12**: Initial release — governance record created as part of lifecycle documentation standardization.
+
+## Acceptance Criteria
+
+- [x] Defined in `agents/solutions-architect.md`
+- [x] Follows standard agent structure
+- [x] Validated by `scripts/validate-agents.ts`

--- a/templates/co-consult/docs/lifecycle/agents/strategy-analyst.md
+++ b/templates/co-consult/docs/lifecycle/agents/strategy-analyst.md
@@ -1,0 +1,17 @@
+# Agent Governance Record — strategy-analyst
+
+## Overview
+
+- **Agent Name**: strategy-analyst
+- **Role**: Market analysis, competitive research, and strategic assessment lead
+- **Phase**: production
+
+## Phase History
+
+- **2026-08-12**: Initial release — governance record created as part of lifecycle documentation standardization.
+
+## Acceptance Criteria
+
+- [x] Defined in `agents/strategy-analyst.md`
+- [x] Follows standard agent structure
+- [x] Validated by `scripts/validate-agents.ts`

--- a/templates/co-consult/docs/lifecycle/agents/technology-specialist.md
+++ b/templates/co-consult/docs/lifecycle/agents/technology-specialist.md
@@ -1,0 +1,17 @@
+# Agent Governance Record — technology-specialist
+
+## Overview
+
+- **Agent Name**: technology-specialist
+- **Role**: Collaboration platforms and digital transformation support specialist
+- **Phase**: production
+
+## Phase History
+
+- **2026-08-12**: Initial release — governance record created as part of lifecycle documentation standardization.
+
+## Acceptance Criteria
+
+- [x] Defined in `agents/technology-specialist.md`
+- [x] Follows standard agent structure
+- [x] Validated by `scripts/validate-agents.ts`

--- a/templates/co-consult/docs/lifecycle/agents/workstream-lead.md
+++ b/templates/co-consult/docs/lifecycle/agents/workstream-lead.md
@@ -1,0 +1,17 @@
+# Agent Governance Record — workstream-lead
+
+## Overview
+
+- **Agent Name**: workstream-lead
+- **Role**: Workstream management and delivery coordination lead
+- **Phase**: production
+
+## Phase History
+
+- **2026-08-12**: Initial release — governance record created as part of lifecycle documentation standardization.
+
+## Acceptance Criteria
+
+- [x] Defined in `agents/workstream-lead.md`
+- [x] Follows standard agent structure
+- [x] Validated by `scripts/validate-agents.ts`

--- a/templates/co-design/docs/lifecycle/agents/design-lead.md
+++ b/templates/co-design/docs/lifecycle/agents/design-lead.md
@@ -1,0 +1,17 @@
+# Agent Governance Record — design-lead
+
+## Overview
+
+- **Agent Name**: design-lead
+- **Role**: Design direction, design system architecture, and creative strategy owner
+- **Phase**: production
+
+## Phase History
+
+- **2026-08-12**: Initial release — governance record created as part of lifecycle documentation standardization.
+
+## Acceptance Criteria
+
+- [x] Defined in `agents/design-lead.md`
+- [x] Follows standard agent structure
+- [x] Validated by `scripts/validate-agents.ts`

--- a/templates/co-design/docs/lifecycle/agents/pm.md
+++ b/templates/co-design/docs/lifecycle/agents/pm.md
@@ -1,0 +1,17 @@
+# Agent Governance Record — pm
+
+## Overview
+
+- **Agent Name**: pm
+- **Role**: Project Manager (PM) Agent — variant override extending common PM template
+- **Phase**: production
+
+## Phase History
+
+- **2026-08-12**: Initial release — governance record created as part of lifecycle documentation standardization.
+
+## Acceptance Criteria
+
+- [x] Defined in `agents/pm.md`
+- [x] Follows standard agent structure
+- [x] Validated by `scripts/validate-agents.ts`

--- a/templates/co-design/docs/lifecycle/agents/prototype-engineer.md
+++ b/templates/co-design/docs/lifecycle/agents/prototype-engineer.md
@@ -1,0 +1,17 @@
+# Agent Governance Record — prototype-engineer
+
+## Overview
+
+- **Agent Name**: prototype-engineer
+- **Role**: Interactive prototypes and design handoff artifacts builder
+- **Phase**: production
+
+## Phase History
+
+- **2026-08-12**: Initial release — governance record created as part of lifecycle documentation standardization.
+
+## Acceptance Criteria
+
+- [x] Defined in `agents/prototype-engineer.md`
+- [x] Follows standard agent structure
+- [x] Validated by `scripts/validate-agents.ts`

--- a/templates/co-design/docs/lifecycle/agents/service-designer.md
+++ b/templates/co-design/docs/lifecycle/agents/service-designer.md
@@ -1,0 +1,17 @@
+# Agent Governance Record — service-designer
+
+## Overview
+
+- **Agent Name**: service-designer
+- **Role**: End-to-end service experience and customer journey designer
+- **Phase**: production
+
+## Phase History
+
+- **2026-08-12**: Initial release — governance record created as part of lifecycle documentation standardization.
+
+## Acceptance Criteria
+
+- [x] Defined in `agents/service-designer.md`
+- [x] Follows standard agent structure
+- [x] Validated by `scripts/validate-agents.ts`

--- a/templates/co-design/docs/lifecycle/agents/storyteller.md
+++ b/templates/co-design/docs/lifecycle/agents/storyteller.md
@@ -1,0 +1,17 @@
+# Agent Governance Record — storyteller
+
+## Overview
+
+- **Agent Name**: storyteller
+- **Role**: Philosophical foundation, meaning, and narrative coherence for design systems
+- **Phase**: production
+
+## Phase History
+
+- **2026-08-12**: Initial release — governance record created as part of lifecycle documentation standardization.
+
+## Acceptance Criteria
+
+- [x] Defined in `agents/storyteller.md`
+- [x] Follows standard agent structure
+- [x] Validated by `scripts/validate-agents.ts`

--- a/templates/co-design/docs/lifecycle/agents/typography-expert.md
+++ b/templates/co-design/docs/lifecycle/agents/typography-expert.md
@@ -1,0 +1,17 @@
+# Agent Governance Record — typography-expert
+
+## Overview
+
+- **Agent Name**: typography-expert
+- **Role**: Font selection, type systems, and visual hierarchy specialist
+- **Phase**: production
+
+## Phase History
+
+- **2026-08-12**: Initial release — governance record created as part of lifecycle documentation standardization.
+
+## Acceptance Criteria
+
+- [x] Defined in `agents/typography-expert.md`
+- [x] Follows standard agent structure
+- [x] Validated by `scripts/validate-agents.ts`

--- a/templates/co-design/docs/lifecycle/agents/ux-researcher.md
+++ b/templates/co-design/docs/lifecycle/agents/ux-researcher.md
@@ -1,0 +1,17 @@
+# Agent Governance Record — ux-researcher
+
+## Overview
+
+- **Agent Name**: ux-researcher
+- **Role**: User research, needs analysis, and UX insights specialist
+- **Phase**: production
+
+## Phase History
+
+- **2026-08-12**: Initial release — governance record created as part of lifecycle documentation standardization.
+
+## Acceptance Criteria
+
+- [x] Defined in `agents/ux-researcher.md`
+- [x] Follows standard agent structure
+- [x] Validated by `scripts/validate-agents.ts`

--- a/templates/co-design/docs/lifecycle/agents/visual-designer.md
+++ b/templates/co-design/docs/lifecycle/agents/visual-designer.md
@@ -1,0 +1,17 @@
+# Agent Governance Record — visual-designer
+
+## Overview
+
+- **Agent Name**: visual-designer
+- **Role**: Visual designs, design tokens, and component specifications producer
+- **Phase**: production
+
+## Phase History
+
+- **2026-08-12**: Initial release — governance record created as part of lifecycle documentation standardization.
+
+## Acceptance Criteria
+
+- [x] Defined in `agents/visual-designer.md`
+- [x] Follows standard agent structure
+- [x] Validated by `scripts/validate-agents.ts`

--- a/templates/co-develop/docs/lifecycle/agents/architect.md
+++ b/templates/co-develop/docs/lifecycle/agents/architect.md
@@ -1,0 +1,17 @@
+# Agent Governance Record — architect
+
+## Overview
+
+- **Agent Name**: architect
+- **Role**: Implementation plans, ADRs, and system architecture design specialist
+- **Phase**: production
+
+## Phase History
+
+- **2026-08-12**: Initial release — governance record created as part of lifecycle documentation standardization.
+
+## Acceptance Criteria
+
+- [x] Defined in `agents/architect.md`
+- [x] Follows standard agent structure
+- [x] Validated by `scripts/validate-agents.ts`

--- a/templates/co-develop/docs/lifecycle/agents/code-writer.md
+++ b/templates/co-develop/docs/lifecycle/agents/code-writer.md
@@ -1,0 +1,17 @@
+# Agent Governance Record — code-writer
+
+## Overview
+
+- **Agent Name**: code-writer
+- **Role**: Approved plan implementation with surgical, minimal code changes
+- **Phase**: production
+
+## Phase History
+
+- **2026-08-12**: Initial release — governance record created as part of lifecycle documentation standardization.
+
+## Acceptance Criteria
+
+- [x] Defined in `agents/code-writer.md`
+- [x] Follows standard agent structure
+- [x] Validated by `scripts/validate-agents.ts`

--- a/templates/co-develop/docs/lifecycle/agents/designer.md
+++ b/templates/co-develop/docs/lifecycle/agents/designer.md
@@ -1,0 +1,17 @@
+# Agent Governance Record — designer
+
+## Overview
+
+- **Agent Name**: designer
+- **Role**: UI/UX specs, wireframes, and component definition producer
+- **Phase**: production
+
+## Phase History
+
+- **2026-08-12**: Initial release — governance record created as part of lifecycle documentation standardization.
+
+## Acceptance Criteria
+
+- [x] Defined in `agents/designer.md`
+- [x] Follows standard agent structure
+- [x] Validated by `scripts/validate-agents.ts`

--- a/templates/co-develop/docs/lifecycle/agents/pm.md
+++ b/templates/co-develop/docs/lifecycle/agents/pm.md
@@ -1,0 +1,17 @@
+# Agent Governance Record — pm
+
+## Overview
+
+- **Agent Name**: pm
+- **Role**: Project Manager (PM) Agent — variant override extending common PM template
+- **Phase**: production
+
+## Phase History
+
+- **2026-08-12**: Initial release — governance record created as part of lifecycle documentation standardization.
+
+## Acceptance Criteria
+
+- [x] Defined in `agents/pm.md`
+- [x] Follows standard agent structure
+- [x] Validated by `scripts/validate-agents.ts`

--- a/templates/co-develop/docs/lifecycle/agents/security-monitor.md
+++ b/templates/co-develop/docs/lifecycle/agents/security-monitor.md
@@ -1,0 +1,17 @@
+# Agent Governance Record — security-monitor
+
+## Overview
+
+- **Agent Name**: security-monitor
+- **Role**: Security policy enforcement and secrets leak prevention specialist
+- **Phase**: production
+
+## Phase History
+
+- **2026-08-12**: Initial release — governance record created as part of lifecycle documentation standardization.
+
+## Acceptance Criteria
+
+- [x] Defined in `agents/security-monitor.md`
+- [x] Follows standard agent structure
+- [x] Validated by `scripts/validate-agents.ts`

--- a/templates/co-develop/docs/lifecycle/agents/stack-setup.md
+++ b/templates/co-develop/docs/lifecycle/agents/stack-setup.md
@@ -1,0 +1,17 @@
+# Agent Governance Record — stack-setup
+
+## Overview
+
+- **Agent Name**: stack-setup
+- **Role**: Unknown stack identification and secure setup procedure specialist
+- **Phase**: production
+
+## Phase History
+
+- **2026-08-12**: Initial release — governance record created as part of lifecycle documentation standardization.
+
+## Acceptance Criteria
+
+- [x] Defined in `agents/stack-setup.md`
+- [x] Follows standard agent structure
+- [x] Validated by `scripts/validate-agents.ts`

--- a/templates/co-develop/docs/lifecycle/agents/test-runner.md
+++ b/templates/co-develop/docs/lifecycle/agents/test-runner.md
@@ -1,0 +1,17 @@
+# Agent Governance Record — test-runner
+
+## Overview
+
+- **Agent Name**: test-runner
+- **Role**: Test execution and acceptance criteria verification specialist
+- **Phase**: production
+
+## Phase History
+
+- **2026-08-12**: Initial release — governance record created as part of lifecycle documentation standardization.
+
+## Acceptance Criteria
+
+- [x] Defined in `agents/test-runner.md`
+- [x] Follows standard agent structure
+- [x] Validated by `scripts/validate-agents.ts`

--- a/templates/co-game/docs/lifecycle/agents/arcade-designer.md
+++ b/templates/co-game/docs/lifecycle/agents/arcade-designer.md
@@ -1,0 +1,17 @@
+# Agent Governance Record — arcade-designer
+
+## Overview
+
+- **Agent Name**: arcade-designer
+- **Role**: Retro arcade game design specialist — entity AI, wave systems, scoring, level layout
+- **Phase**: production
+
+## Phase History
+
+- **2026-08-12**: Initial release — governance record created as part of lifecycle documentation standardization.
+
+## Acceptance Criteria
+
+- [x] Defined in `agents/arcade-designer.md`
+- [x] Follows standard agent structure
+- [x] Validated by `scripts/validate-agents.ts`

--- a/templates/co-game/docs/lifecycle/agents/architect.md
+++ b/templates/co-game/docs/lifecycle/agents/architect.md
@@ -1,0 +1,17 @@
+# Agent Governance Record — architect
+
+## Overview
+
+- **Agent Name**: architect
+- **Role**: Implementation plans, ADRs, and system architecture design specialist
+- **Phase**: production
+
+## Phase History
+
+- **2026-08-12**: Initial release — governance record created as part of lifecycle documentation standardization.
+
+## Acceptance Criteria
+
+- [x] Defined in `agents/architect.md`
+- [x] Follows standard agent structure
+- [x] Validated by `scripts/validate-agents.ts`

--- a/templates/co-game/docs/lifecycle/agents/designer.md
+++ b/templates/co-game/docs/lifecycle/agents/designer.md
@@ -1,0 +1,17 @@
+# Agent Governance Record — designer
+
+## Overview
+
+- **Agent Name**: designer
+- **Role**: UI/UX specs, wireframes, and component definition producer
+- **Phase**: production
+
+## Phase History
+
+- **2026-08-12**: Initial release — governance record created as part of lifecycle documentation standardization.
+
+## Acceptance Criteria
+
+- [x] Defined in `agents/designer.md`
+- [x] Follows standard agent structure
+- [x] Validated by `scripts/validate-agents.ts`

--- a/templates/co-game/docs/lifecycle/agents/game-debugger.md
+++ b/templates/co-game/docs/lifecycle/agents/game-debugger.md
@@ -1,0 +1,17 @@
+# Agent Governance Record — game-debugger
+
+## Overview
+
+- **Agent Name**: game-debugger
+- **Role**: Bug root cause analysis, fix proposals, and bug pattern documentation specialist for game engine
+- **Phase**: production
+
+## Phase History
+
+- **2026-08-12**: Initial release — governance record created as part of lifecycle documentation standardization.
+
+## Acceptance Criteria
+
+- [x] Defined in `agents/game-debugger.md`
+- [x] Follows standard agent structure
+- [x] Validated by `scripts/validate-agents.ts`

--- a/templates/co-game/docs/lifecycle/agents/game-designer.md
+++ b/templates/co-game/docs/lifecycle/agents/game-designer.md
@@ -1,0 +1,17 @@
+# Agent Governance Record — game-designer
+
+## Overview
+
+- **Agent Name**: game-designer
+- **Role**: Universal game design agent — core loop, difficulty curves, reward systems, tutorial/onboarding across all genres
+- **Phase**: production
+
+## Phase History
+
+- **2026-08-12**: Initial release — governance record created as part of lifecycle documentation standardization.
+
+## Acceptance Criteria
+
+- [x] Defined in `agents/game-designer.md`
+- [x] Follows standard agent structure
+- [x] Validated by `scripts/validate-agents.ts`

--- a/templates/co-game/docs/lifecycle/agents/game-developer.md
+++ b/templates/co-game/docs/lifecycle/agents/game-developer.md
@@ -1,0 +1,17 @@
+# Agent Governance Record — game-developer
+
+## Overview
+
+- **Agent Name**: game-developer
+- **Role**: Canvas rendering engine, game loop, collision detection, and entity implementation specialist
+- **Phase**: production
+
+## Phase History
+
+- **2026-08-12**: Initial release — governance record created as part of lifecycle documentation standardization.
+
+## Acceptance Criteria
+
+- [x] Defined in `agents/game-developer.md`
+- [x] Follows standard agent structure
+- [x] Validated by `scripts/validate-agents.ts`

--- a/templates/co-game/docs/lifecycle/agents/pm.md
+++ b/templates/co-game/docs/lifecycle/agents/pm.md
@@ -1,0 +1,17 @@
+# Agent Governance Record — pm
+
+## Overview
+
+- **Agent Name**: pm
+- **Role**: Project Manager (PM) Agent — variant override extending common PM template
+- **Phase**: production
+
+## Phase History
+
+- **2026-08-12**: Initial release — governance record created as part of lifecycle documentation standardization.
+
+## Acceptance Criteria
+
+- [x] Defined in `agents/pm.md`
+- [x] Follows standard agent structure
+- [x] Validated by `scripts/validate-agents.ts`

--- a/templates/co-game/docs/lifecycle/agents/puzzle-designer.md
+++ b/templates/co-game/docs/lifecycle/agents/puzzle-designer.md
@@ -1,0 +1,17 @@
+# Agent Governance Record — puzzle-designer
+
+## Overview
+
+- **Agent Name**: puzzle-designer
+- **Role**: Puzzle/board game design specialist — matching logic, turn systems, difficulty generation
+- **Phase**: production
+
+## Phase History
+
+- **2026-08-12**: Initial release — governance record created as part of lifecycle documentation standardization.
+
+## Acceptance Criteria
+
+- [x] Defined in `agents/puzzle-designer.md`
+- [x] Follows standard agent structure
+- [x] Validated by `scripts/validate-agents.ts`

--- a/templates/co-game/docs/lifecycle/agents/security-monitor.md
+++ b/templates/co-game/docs/lifecycle/agents/security-monitor.md
@@ -1,0 +1,17 @@
+# Agent Governance Record — security-monitor
+
+## Overview
+
+- **Agent Name**: security-monitor
+- **Role**: Security policy enforcement and secrets leak prevention specialist
+- **Phase**: production
+
+## Phase History
+
+- **2026-08-12**: Initial release — governance record created as part of lifecycle documentation standardization.
+
+## Acceptance Criteria
+
+- [x] Defined in `agents/security-monitor.md`
+- [x] Follows standard agent structure
+- [x] Validated by `scripts/validate-agents.ts`

--- a/templates/co-game/docs/lifecycle/agents/sound-designer.md
+++ b/templates/co-game/docs/lifecycle/agents/sound-designer.md
@@ -1,0 +1,17 @@
+# Agent Governance Record — sound-designer
+
+## Overview
+
+- **Agent Name**: sound-designer
+- **Role**: Procedural audio design specialist — sound effects, BGM loops, audio architecture
+- **Phase**: production
+
+## Phase History
+
+- **2026-08-12**: Initial release — governance record created as part of lifecycle documentation standardization.
+
+## Acceptance Criteria
+
+- [x] Defined in `agents/sound-designer.md`
+- [x] Follows standard agent structure
+- [x] Validated by `scripts/validate-agents.ts`

--- a/templates/co-game/docs/lifecycle/agents/stack-setup.md
+++ b/templates/co-game/docs/lifecycle/agents/stack-setup.md
@@ -1,0 +1,17 @@
+# Agent Governance Record — stack-setup
+
+## Overview
+
+- **Agent Name**: stack-setup
+- **Role**: Unknown stack identification and secure setup procedure specialist
+- **Phase**: production
+
+## Phase History
+
+- **2026-08-12**: Initial release — governance record created as part of lifecycle documentation standardization.
+
+## Acceptance Criteria
+
+- [x] Defined in `agents/stack-setup.md`
+- [x] Follows standard agent structure
+- [x] Validated by `scripts/validate-agents.ts`

--- a/templates/co-game/docs/lifecycle/agents/test-runner.md
+++ b/templates/co-game/docs/lifecycle/agents/test-runner.md
@@ -1,0 +1,17 @@
+# Agent Governance Record — test-runner
+
+## Overview
+
+- **Agent Name**: test-runner
+- **Role**: Test execution and acceptance criteria verification specialist
+- **Phase**: production
+
+## Phase History
+
+- **2026-08-12**: Initial release — governance record created as part of lifecycle documentation standardization.
+
+## Acceptance Criteria
+
+- [x] Defined in `agents/test-runner.md`
+- [x] Follows standard agent structure
+- [x] Validated by `scripts/validate-agents.ts`

--- a/templates/co-game/docs/lifecycle/agents/visual-artist.md
+++ b/templates/co-game/docs/lifecycle/agents/visual-artist.md
@@ -1,0 +1,17 @@
+# Agent Governance Record — visual-artist
+
+## Overview
+
+- **Agent Name**: visual-artist
+- **Role**: Visual asset specialist — sprite design, animation frames, board/tile visuals, background, HUD elements
+- **Phase**: production
+
+## Phase History
+
+- **2026-08-12**: Initial release — governance record created as part of lifecycle documentation standardization.
+
+## Acceptance Criteria
+
+- [x] Defined in `agents/visual-artist.md`
+- [x] Follows standard agent structure
+- [x] Validated by `scripts/validate-agents.ts`

--- a/templates/co-news/docs/lifecycle/agents/fact-checker.md
+++ b/templates/co-news/docs/lifecycle/agents/fact-checker.md
@@ -1,0 +1,17 @@
+# Agent Governance Record — fact-checker
+
+## Overview
+
+- **Agent Name**: fact-checker
+- **Role**: Citation ledger owner and newsroom gatekeeper
+- **Phase**: beta
+
+## Phase History
+
+- **2026-08-12**: Initial release — governance record created as part of lifecycle documentation standardization.
+
+## Acceptance Criteria
+
+- [x] Defined in `agents/fact-checker.md`
+- [x] Follows standard agent structure
+- [x] Validated by `scripts/validate-agents.ts`

--- a/templates/co-news/docs/lifecycle/agents/financial-analyst.md
+++ b/templates/co-news/docs/lifecycle/agents/financial-analyst.md
@@ -1,0 +1,17 @@
+# Agent Governance Record — financial-analyst
+
+## Overview
+
+- **Agent Name**: financial-analyst
+- **Role**: DART-sourced financial narrative brief lead
+- **Phase**: beta
+
+## Phase History
+
+- **2026-08-12**: Initial release — governance record created as part of lifecycle documentation standardization.
+
+## Acceptance Criteria
+
+- [x] Defined in `agents/financial-analyst.md`
+- [x] Follows standard agent structure
+- [x] Validated by `scripts/validate-agents.ts`

--- a/templates/co-news/docs/lifecycle/agents/legal-researcher.md
+++ b/templates/co-news/docs/lifecycle/agents/legal-researcher.md
@@ -1,0 +1,17 @@
+# Agent Governance Record — legal-researcher
+
+## Overview
+
+- **Agent Name**: legal-researcher
+- **Role**: Corporate law and regulatory context research lead
+- **Phase**: beta
+
+## Phase History
+
+- **2026-08-12**: Initial release — governance record created as part of lifecycle documentation standardization.
+
+## Acceptance Criteria
+
+- [x] Defined in `agents/legal-researcher.md`
+- [x] Follows standard agent structure
+- [x] Validated by `scripts/validate-agents.ts`

--- a/templates/co-news/docs/lifecycle/agents/pm.md
+++ b/templates/co-news/docs/lifecycle/agents/pm.md
@@ -1,0 +1,17 @@
+# Agent Governance Record — pm
+
+## Overview
+
+- **Agent Name**: pm
+- **Role**: Project Manager (PM) Agent — variant override extending common PM template
+- **Phase**: beta
+
+## Phase History
+
+- **2026-08-12**: Initial release — governance record created as part of lifecycle documentation standardization.
+
+## Acceptance Criteria
+
+- [x] Defined in `agents/pm.md`
+- [x] Follows standard agent structure
+- [x] Validated by `scripts/validate-agents.ts`

--- a/templates/co-news/docs/lifecycle/agents/reporter.md
+++ b/templates/co-news/docs/lifecycle/agents/reporter.md
@@ -1,0 +1,17 @@
+# Agent Governance Record — reporter
+
+## Overview
+
+- **Agent Name**: reporter
+- **Role**: Article drafting lead — headline, lead, and body
+- **Phase**: beta
+
+## Phase History
+
+- **2026-08-12**: Initial release — governance record created as part of lifecycle documentation standardization.
+
+## Acceptance Criteria
+
+- [x] Defined in `agents/reporter.md`
+- [x] Follows standard agent structure
+- [x] Validated by `scripts/validate-agents.ts`

--- a/templates/co-news/docs/lifecycle/agents/style-editor.md
+++ b/templates/co-news/docs/lifecycle/agents/style-editor.md
@@ -1,0 +1,17 @@
+# Agent Governance Record — style-editor
+
+## Overview
+
+- **Agent Name**: style-editor
+- **Role**: AI-tell reduction and house-style conformance lead
+- **Phase**: beta
+
+## Phase History
+
+- **2026-08-12**: Initial release — governance record created as part of lifecycle documentation standardization.
+
+## Acceptance Criteria
+
+- [x] Defined in `agents/style-editor.md`
+- [x] Follows standard agent structure
+- [x] Validated by `scripts/validate-agents.ts`

--- a/templates/co-news/docs/lifecycle/agents/visual-editor.md
+++ b/templates/co-news/docs/lifecycle/agents/visual-editor.md
@@ -1,0 +1,17 @@
+# Agent Governance Record — visual-editor
+
+## Overview
+
+- **Agent Name**: visual-editor
+- **Role**: Inline SVG financial infographic lead
+- **Phase**: beta
+
+## Phase History
+
+- **2026-08-12**: Initial release — governance record created as part of lifecycle documentation standardization.
+
+## Acceptance Criteria
+
+- [x] Defined in `agents/visual-editor.md`
+- [x] Follows standard agent structure
+- [x] Validated by `scripts/validate-agents.ts`

--- a/templates/co-security/docs/lifecycle/agents/patch-engineer.md
+++ b/templates/co-security/docs/lifecycle/agents/patch-engineer.md
@@ -1,0 +1,17 @@
+# Agent Governance Record — patch-engineer
+
+## Overview
+
+- **Agent Name**: patch-engineer
+- **Role**: Cross-platform patch deployment and remediation specialist
+- **Phase**: production
+
+## Phase History
+
+- **2026-08-12**: Initial release — governance record created as part of lifecycle documentation standardization.
+
+## Acceptance Criteria
+
+- [x] Defined in `agents/patch-engineer.md`
+- [x] Follows standard agent structure
+- [x] Validated by `scripts/validate-agents.ts`

--- a/templates/co-security/docs/lifecycle/agents/pentester.md
+++ b/templates/co-security/docs/lifecycle/agents/pentester.md
@@ -1,0 +1,17 @@
+# Agent Governance Record — pentester
+
+## Overview
+
+- **Agent Name**: pentester
+- **Role**: Vulnerability discovery, PoC development, and re-testing specialist
+- **Phase**: production
+
+## Phase History
+
+- **2026-08-12**: Initial release — governance record created as part of lifecycle documentation standardization.
+
+## Acceptance Criteria
+
+- [x] Defined in `agents/pentester.md`
+- [x] Follows standard agent structure
+- [x] Validated by `scripts/validate-agents.ts`

--- a/templates/co-security/docs/lifecycle/agents/pm.md
+++ b/templates/co-security/docs/lifecycle/agents/pm.md
@@ -1,0 +1,17 @@
+# Agent Governance Record — pm
+
+## Overview
+
+- **Agent Name**: pm
+- **Role**: Project Manager (PM) Agent — variant override extending common PM template
+- **Phase**: production
+
+## Phase History
+
+- **2026-08-12**: Initial release — governance record created as part of lifecycle documentation standardization.
+
+## Acceptance Criteria
+
+- [x] Defined in `agents/pm.md`
+- [x] Follows standard agent structure
+- [x] Validated by `scripts/validate-agents.ts`

--- a/templates/co-security/docs/lifecycle/agents/red-team-lead.md
+++ b/templates/co-security/docs/lifecycle/agents/red-team-lead.md
@@ -1,0 +1,17 @@
+# Agent Governance Record — red-team-lead
+
+## Overview
+
+- **Agent Name**: red-team-lead
+- **Role**: Attack methodology, MITRE ATT&CK TTPs, and PoC review specialist
+- **Phase**: production
+
+## Phase History
+
+- **2026-08-12**: Initial release — governance record created as part of lifecycle documentation standardization.
+
+## Acceptance Criteria
+
+- [x] Defined in `agents/red-team-lead.md`
+- [x] Follows standard agent structure
+- [x] Validated by `scripts/validate-agents.ts`

--- a/templates/co-security/docs/lifecycle/agents/report-writer.md
+++ b/templates/co-security/docs/lifecycle/agents/report-writer.md
@@ -1,0 +1,17 @@
+# Agent Governance Record — report-writer
+
+## Overview
+
+- **Agent Name**: report-writer
+- **Role**: Pentest reports and executive summary documentation specialist
+- **Phase**: production
+
+## Phase History
+
+- **2026-08-12**: Initial release — governance record created as part of lifecycle documentation standardization.
+
+## Acceptance Criteria
+
+- [x] Defined in `agents/report-writer.md`
+- [x] Follows standard agent structure
+- [x] Validated by `scripts/validate-agents.ts`

--- a/templates/co-security/docs/lifecycle/agents/threat-modeler.md
+++ b/templates/co-security/docs/lifecycle/agents/threat-modeler.md
@@ -1,0 +1,17 @@
+# Agent Governance Record — threat-modeler
+
+## Overview
+
+- **Agent Name**: threat-modeler
+- **Role**: STRIDE analysis, ATT&CK mapping, and risk scoring specialist
+- **Phase**: production
+
+## Phase History
+
+- **2026-08-12**: Initial release — governance record created as part of lifecycle documentation standardization.
+
+## Acceptance Criteria
+
+- [x] Defined in `agents/threat-modeler.md`
+- [x] Follows standard agent structure
+- [x] Validated by `scripts/validate-agents.ts`

--- a/templates/co-work/docs/lifecycle/agents/analyst.md
+++ b/templates/co-work/docs/lifecycle/agents/analyst.md
@@ -1,0 +1,17 @@
+# Agent Governance Record — analyst
+
+## Overview
+
+- **Agent Name**: analyst
+- **Role**: Systematic investigation, data synthesis, and evidence gathering specialist
+- **Phase**: production
+
+## Phase History
+
+- **2026-08-12**: Initial release — governance record created as part of lifecycle documentation standardization.
+
+## Acceptance Criteria
+
+- [x] Defined in `agents/analyst.md`
+- [x] Follows standard agent structure
+- [x] Validated by `scripts/validate-agents.ts`

--- a/templates/co-work/docs/lifecycle/agents/content-writer.md
+++ b/templates/co-work/docs/lifecycle/agents/content-writer.md
@@ -1,0 +1,17 @@
+# Agent Governance Record — content-writer
+
+## Overview
+
+- **Agent Name**: content-writer
+- **Role**: Research-to-documentation transformation and communications specialist
+- **Phase**: production
+
+## Phase History
+
+- **2026-08-12**: Initial release — governance record created as part of lifecycle documentation standardization.
+
+## Acceptance Criteria
+
+- [x] Defined in `agents/content-writer.md`
+- [x] Follows standard agent structure
+- [x] Validated by `scripts/validate-agents.ts`

--- a/templates/co-work/docs/lifecycle/agents/ms365-expert.md
+++ b/templates/co-work/docs/lifecycle/agents/ms365-expert.md
@@ -1,0 +1,17 @@
+# Agent Governance Record — ms365-expert
+
+## Overview
+
+- **Agent Name**: ms365-expert
+- **Role**: Microsoft 365 platform expertise for productivity and collaboration tools
+- **Phase**: production
+
+## Phase History
+
+- **2026-08-12**: Initial release — governance record created as part of lifecycle documentation standardization.
+
+## Acceptance Criteria
+
+- [x] Defined in `agents/ms365-expert.md`
+- [x] Follows standard agent structure
+- [x] Validated by `scripts/validate-agents.ts`

--- a/templates/co-work/docs/lifecycle/agents/pm.md
+++ b/templates/co-work/docs/lifecycle/agents/pm.md
@@ -1,0 +1,17 @@
+# Agent Governance Record — pm
+
+## Overview
+
+- **Agent Name**: pm
+- **Role**: Project Manager (PM) Agent — variant override extending common PM template
+- **Phase**: production
+
+## Phase History
+
+- **2026-08-12**: Initial release — governance record created as part of lifecycle documentation standardization.
+
+## Acceptance Criteria
+
+- [x] Defined in `agents/pm.md`
+- [x] Follows standard agent structure
+- [x] Validated by `scripts/validate-agents.ts`

--- a/templates/co-work/docs/lifecycle/agents/project-coordinator.md
+++ b/templates/co-work/docs/lifecycle/agents/project-coordinator.md
@@ -1,0 +1,17 @@
+# Agent Governance Record — project-coordinator
+
+## Overview
+
+- **Agent Name**: project-coordinator
+- **Role**: Schedule management, stakeholder communication, and delivery logistics specialist
+- **Phase**: production
+
+## Phase History
+
+- **2026-08-12**: Initial release — governance record created as part of lifecycle documentation standardization.
+
+## Acceptance Criteria
+
+- [x] Defined in `agents/project-coordinator.md`
+- [x] Follows standard agent structure
+- [x] Validated by `scripts/validate-agents.ts`

--- a/templates/co-work/docs/lifecycle/agents/storyteller.md
+++ b/templates/co-work/docs/lifecycle/agents/storyteller.md
@@ -1,0 +1,17 @@
+# Agent Governance Record — storyteller
+
+## Overview
+
+- **Agent Name**: storyteller
+- **Role**: Organizational culture, change narratives, and institutional knowledge specialist
+- **Phase**: production
+
+## Phase History
+
+- **2026-08-12**: Initial release — governance record created as part of lifecycle documentation standardization.
+
+## Acceptance Criteria
+
+- [x] Defined in `agents/storyteller.md`
+- [x] Follows standard agent structure
+- [x] Validated by `scripts/validate-agents.ts`

--- a/templates/co-work/docs/lifecycle/agents/technical-writer.md
+++ b/templates/co-work/docs/lifecycle/agents/technical-writer.md
@@ -1,0 +1,17 @@
+# Agent Governance Record — technical-writer
+
+## Overview
+
+- **Agent Name**: technical-writer
+- **Role**: API documentation, technical guides, and developer resources creator
+- **Phase**: production
+
+## Phase History
+
+- **2026-08-12**: Initial release — governance record created as part of lifecycle documentation standardization.
+
+## Acceptance Criteria
+
+- [x] Defined in `agents/technical-writer.md`
+- [x] Follows standard agent structure
+- [x] Validated by `scripts/validate-agents.ts`


### PR DESCRIPTION
## Why
Seven variant templates (co-consult, co-design, co-develop, co-game, co-news, co-security, co-work) were missing `docs/lifecycle/agents/` governance records. Only co-export and co-deck had complete lifecycle documentation. This PR standardizes lifecycle coverage across all production and beta variants per the co-export template pattern.

## What Changed
- Created `docs/lifecycle/agents/` directories in 7 variants
- Added 59 agent governance records total:
  - co-consult: 11 records (10 specialists + pm)
  - co-design: 8 records (7 specialists + pm)
  - co-develop: 7 records (6 specialists + pm)
  - co-game: 13 records (12 specialists + pm)
  - co-news: 7 records (6 specialists + pm, beta phase)
  - co-security: 6 records (5 specialists + pm)
  - co-work: 7 records (6 specialists + pm)
- Each record includes: Overview (name, role, phase), Phase History (initial release 2026-08-12), Acceptance Criteria (3 checked items)

## Test Plan
- [ ] `bun scripts/audit.ts` passes
- [ ] All 59 .md files follow the co-export template pattern
- [ ] co-news records correctly use Phase: beta; all others use Phase: production
- [ ] Every agent listed in each variant's variant.json has a matching lifecycle record

## Security Checklist
- [ ] No secrets, credentials, or API keys committed
- [ ] No `.env` files staged (use `.env.sample` for templates)
- [ ] Dependencies unchanged or reviewed for new CVEs

## Notes
None.
