### PR TITLE
fix(scripts): fix validate-agents.ts frontmatter regex for leading-comment files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
 
+- **[2026-08-15]**: fix(scripts): `validate-agents.ts`'s frontmatter regex anchored `---` to the literal start of the file (`^---\n`, no `m` flag), so any agent file with a leading comment before its frontmatter (e.g. co-deck's extends-pattern `pm.md`, which starts with `# @resolved-from: L0/common/agents/pm.md`) was treated as having no frontmatter at all — even though it had a complete, valid `lifecycle:` block. Added the `m` flag so `^---` matches the frontmatter delimiter on any line, not just line 1. v1.0.3→1.0.4, propagated L0→L1. Discovered while fixing missing `lifecycle` frontmatter across several `Projects/co-*` repos.
+
 - **[2026-08-15]**: fix(scripts): `validate-agents.ts` excluded `README.md` from agent lifecycle-frontmatter validation but not `README_ko.md`, causing false-positive "missing lifecycle frontmatter" errors on Korean README files in `agents/` — discovered while unblocking `/sync` for several `Projects/co-*` repos. Broadened the exclusion regex to `^README(_\w+)?\.md$` plus any underscore-prefixed file (`_COMMON.md`, etc.), matching the convention used elsewhere. v1.0.2→1.0.3, propagated L0→L1. `bun scripts/audit.ts` passes clean.
 
 - **[2026-08-15]**: fix(templates): bump `version:` on all 13 `templates/co-game/agents/*.md` files — discovered while syncing `Projects/co-game` with the model-registry update: the same content-changed-without-version-bump bug affected co-game's non-extends agent roster, whose `tier:` comment lines were updated in that earlier PR without bumping `version:`, so `upgrade-project.ts` silently skipped them too. All 12 files 1.0.0→1.0.1, `pm.md` 1.1.0→1.1.1. `bun scripts/audit.ts` passes clean.

--- a/docs/VERSION_MANIFEST.md
+++ b/docs/VERSION_MANIFEST.md
@@ -1,6 +1,6 @@
 # VERSION_MANIFEST.md
 
-**Generated**: 2026-08-15T10:05:49.186Z
+**Generated**: 2026-08-15T10:14:16.974Z
 **Manifest Version**: 1.0
 **Location**: docs\VERSION_MANIFEST.md
 
@@ -134,7 +134,7 @@
 | ticket.ts | 1.0.0 | scripts/ticket.ts | N/A |
 | translate-readme.ts | 1.0.0 | scripts/translate-readme.ts | bun, fs, path |
 | upgrade-project.ts | 1.7.1 | scripts/upgrade-project.ts | N/A |
-| validate-agents.ts | 1.0.3 | scripts/validate-agents.ts | N/A |
+| validate-agents.ts | 1.0.4 | scripts/validate-agents.ts | N/A |
 | validate-doc-folder.ts | 1.0.0 | scripts/validate-doc-folder.ts | fs, path |
 | validate-docs-links.ts | 1.0.0 | scripts/validate-docs-links.ts | fs, path |
 | validate-md-language.ts | 1.4.4 | scripts/validate-md-language.ts | fs |

--- a/memory/2026-08-15.md
+++ b/memory/2026-08-15.md
@@ -1833,3 +1833,21 @@ fix(scripts): fix validate-agents.ts README_ko.md exclusion gap
 
 ## Open Issues
 - None
+
+---
+
+## Session Summary
+fix(scripts): fix validate-agents.ts frontmatter regex for leading-comment files
+
+## Changes
+- `M CHANGELOG.md` — modified
+- `scripts/SCRIPTS.md` — modified
+- `scripts/validate-agents.ts` — modified
+- `templates/common/scripts/SCRIPTS.md` — modified
+- `templates/common/scripts/validate-agents.ts` — modified
+
+## Decisions
+- None
+
+## Open Issues
+- None

--- a/scripts/SCRIPTS.md
+++ b/scripts/SCRIPTS.md
@@ -178,7 +178,7 @@ bun run <alias>                     # via package.json alias (preferred for CI)
 | `ticket.ts` | L0 | 1.0.0 | active | —| —| L0 | —|
 | `upgrade-project.ts` | L0 | 1.7.1 | active | `--variant`, `--platform`, `--dry-run`, `--prune-removed`, `--rollback`, `--yes` | —| L0 | —|
 | `variant-feature.ts` | L0 | 1.0.0 | active | `--variant`, `--feature`, `--type` | —| L0 | —|
-| `validate-agents.ts` | L0 | 1.0.3 | active | —| —| L0+L1 | —|
+| `validate-agents.ts` | L0 | 1.0.4 | active | —| —| L0+L1 | —|
 | `validate-doc-folder.ts` | L0 | 1.0.0 | active | —| —| L0+L1 | —|
 | `validate-docs-links.ts` | L0 | 1.0.0 | active | —| —| L0+L1 | —|
 | `validate-md-language.ts` | L0 | 1.4.4 | active | —| —| L0+L1 | —|

--- a/scripts/validate-agents.ts
+++ b/scripts/validate-agents.ts
@@ -1,7 +1,7 @@
 #!/usr/bin/env bun
 /**
  * Agent Lifecycle Validation Script
- * @version 1.0.3
+ * @version 1.0.4
  *
  * Validates all agents/*.md files for required lifecycle frontmatter
  * and checks governance records in docs/lifecycle/agents/*.md
@@ -98,7 +98,10 @@ function normalizeContent(raw: string): string {
 // Parse frontmatter fields from markdown
 function parseFrontmatter(rawContent: string): Record<string, true> {
   const content = normalizeContent(rawContent);
-  const match = content.match(/^---\n([\s\S]*?)\n---/);
+  // 'm' flag: frontmatter may be preceded by a leading comment line (e.g. co-deck's
+  // "# @resolved-from: ..." annotation on extends-pattern agent files), so the opening
+  // "---" isn't always the first line of the file.
+  const match = content.match(/^---\n([\s\S]*?)\n---/m);
   if (!match) return {};
 
   const fields: Record<string, true> = {};
@@ -124,7 +127,10 @@ function parseFrontmatter(rawContent: string): Record<string, true> {
 // Check nested field existence in frontmatter
 function hasNestedField(rawContent: string, fieldPath: string): boolean {
   const content = normalizeContent(rawContent);
-  const match = content.match(/^---\n([\s\S]*?)\n---/);
+  // 'm' flag: frontmatter may be preceded by a leading comment line (e.g. co-deck's
+  // "# @resolved-from: ..." annotation on extends-pattern agent files), so the opening
+  // "---" isn't always the first line of the file.
+  const match = content.match(/^---\n([\s\S]*?)\n---/m);
   if (!match) return false;
 
   const parts = fieldPath.split('.');

--- a/templates/common/scripts/SCRIPTS.md
+++ b/templates/common/scripts/SCRIPTS.md
@@ -176,7 +176,7 @@ bun run <alias>                     # via package.json alias (preferred for CI)
 | `ticket.ts` | L0 | 1.0.0 | active | —| —| L0 | —|
 | `upgrade-project.ts` | L0 | 1.7.1 | active | `--variant`, `--platform`, `--dry-run`, `--prune-removed`, `--rollback`, `--yes` | —| L0 | —|
 | `variant-feature.ts` | L0 | 1.0.0 | active | `--variant`, `--feature`, `--type` | —| L0 | —|
-| `validate-agents.ts` | L0 | 1.0.3 | active | —| —| L0+L1 | —|
+| `validate-agents.ts` | L0 | 1.0.4 | active | —| —| L0+L1 | —|
 | `validate-doc-folder.ts` | L0 | 1.0.0 | active | —| —| L0+L1 | —|
 | `validate-docs-links.ts` | L0 | 1.0.0 | active | —| —| L0+L1 | —|
 | `validate-md-language.ts` | L0 | 1.4.4 | active | —| —| L0+L1 | —|

--- a/templates/common/scripts/validate-agents.ts
+++ b/templates/common/scripts/validate-agents.ts
@@ -1,7 +1,7 @@
 #!/usr/bin/env bun
 /**
  * Agent Lifecycle Validation Script
- * @version 1.0.3
+ * @version 1.0.4
  *
  * Validates all agents/*.md files for required lifecycle frontmatter
  * and checks governance records in docs/lifecycle/agents/*.md
@@ -98,7 +98,10 @@ function normalizeContent(raw: string): string {
 // Parse frontmatter fields from markdown
 function parseFrontmatter(rawContent: string): Record<string, true> {
   const content = normalizeContent(rawContent);
-  const match = content.match(/^---\n([\s\S]*?)\n---/);
+  // 'm' flag: frontmatter may be preceded by a leading comment line (e.g. co-deck's
+  // "# @resolved-from: ..." annotation on extends-pattern agent files), so the opening
+  // "---" isn't always the first line of the file.
+  const match = content.match(/^---\n([\s\S]*?)\n---/m);
   if (!match) return {};
 
   const fields: Record<string, true> = {};
@@ -124,7 +127,10 @@ function parseFrontmatter(rawContent: string): Record<string, true> {
 // Check nested field existence in frontmatter
 function hasNestedField(rawContent: string, fieldPath: string): boolean {
   const content = normalizeContent(rawContent);
-  const match = content.match(/^---\n([\s\S]*?)\n---/);
+  // 'm' flag: frontmatter may be preceded by a leading comment line (e.g. co-deck's
+  // "# @resolved-from: ..." annotation on extends-pattern agent files), so the opening
+  // "---" isn't always the first line of the file.
+  const match = content.match(/^---\n([\s\S]*?)\n---/m);
   if (!match) return false;
 
   const parts = fieldPath.split('.');


### PR DESCRIPTION
## Why
While fixing missing `lifecycle` frontmatter across several Projects/co-* repos, found that co-deck's extends-pattern `pm.md` (which starts with a `# @resolved-from: L0/common/agents/pm.md` comment before its frontmatter) was reported as missing lifecycle fields even though it had a complete, valid `lifecycle:` block. The validator's regex anchored `---` to the literal start of the file with no `m` flag, so any leading comment broke frontmatter detection entirely.

## What Changed
- scripts/validate-agents.ts: added the `m` flag to both frontmatter-matching regexes so `^---` matches the delimiter on any line, not just line 1
- v1.0.3->1.0.4, propagated L0->L1

## Test Plan
- [x] `bun scripts/audit.ts` passes clean
- [x] Verified against Projects/co-deck's pm.md, which previously false-failed and now passes

## Security Checklist
- [ ] No secrets, credentials, or API keys committed
- [ ] No `.env` files staged (use `.env.sample` for templates)
- [ ] Dependencies unchanged or reviewed for new CVEs

## Notes
None.
