### PR TITLE
fix(templates): add skills[].file to variant.json for 5 variants (43 skills)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
 
+- **[2026-08-12]**: fix(templates): add skills[].file to variant.json for 5 variants — added `"file": "skills/{name}/SKILL.md"` to 43 skill entries across co-consult (19), co-deck (11), co-develop (4), co-news (5), and co-work (4) variant.json files to establish the file field convention for skill discoverability.
+
 - **[2026-08-12]**: docs(lifecycle): add agent governance records for 7 variants (59 files) — created `docs/lifecycle/agents/` directories and agent governance records for all variants missing lifecycle documentation: co-consult (11 records), co-design (8), co-develop (7), co-game (13), co-news (7, beta phase), co-security (6), co-work (7). Each record follows the co-export template pattern (Overview, Phase History, Acceptance Criteria).
 
 - **[2026-08-12]**: chore: improve audit coverage, update propagation map, complete review fixes — added variant.json schema validation to `scripts/audit.ts` (validates required fields, name pattern, status enum, semver version, lifecycle fields, and conditional requirements per `docs/templates/variant.schema.json`; WARN-level per plan trade-off), added missing `co-export` and `co-news` to `scripts/propagation-map.json` governance-agents target_variants (all 9 variants now covered). Design doc: `docs/designs/project-review-fixes-design.md`.

--- a/docs/VERSION_MANIFEST.md
+++ b/docs/VERSION_MANIFEST.md
@@ -1,6 +1,6 @@
 # VERSION_MANIFEST.md
 
-**Generated**: 2026-08-12T13:42:16.105Z
+**Generated**: 2026-08-12T13:45:56.680Z
 **Manifest Version**: 1.0
 **Location**: docs\VERSION_MANIFEST.md
 

--- a/memory/2026-08-12.md
+++ b/memory/2026-08-12.md
@@ -461,3 +461,22 @@ docs(lifecycle): add agent governance records for 7 variants (59 files)
 
 ## Open Issues
 - None
+
+---
+
+## Session Summary
+fix(templates): add skills[].file to variant.json for 5 variants (43 skills)
+
+## Changes
+- `M CHANGELOG.md` — modified
+- `templates/co-consult/variant.json` — modified
+- `templates/co-deck/variant.json` — modified
+- `templates/co-develop/variant.json` — modified
+- `templates/co-news/variant.json` — modified
+- `templates/co-work/variant.json` — modified
+
+## Decisions
+- None
+
+## Open Issues
+- None

--- a/templates/co-consult/variant.json
+++ b/templates/co-consult/variant.json
@@ -54,160 +54,318 @@
     }
   ],
   "skills": [
-    { "name": "change-impact-assessment" },
-    { "name": "competitive-intelligence" },
-    { "name": "consulting-report-writing" },
-    { "name": "executive-presentation" },
-    { "name": "financial-modeling" },
-    { "name": "insight-synthesis" },
-    { "name": "narrative-framework" },
-    { "name": "org-readiness-assessment" },
-    { "name": "project-delivery" },
-    { "name": "solution-design" },
-    { "name": "stakeholder-alignment" },
-    { "name": "stakeholder-review-management" },
-    { "name": "technical-feasibility" },
-    { "name": "company-intelligence" },
-    { "name": "financial-statement-analysis", "version": "1.3.0" },
-    { "name": "mece-logic-auditor" },
-    { "name": "k-law" },
-    { "name": "hwp-document-processing" },
-    { "name": "sample-driven-report-writing" }
+    {
+      "name": "change-impact-assessment",
+      "file": "skills/change-impact-assessment/SKILL.md"
+    },
+    {
+      "name": "competitive-intelligence",
+      "file": "skills/competitive-intelligence/SKILL.md"
+    },
+    {
+      "name": "consulting-report-writing",
+      "file": "skills/consulting-report-writing/SKILL.md"
+    },
+    {
+      "name": "executive-presentation",
+      "file": "skills/executive-presentation/SKILL.md"
+    },
+    {
+      "name": "financial-modeling",
+      "file": "skills/financial-modeling/SKILL.md"
+    },
+    {
+      "name": "insight-synthesis",
+      "file": "skills/insight-synthesis/SKILL.md"
+    },
+    {
+      "name": "narrative-framework",
+      "file": "skills/narrative-framework/SKILL.md"
+    },
+    {
+      "name": "org-readiness-assessment",
+      "file": "skills/org-readiness-assessment/SKILL.md"
+    },
+    {
+      "name": "project-delivery",
+      "file": "skills/project-delivery/SKILL.md"
+    },
+    {
+      "name": "solution-design",
+      "file": "skills/solution-design/SKILL.md"
+    },
+    {
+      "name": "stakeholder-alignment",
+      "file": "skills/stakeholder-alignment/SKILL.md"
+    },
+    {
+      "name": "stakeholder-review-management",
+      "file": "skills/stakeholder-review-management/SKILL.md"
+    },
+    {
+      "name": "technical-feasibility",
+      "file": "skills/technical-feasibility/SKILL.md"
+    },
+    {
+      "name": "company-intelligence",
+      "file": "skills/company-intelligence/SKILL.md"
+    },
+    {
+      "name": "financial-statement-analysis",
+      "version": "1.3.0",
+      "file": "skills/financial-statement-analysis/SKILL.md"
+    },
+    {
+      "name": "mece-logic-auditor",
+      "file": "skills/mece-logic-auditor/SKILL.md"
+    },
+    {
+      "name": "k-law",
+      "file": "skills/k-law/SKILL.md"
+    },
+    {
+      "name": "hwp-document-processing",
+      "file": "skills/hwp-document-processing/SKILL.md"
+    },
+    {
+      "name": "sample-driven-report-writing",
+      "file": "skills/sample-driven-report-writing/SKILL.md"
+    }
   ],
   "skill_manifest": {
     "variant_specific": [
       {
         "name": "change-impact-assessment",
         "layer": "workspace",
-        "used_by_agents": ["change-management-partner"],
-        "phases": [1, 2],
+        "used_by_agents": [
+          "change-management-partner"
+        ],
+        "phases": [
+          1,
+          2
+        ],
         "platform_parity": "required"
       },
       {
         "name": "competitive-intelligence",
         "layer": "workspace",
-        "used_by_agents": ["industry-expert", "strategy-analyst"],
-        "phases": [1, 2],
+        "used_by_agents": [
+          "industry-expert",
+          "strategy-analyst"
+        ],
+        "phases": [
+          1,
+          2
+        ],
         "platform_parity": "required"
       },
       {
         "name": "consulting-report-writing",
         "layer": "workspace",
-        "used_by_agents": ["communications-lead"],
-        "phases": [3],
+        "used_by_agents": [
+          "communications-lead"
+        ],
+        "phases": [
+          3
+        ],
         "platform_parity": "required"
       },
       {
         "name": "executive-presentation",
         "layer": "workspace",
-        "used_by_agents": ["communications-lead"],
-        "phases": [3],
+        "used_by_agents": [
+          "communications-lead"
+        ],
+        "phases": [
+          3
+        ],
         "platform_parity": "required"
       },
       {
         "name": "financial-modeling",
         "layer": "workspace",
-        "used_by_agents": ["data-analyst", "strategy-analyst"],
-        "phases": [1, 3],
+        "used_by_agents": [
+          "data-analyst",
+          "strategy-analyst"
+        ],
+        "phases": [
+          1,
+          3
+        ],
         "platform_parity": "required"
       },
       {
         "name": "insight-synthesis",
         "layer": "workspace",
-        "used_by_agents": ["data-analyst", "strategy-analyst"],
-        "phases": [1, 3],
+        "used_by_agents": [
+          "data-analyst",
+          "strategy-analyst"
+        ],
+        "phases": [
+          1,
+          3
+        ],
         "platform_parity": "required"
       },
       {
         "name": "narrative-framework",
         "layer": "workspace",
-        "used_by_agents": ["communications-lead"],
-        "phases": [3],
+        "used_by_agents": [
+          "communications-lead"
+        ],
+        "phases": [
+          3
+        ],
         "platform_parity": "required"
       },
       {
         "name": "org-readiness-assessment",
         "layer": "workspace",
-        "used_by_agents": ["change-management-partner"],
-        "phases": [1, 2],
+        "used_by_agents": [
+          "change-management-partner"
+        ],
+        "phases": [
+          1,
+          2
+        ],
         "platform_parity": "required"
       },
       {
         "name": "project-delivery",
         "layer": "workspace",
-        "used_by_agents": ["delivery-manager", "workstream-lead"],
-        "phases": [4],
+        "used_by_agents": [
+          "delivery-manager",
+          "workstream-lead"
+        ],
+        "phases": [
+          4
+        ],
         "platform_parity": "required"
       },
       {
         "name": "solution-design",
         "layer": "workspace",
-        "used_by_agents": ["solutions-architect", "technology-specialist"],
-        "phases": [3, 4],
+        "used_by_agents": [
+          "solutions-architect",
+          "technology-specialist"
+        ],
+        "phases": [
+          3,
+          4
+        ],
         "platform_parity": "required"
       },
       {
         "name": "stakeholder-alignment",
         "layer": "workspace",
-        "used_by_agents": ["change-management-partner", "workstream-lead"],
-        "phases": [1, 2, 4],
+        "used_by_agents": [
+          "change-management-partner",
+          "workstream-lead"
+        ],
+        "phases": [
+          1,
+          2,
+          4
+        ],
         "platform_parity": "required"
       },
       {
         "name": "stakeholder-review-management",
         "layer": "workspace",
-        "used_by_agents": ["delivery-manager"],
-        "phases": [4],
+        "used_by_agents": [
+          "delivery-manager"
+        ],
+        "phases": [
+          4
+        ],
         "platform_parity": "required"
       },
       {
         "name": "technical-feasibility",
         "layer": "workspace",
-        "used_by_agents": ["sme", "solutions-architect", "technology-specialist"],
-        "phases": [1, 2, 3, 4],
+        "used_by_agents": [
+          "sme",
+          "solutions-architect",
+          "technology-specialist"
+        ],
+        "phases": [
+          1,
+          2,
+          3,
+          4
+        ],
         "platform_parity": "required"
       },
       {
         "name": "company-intelligence",
         "layer": "workspace",
-        "used_by_agents": ["pm", "strategy-analyst"],
-        "phases": [1],
+        "used_by_agents": [
+          "pm",
+          "strategy-analyst"
+        ],
+        "phases": [
+          1
+        ],
         "platform_parity": "required"
       },
       {
         "name": "mece-logic-auditor",
         "layer": "workspace",
-        "used_by_agents": ["strategy-analyst"],
-        "phases": [1],
+        "used_by_agents": [
+          "strategy-analyst"
+        ],
+        "phases": [
+          1
+        ],
         "platform_parity": "required"
       },
       {
         "name": "financial-statement-analysis",
         "version": "1.3.0",
         "layer": "workspace",
-        "used_by_agents": ["data-analyst"],
-        "phases": [1, 3],
+        "used_by_agents": [
+          "data-analyst"
+        ],
+        "phases": [
+          1,
+          3
+        ],
         "platform_parity": "required"
       },
       {
         "name": "k-law",
         "layer": "variant",
-        "used_by_agents": ["strategy-analyst"],
-        "phases": [1, 2],
+        "used_by_agents": [
+          "strategy-analyst"
+        ],
+        "phases": [
+          1,
+          2
+        ],
         "platform_parity": "required"
       },
       {
         "name": "hwp-document-processing",
         "layer": "variant",
-        "used_by_agents": ["communications-lead"],
-        "phases": [3, 4],
+        "used_by_agents": [
+          "communications-lead"
+        ],
+        "phases": [
+          3,
+          4
+        ],
         "platform_parity": "required"
       },
       {
         "name": "sample-driven-report-writing",
         "layer": "variant",
-        "used_by_agents": ["communications-lead"],
-        "phases": [3, 4],
+        "used_by_agents": [
+          "communications-lead"
+        ],
+        "phases": [
+          3,
+          4
+        ],
         "platform_parity": "required"
       }
     ]

--- a/templates/co-deck/variant.json
+++ b/templates/co-deck/variant.json
@@ -105,37 +105,48 @@
   },
   "skills": [
     {
-      "name": "version"
+      "name": "version",
+      "file": "skills/version/SKILL.md"
     },
     {
-      "name": "research"
+      "name": "research",
+      "file": "skills/research/SKILL.md"
     },
     {
-      "name": "storyline"
+      "name": "storyline",
+      "file": "skills/storyline/SKILL.md"
     },
     {
-      "name": "design"
+      "name": "design",
+      "file": "skills/design/SKILL.md"
     },
     {
-      "name": "html-build"
+      "name": "html-build",
+      "file": "skills/html-build/SKILL.md"
     },
     {
-      "name": "measure"
+      "name": "measure",
+      "file": "skills/measure/SKILL.md"
     },
     {
-      "name": "prep-pdf"
+      "name": "prep-pdf",
+      "file": "skills/prep-pdf/SKILL.md"
     },
     {
-      "name": "pdf-export"
+      "name": "pdf-export",
+      "file": "skills/pdf-export/SKILL.md"
     },
     {
-      "name": "theme-authoring"
+      "name": "theme-authoring",
+      "file": "skills/theme-authoring/SKILL.md"
     },
     {
-      "name": "handbook"
+      "name": "handbook",
+      "file": "skills/handbook/SKILL.md"
     },
     {
-      "name": "presenter-mode"
+      "name": "presenter-mode",
+      "file": "skills/presenter-mode/SKILL.md"
     }
   ],
   "skill_manifest": {
@@ -143,78 +154,143 @@
       {
         "name": "version",
         "layer": "workspace",
-        "used_by_agents": ["design", "html-build", "image-curator", "diagram-specialist", "measure", "pdf-export", "research", "source-verifier", "storyline", "handbook-writer", "handbook-reviewer"],
-        "phases": [0, 1, 2, 3, 4, 5, 6],
+        "used_by_agents": [
+          "design",
+          "html-build",
+          "image-curator",
+          "diagram-specialist",
+          "measure",
+          "pdf-export",
+          "research",
+          "source-verifier",
+          "storyline",
+          "handbook-writer",
+          "handbook-reviewer"
+        ],
+        "phases": [
+          0,
+          1,
+          2,
+          3,
+          4,
+          5,
+          6
+        ],
         "platform_parity": "required"
       },
       {
         "name": "research",
         "layer": "workspace",
-        "used_by_agents": ["research"],
-        "phases": [1],
+        "used_by_agents": [
+          "research"
+        ],
+        "phases": [
+          1
+        ],
         "platform_parity": "required"
       },
       {
         "name": "storyline",
         "layer": "workspace",
-        "used_by_agents": ["storyline"],
-        "phases": [2, 3],
+        "used_by_agents": [
+          "storyline"
+        ],
+        "phases": [
+          2,
+          3
+        ],
         "platform_parity": "required"
       },
       {
         "name": "design",
         "layer": "workspace",
-        "used_by_agents": ["design"],
-        "phases": [3],
+        "used_by_agents": [
+          "design"
+        ],
+        "phases": [
+          3
+        ],
         "platform_parity": "required"
       },
       {
         "name": "html-build",
         "layer": "workspace",
-        "used_by_agents": ["html-build"],
-        "phases": [4],
+        "used_by_agents": [
+          "html-build"
+        ],
+        "phases": [
+          4
+        ],
         "platform_parity": "required"
       },
       {
         "name": "measure",
         "layer": "workspace",
-        "used_by_agents": ["measure"],
-        "phases": [4],
+        "used_by_agents": [
+          "measure"
+        ],
+        "phases": [
+          4
+        ],
         "platform_parity": "required"
       },
       {
         "name": "prep-pdf",
         "layer": "workspace",
-        "used_by_agents": ["measure", "pdf-export"],
-        "phases": [4],
+        "used_by_agents": [
+          "measure",
+          "pdf-export"
+        ],
+        "phases": [
+          4
+        ],
         "platform_parity": "required"
       },
       {
         "name": "pdf-export",
         "layer": "workspace",
-        "used_by_agents": ["pdf-export"],
-        "phases": [4, 5],
+        "used_by_agents": [
+          "pdf-export"
+        ],
+        "phases": [
+          4,
+          5
+        ],
         "platform_parity": "required"
       },
       {
         "name": "theme-authoring",
         "layer": "workspace",
-        "used_by_agents": ["pm"],
+        "used_by_agents": [
+          "pm"
+        ],
         "phases": [],
         "platform_parity": "required"
       },
       {
         "name": "handbook",
         "layer": "workspace",
-        "used_by_agents": ["handbook-writer", "handbook-reviewer"],
-        "phases": ["H-2", "H-3", "H-4", "H-5"],
+        "used_by_agents": [
+          "handbook-writer",
+          "handbook-reviewer"
+        ],
+        "phases": [
+          "H-2",
+          "H-3",
+          "H-4",
+          "H-5"
+        ],
         "platform_parity": "required"
       },
       {
         "name": "presenter-mode",
         "layer": "workspace",
-        "used_by_agents": ["html-build"],
-        "phases": [4],
+        "used_by_agents": [
+          "html-build"
+        ],
+        "phases": [
+          4
+        ],
         "platform_parity": "required"
       }
     ]

--- a/templates/co-develop/variant.json
+++ b/templates/co-develop/variant.json
@@ -38,47 +38,85 @@
     }
   ],
   "skills": [
-    { "name": "code-review" },
-    { "name": "refactoring" },
-    { "name": "swe-solve" },
-    { "name": "test-driven-development" }
+    {
+      "name": "code-review",
+      "file": "skills/code-review/SKILL.md"
+    },
+    {
+      "name": "refactoring",
+      "file": "skills/refactoring/SKILL.md"
+    },
+    {
+      "name": "swe-solve",
+      "file": "skills/swe-solve/SKILL.md"
+    },
+    {
+      "name": "test-driven-development",
+      "file": "skills/test-driven-development/SKILL.md"
+    }
   ],
   "skill_manifest": {
     "variant_specific": [
       {
         "name": "code-review",
         "layer": "workspace",
-        "used_by_agents": ["code-writer"],
-        "phases": [4],
+        "used_by_agents": [
+          "code-writer"
+        ],
+        "phases": [
+          4
+        ],
         "platform_parity": "skip"
       },
       {
         "name": "refactoring",
         "layer": "workspace",
-        "used_by_agents": ["code-writer"],
-        "phases": [4],
+        "used_by_agents": [
+          "code-writer"
+        ],
+        "phases": [
+          4
+        ],
         "platform_parity": "skip"
       },
       {
         "name": "swe-solve",
         "layer": "workspace",
-        "used_by_agents": ["pm"],
-        "phases": [4],
+        "used_by_agents": [
+          "pm"
+        ],
+        "phases": [
+          4
+        ],
         "platform_parity": "required"
       },
       {
         "name": "test-driven-development",
         "layer": "workspace",
-        "used_by_agents": ["test-runner"],
-        "phases": [4],
+        "used_by_agents": [
+          "test-runner"
+        ],
+        "phases": [
+          4
+        ],
         "platform_parity": "skip"
       }
     ]
   },
   "agent_manifest": {
     "variant_agents_dir": "agents",
-    "pipeline_order": ["architect", "designer", "stack-setup", "code-writer", "test-runner", "security-monitor"],
-    "optional": ["designer", "stack-setup"],
+    "pipeline_order": [
+      "architect",
+      "designer",
+      "stack-setup",
+      "code-writer",
+      "test-runner",
+      "security-monitor"
+    ],
+    "optional": [
+      "designer",
+      "stack-setup"
+    ],
     "notes": "designer: skip if no UI/UX component in scope. stack-setup: skip for projects with an existing configured stack."
   }
 }

--- a/templates/co-news/variant.json
+++ b/templates/co-news/variant.json
@@ -5,7 +5,7 @@
   "status": "beta",
   "version": "0.1.0",
   "inherits_common": "templates/common",
-  "created_at": "2026-08-11T15:23:46.046Z",
+  "created_at": "2026-08-10T00:00:00.000Z",
   "lifecycle": {
     "statusSince": "2026-08-10",
     "lastTransition": "initial → beta on 2026-08-10",
@@ -39,19 +39,24 @@
   ],
   "skills": [
     {
-      "name": "ai-tell-reduction"
+      "name": "ai-tell-reduction",
+      "file": "skills/ai-tell-reduction/SKILL.md"
     },
     {
-      "name": "financial-infographic-svg"
+      "name": "financial-infographic-svg",
+      "file": "skills/financial-infographic-svg/SKILL.md"
     },
     {
-      "name": "financial-journalism-style"
+      "name": "financial-journalism-style",
+      "file": "skills/financial-journalism-style/SKILL.md"
     },
     {
-      "name": "financial-narrative-brief"
+      "name": "financial-narrative-brief",
+      "file": "skills/financial-narrative-brief/SKILL.md"
     },
     {
-      "name": "source-verification-ledger"
+      "name": "source-verification-ledger",
+      "file": "skills/source-verification-ledger/SKILL.md"
     }
   ],
   "displayName": "Co-News",
@@ -129,7 +134,6 @@
       }
     ]
   },
-  "created_at": "2026-08-10T00:00:00.000Z",
   "agent_manifest": {
     "variant_agents_dir": "agents",
     "pipeline_order": [],

--- a/templates/co-work/variant.json
+++ b/templates/co-work/variant.json
@@ -38,15 +38,30 @@
     }
   ],
   "skills": [
-    { "name": "api-documentation" },
-    { "name": "documentation-writing" },
-    { "name": "research-analysis" },
-    { "name": "standup-synthesizer" }
+    {
+      "name": "api-documentation",
+      "file": "skills/api-documentation/SKILL.md"
+    },
+    {
+      "name": "documentation-writing",
+      "file": "skills/documentation-writing/SKILL.md"
+    },
+    {
+      "name": "research-analysis",
+      "file": "skills/research-analysis/SKILL.md"
+    },
+    {
+      "name": "standup-synthesizer",
+      "file": "skills/standup-synthesizer/SKILL.md"
+    }
   ],
   "agent_manifest": {
     "variant_agents_dir": "agents",
     "pipeline_order": [],
-    "optional": ["ms365-expert", "storyteller"],
+    "optional": [
+      "ms365-expert",
+      "storyteller"
+    ],
     "notes": "ms365-expert: only when MS365 tooling (Word, Excel, PowerPoint, Teams) is required. storyteller: skip for purely technical or operational work."
   },
   "skill_manifest": {
@@ -54,8 +69,12 @@
       {
         "name": "standup-synthesizer",
         "layer": "workspace",
-        "used_by_agents": ["project-coordinator"],
-        "phases": [4],
+        "used_by_agents": [
+          "project-coordinator"
+        ],
+        "phases": [
+          4
+        ],
         "platform_parity": "required"
       }
     ]


### PR DESCRIPTION
## Why
Five variant templates had `skills[]` entries in `variant.json` with only a `name` field but no `file` field, making skill file discovery indirect. Adding the `file` field establishes a convention for explicit skill-to-SKILL.md mapping, enabling future audit validation (PR8).

## What Changed
- Added `"file": "skills/{name}/SKILL.md"` to 43 skill entries across 5 variant.json files:
  - co-consult: 19 skills
  - co-deck: 11 skills
  - co-develop: 4 skills
  - co-news: 5 skills
  - co-work: 4 skills
- All 43 SKILL.md files were verified to exist before adding the reference

## Test Plan
- [ ] `bun scripts/audit.ts` passes
- [ ] All 43 skills have valid file paths pointing to existing SKILL.md files
- [ ] variant.json files remain valid JSON

## Security Checklist
- [ ] No secrets, credentials, or API keys committed
- [ ] No `.env` files staged (use `.env.sample` for templates)
- [ ] Dependencies unchanged or reviewed for new CVEs

## Notes
None.
