### PR TITLE
fix(upgrade): upgrade-project.ts 1.8.0 — JSDoc version detection, variant scripts/skills sync, agent lifecycle frontmatter preservation

### DIFF
--- a/docs/VERSION_MANIFEST.md
+++ b/docs/VERSION_MANIFEST.md
@@ -1,6 +1,6 @@
 # VERSION_MANIFEST.md
 
-**Generated**: 2026-08-16T23:09:43.038Z
+**Generated**: 2026-08-16T23:13:02.193Z
 **Manifest Version**: 1.0
 **Location**: docs\VERSION_MANIFEST.md
 

--- a/docs/VERSION_MANIFEST.md
+++ b/docs/VERSION_MANIFEST.md
@@ -1,6 +1,6 @@
 # VERSION_MANIFEST.md
 
-**Generated**: 2026-08-16T22:52:38.291Z
+**Generated**: 2026-08-16T23:09:43.038Z
 **Manifest Version**: 1.0
 **Location**: docs\VERSION_MANIFEST.md
 
@@ -134,7 +134,7 @@
 | test-runner.ts | 1.1.0 | scripts/test-runner.ts | fs, os, path |
 | ticket.ts | 1.1.0 | scripts/ticket.ts | N/A |
 | translate-readme.ts | 1.0.0 | scripts/translate-readme.ts | bun, fs, path |
-| upgrade-project.ts | 1.7.1 | scripts/upgrade-project.ts | N/A |
+| upgrade-project.ts | 1.8.0 | scripts/upgrade-project.ts | N/A |
 | validate-agents.ts | 1.0.5 | scripts/validate-agents.ts | N/A |
 | validate-doc-folder.ts | 1.1.0 | scripts/validate-doc-folder.ts | fs, path |
 | validate-docs-links.ts | 1.0.0 | scripts/validate-docs-links.ts | fs, path |

--- a/docs/designs/upgrade-project-content-sync-plan.md
+++ b/docs/designs/upgrade-project-content-sync-plan.md
@@ -105,13 +105,15 @@ bun scripts/upgrade-project.ts Projects/co-architect --dry-run
 
 ## 알려진 한계
 
-`extractScriptVersion`은 `// @version X.Y.Z` (라인 주석) 형식만 인식한다. `scripts/helpers/security-validator.ts`처럼 JSDoc 블록 주석(`/**\n * @version X.Y.Z\n */`) 스타일로 버전을 선언한 파일은 정규식이 매칭되지 않아 항상 "버전 없음"으로 판정되고, `SYNC_IF_NEWER` 대상에서 조용히 제외된다 — 실제로는 버전이 있고 outdated한 파일인데도 사용자에게 아무 경고 없이 영구히 동기화되지 않는다.
+~~`extractScriptVersion`은 `// @version X.Y.Z` (라인 주석) 형식만 인식한다. `scripts/helpers/security-validator.ts`처럼 JSDoc 블록 주석(`/**\n * @version X.Y.Z\n */`) 스타일로 버전을 선언한 파일은 정규식이 매칭되지 않아 항상 "버전 없음"으로 판정되고, `SYNC_IF_NEWER` 대상에서 조용히 제외된다 — 실제로는 버전이 있고 outdated한 파일인데도 사용자에게 아무 경고 없이 영구히 동기화되지 않는다.~~
 
-2026-08-17에 `Projects/co-deck` 업그레이드 중 이 문제로 실제 장애가 발생했다: `scripts/audit.ts`를 최신 버전으로 동기화했더니, 이 최신 `audit.ts`가 `security-validator.ts` 1.1.0에서만 추가된 `sourceShellInjectionPatterns` export를 요구했다. `security-validator.ts`는 위 버그 때문에 계속 1.0.1에 머물러 있었고(정상적으로 SYNC_IF_NEWER 대상이 되었어야 함), 그 결과 `audit.ts` import 시점에 `SyntaxError: Export named 'sourceShellInjectionPatterns' not found`로 파이프라인 전체가 크래시했다. 해당 세션에서는 `audit.ts`/`security-validator.ts` 둘 다 업그레이드에서 제외하고 롤백한 뒤, 정규식 수정 + `security-validator.ts` 자체 테스트(`security-validator.test.ts`, 업그레이드 전부터 6개 실패 상태였음)와 함께 별도 팔로업 작업으로 분리했다.
+~~2026-08-17에 `Projects/co-deck` 업그레이드 중 이 문제로 실제 장애가 발생했다: `scripts/audit.ts`를 최신 버전으로 동기화했더니, 이 최신 `audit.ts`가 `security-validator.ts` 1.1.0에서만 추가된 `sourceShellInjectionPatterns` export를 요구했다. `security-validator.ts`는 위 버그 때문에 계속 1.0.1에 머물러 있었고(정상적으로 SYNC_IF_NEWER 대상이 되었어야 함), 그 결과 `audit.ts` import 시점에 `SyntaxError: Export named 'sourceShellInjectionPatterns' not found`로 파이프라인 전체가 크래시했다. 해당 세션에서는 `audit.ts`/`security-validator.ts` 둘 다 업그레이드에서 제외하고 롤백한 뒤, 정규식 수정 + `security-validator.ts` 자체 테스트(`security-validator.test.ts`, 업그레이드 전부터 6개 실패 상태였음)와 함께 별도 팔로업 작업으로 분리했다.~~
 
-**후속 조치 필요**: `extractScriptVersion`이 JSDoc 스타일(`\*\s*@version\s+(\d+\.\d+\.\d+)`)도 매칭하도록 정규식 확장. 워크스페이스 전역에서 `// @version` vs `* @version` 두 스타일이 몇 개 파일에 쓰이고 있는지 먼저 확인(`grep -rn "\* @version" scripts/` vs `grep -rn "// @version" scripts/`) — 이 설계 문서가 애초에 라인 주석 스타일만 상정하고 작성됐으므로, 다른 파일도 같은 이유로 조용히 스킵되고 있을 가능성이 있다.
+**해결됨 (2026-08-17, upgrade-project.ts v1.8.0)**: `extractScriptVersion`이 이제 `// @version` 라인 주석을 우선 매칭하고, 없으면 JSDoc 스타일(`^\s*\*\s*@version\s+(\d+\.\d+\.\d+)`)을 폴백으로 매칭한다. 구현은 테스트 가능한 순수 헬퍼(`scripts/helpers/upgrade-versions.ts`)로 분리했고 `tests/unit/upgrade-versions.test.ts`에서 두 스타일 모두 검증한다. 같은 이유로 조용히 스킵되던 다른 JSDoc 버전 파일(`lifecycle-sync-audit.ts`, `validate-doc-folder.ts`, `compile-tokens.ts` 등)도 이제 동기화 대상이 된다.
+
+**추가로 해결된 전파 갭 (v1.8.0)**: `upgrade-project.ts`가 이제 변형 전용 콘텐츠도 동기화한다 — `scripts/<variant>/` (버전/해시 기반, 프로젝트 전용 파일 보존, variant SCRIPTS.md 레지스트리 포함)와 `skills/<variant>/` (SKILL.md 프론트매터 버전/해시 기반, 전체 스킬 폴더 미러). agents 덮어쓰기 시 프로젝트의 `lifecycle:` 프론트매터 블록도 보존한다. (변형 docs — `docs/html-themes/`, `docs/designs/` — 는 생성물/이진 아티팩트 특성상 아직 자동 동기화 범위 밖이며 수동 동기화 대상.)
 
 ## 상태
 
 - [x] 구현 완료 — `semverGt`/`extractScriptVersion`/`extractFrontmatterVersion`/`fileHash` 및 `SYNC_IF_NEWER` (scripts/agents/skills), `docs/_common/` OVERWRITE 전부 `upgrade-project.ts`에 반영되어 있고, `Sync files updated` 카운터도 존재함 (커밋 이력상 2026-07-19 `v1.7.0` 확장 작업보다 앞서 구현된 것으로 추정 — 정확한 구현 커밋은 미확인). 2026-08-17 `Projects/co-deck` 업그레이드에서 실제로 정상 동작 확인.
-- [ ] 위 "알려진 한계" 섹션의 JSDoc `@version` 인식 확장 — 미착수, 별도 세션에서 팔로업 예정
+- [x] "알려진 한계" 섹션의 JSDoc `@version` 인식 확장 — **v1.8.0에서 해결됨** (2026-08-17): 라인 주석 우선 + JSDoc 폴백, `scripts/helpers/upgrade-versions.ts`로 분리, `tests/unit/upgrade-versions.test.ts` 7건 통과. 함께 해결: 변형 스크립트/스킬 동기화, agents `lifecycle:` 프론트매터 보존.

--- a/memory/2026-08-17.md
+++ b/memory/2026-08-17.md
@@ -114,3 +114,21 @@ fix(co-deck): scaffold-handbook.ts 1.2.0 — copy all 21 validation scripts so v
 
 ## Open Issues
 - None
+
+---
+
+## Session Summary
+fix(upgrade): upgrade-project.ts 1.8.0 — JSDoc version detection, variant scripts/skills sync, agent lifecycle frontmatter preservation
+
+## Changes
+- `M docs/designs/upgrade-project-content-sync-plan.md` — modified
+- `scripts/SCRIPTS.md` — modified
+- `scripts/upgrade-project.ts` — modified
+- `scripts/helpers/upgrade-versions.ts` — modified
+- `tests/unit/upgrade-versions.test.ts` — modified
+
+## Decisions
+- None
+
+## Open Issues
+- None

--- a/scripts/SCRIPTS.md
+++ b/scripts/SCRIPTS.md
@@ -88,6 +88,7 @@ bun run <alias>                     # via package.json alias (preferred for CI)
 | `helpers/layer-filter.ts` | L0 | 1.4.1 | active | —| —| L0 | —|
 | `helpers/lifecycle-governance.ts` | L0 | 1.0.0 | active | —| —| L0 | —|
 | `helpers/extends-validator.ts` | L0 | 1.0.1 | active | —| —| L0+L1 | —|
+| `helpers/upgrade-versions.ts` | L0 | 1.0.0 | active | —| —| L0 | —|
 | `helpers/merge-frontmatter.ts` | L0 | 1.8.6 | active | —| —| L0+L1 | —|
 | `helpers/security-validator.ts` | L0 | 1.1.0 | active | —| —| L0+L1 | —|
 | `helpers/pm-md-parser.ts` | L0 | 1.1.0 | active | —| —| L0+L1 | —|
@@ -180,7 +181,7 @@ bun run <alias>                     # via package.json alias (preferred for CI)
 | `test-runner.ts` | L0 | 1.1.0 | active | `--parallel`, `--sequential`, `--concurrency <n>`, `--timeout <ms>` | —| L0+L1 | —|
 | `translate-readme.ts` | L0 | 1.0.0 | active | —| —| L0+L1 | —|
 | `ticket.ts` | L0 | 1.1.0 | active | `create --not-before`, `list --kind`, `list --ready` | —| L0 | —|
-| `upgrade-project.ts` | L0 | 1.7.1 | active | `--variant`, `--platform`, `--dry-run`, `--prune-removed`, `--rollback`, `--yes` | —| L0 | —|
+| `upgrade-project.ts` | L0 | 1.8.0 | active | `--variant`, `--platform`, `--dry-run`, `--prune-removed`, `--rollback`, `--yes` | —| L0 | —|
 | `variant-feature.ts` | L0 | 1.0.0 | active | `--variant`, `--feature`, `--type` | —| L0 | —|
 | `validate-agents.ts` | L0 | 1.0.5 | active | —| —| L0+L1 | —|
 | `validate-doc-folder.ts` | L0 | 1.1.0 | active | —| —| L0+L1 | —|

--- a/scripts/helpers/upgrade-versions.ts
+++ b/scripts/helpers/upgrade-versions.ts
@@ -1,0 +1,59 @@
+// @version 1.0.0
+// scripts/helpers/upgrade-versions.ts
+// Pure version-extraction and frontmatter-merge helpers for upgrade-project.ts.
+// Extracted so the version-detection logic is unit-testable (the CLI script's
+// top-level imperative body cannot be imported safely).
+//
+// Usage (in upgrade-project.ts):
+//   import { extractScriptVersion, preserveLifecycleFrontmatter } from "./helpers/upgrade-versions.ts";
+
+import { existsSync, readFileSync } from "node:fs";
+
+/**
+ * Extract a script's version from its header.
+ * Priority: `// @version X.Y.Z` line comment (established convention), then
+ * JSDoc block style `* @version X.Y.Z` (used by security-validator.ts, whose
+ * version lived in a JSDoc block and was silently never detected — see
+ * docs/designs/upgrade-project-content-sync-plan.md §알려진 한계).
+ */
+export function extractScriptVersion(filePath: string): string {
+  if (!existsSync(filePath)) return "";
+  const content = readFileSync(filePath, "utf8");
+  const lineVersion = content.split("\n").find(l => /^\s*\/\/\s*@version\s+\d/.test(l));
+  if (lineVersion) return lineVersion.match(/(\d+\.\d+\.\d+)/)?.[1] ?? "";
+  return content.match(/^\s*\*\s*@version\s+(\d+\.\d+\.\d+)/m)?.[1] ?? "";
+}
+
+/**
+ * Preserve a project-local `lifecycle:` frontmatter block when overwriting an
+ * agent with the template version. L3 projects track agent lifecycle governance
+ * (phase, created, last_updated, governance → docs/lifecycle/agents/*.md) in
+ * frontmatter the template does not carry — a blind overwrite would lose it.
+ * Returns template content with the project's lifecycle block re-inserted (or
+ * the template content unchanged when the project file has no lifecycle block).
+ */
+export function preserveLifecycleFrontmatter(tplContent: string, projContent: string): string {
+  // Locate the `lifecycle:` key inside the project's YAML frontmatter block.
+  const lines = projContent.split("\n");
+  const lifecycleIdx = lines.findIndex(l => /^lifecycle:\s*$/.test(l));
+  if (lifecycleIdx === -1) return tplContent;
+
+  // Collect the indented keys that belong to the lifecycle block.
+  const block: string[] = ["lifecycle:"];
+  for (let i = lifecycleIdx + 1; i < lines.length; i++) {
+    if (/^\s{2,}\S/.test(lines[i])) block.push(lines[i]);
+    else break;
+  }
+  if (block.length === 1) return tplContent;
+
+  const lifecycleBlock = block.join("\n");
+  const tplLines = tplContent.split("\n");
+  // Insert before the closing `---` of the template frontmatter.
+  let closingIdx = -1;
+  for (let i = 1; i < tplLines.length; i++) {
+    if (tplLines[i].trim() === "---") { closingIdx = i; break; }
+  }
+  if (closingIdx === -1) return tplContent;
+  tplLines.splice(closingIdx, 0, lifecycleBlock);
+  return tplLines.join("\n");
+}

--- a/scripts/upgrade-project.ts
+++ b/scripts/upgrade-project.ts
@@ -1,5 +1,5 @@
 #!/usr/bin/env bun
-// @version 1.7.1
+// @version 1.8.0
 // upgrade-project.ts — Upgrade an existing project to the current template version
 // Usage: bun scripts/upgrade-project.ts <project-path> [--variant <variant>] [--platform claude|antigravity|both] [--dry-run] [--prune-removed] [--rollback]
 // v1.3.0: Added multi-pattern managed block support (WORKSPACE-MANAGED, COMMON-CLAUDE, COMMON-GEMINI);
@@ -8,6 +8,10 @@
 // v1.7.0: Added DOCS_MERGE (variant/common docs), VARIANT_DOCS_SYNC, COMMANDS_SYNC;
 //           extended managed block markers (VARIANT-INJECT, COMMON-AGENTS, DYNAMIC_SKILLS);
 //           added sync-skills.ts post-invoke for platform skill distribution
+// v1.8.0: extractScriptVersion now falls back to JSDoc `* @version` headers (files like
+//           security-validator.ts were silently never synced); added variant scripts/skills
+//           sync (templates/<variant>/scripts/<variant>/ and skills/<variant>/ → project);
+//           agent overwrites preserve the project's local `lifecycle:` frontmatter block.
 //
 // Migrated from upgrade-project.sh/ps1 per ADR-0036. No file permission manipulation.
 
@@ -18,6 +22,7 @@ import {
 import { resolve, join, dirname, basename, isAbsolute, relative } from 'node:path';
 import { spawnSync } from 'node:child_process';
 import { createHash } from 'node:crypto';
+import { extractScriptVersion, preserveLifecycleFrontmatter } from './helpers/upgrade-versions.ts';
 
 // ── Argument parsing ───────────────────────────────────────────────────────────
 let projectPath = '';
@@ -224,11 +229,8 @@ function semverGt(a: string, b: string): boolean {
   return false;
 }
 
-function extractScriptVersion(filePath: string): string {
-  if (!existsSync(filePath)) return '';
-  const line = readFileSync(filePath, 'utf8').split('\n').find(l => /^\s*\/\/\s*@version\s+\d/.test(l)) ?? '';
-  return line.match(/(\d+\.\d+\.\d+)/)?.[1] ?? '';
-}
+// extractScriptVersion / preserveLifecycleFrontmatter are imported from
+// ./helpers/upgrade-versions.ts (testable pure helpers).
 
 function extractFrontmatterVersion(filePath: string): string {
   if (!existsSync(filePath)) return '';
@@ -695,7 +697,111 @@ for (const subDir of scriptSubDirs) {
 }
 console.log('');
 
+// ── VARIANT SCRIPTS SYNC: scripts/<variant>/ ─────────────────────────────────
+// Variant-specific scripts (scripts/<variant>/) are not part of the L1 common
+// registry; sync them from templates/<variant>/scripts/<variant>/ so template
+// improvements (e.g. handbook validation scripts) reach the project. Version-
+// based where an @version header exists (line or JSDoc style); hash-based for
+// unversioned files (template is canonical). Project-only files are preserved.
+const variantScriptsSrc = join(templatesDir, 'scripts', variant);
+if (existsSync(variantScriptsSrc)) {
+  console.log(`--- VARIANT SCRIPTS: scripts/${variant}/ ---`);
+  const variantScriptsDst = join(projectDir, 'scripts', variant);
+  const seenVariantScripts = new Set<string>();
+  const syncVariantScripts = (dir: string, rel: string): void => {
+    for (const entry of readdirSync(dir, { withFileTypes: true })) {
+      if (entry.name === '.git' || entry.name === 'node_modules' || entry.name === 'temp') continue;
+      const abs = join(dir, entry.name);
+      const entryRel = rel ? `${rel}/${entry.name}` : entry.name;
+      if (entry.isDirectory()) {
+        syncVariantScripts(abs, entryRel);
+      } else if (entry.isFile() && (entry.name.endsWith('.ts') || entry.name.endsWith('.mjs'))) {
+        seenVariantScripts.add(entryRel);
+        const rel2 = `scripts/${variant}/${entryRel}`;
+        const projFile = join(projectDir, rel2);
+        const tplVer = extractScriptVersion(abs);
+        if (tplVer) {
+          const projVer = existsSync(projFile) ? extractScriptVersion(projFile) : '';
+          if (!existsSync(projFile)) {
+            console.log(`  NEW   ${rel2}  (none) → ${tplVer}`);
+            if (!dryRun) { mkdirSync(dirname(projFile), { recursive: true }); copyFileSync(abs, projFile); }
+            console.log(`  ${dryTag}COPIED: ${rel2}`);
+            syncChanged++;
+          } else if (semverGt(tplVer, projVer)) {
+            if (isLocallyModified(projFile)) {
+              console.log(`  ⚠️  CONFLICT ${rel2}  ${projVer} → ${tplVer}  (local modifications exist — template will overwrite)`);
+            } else {
+              console.log(`  UPDATE ${rel2}  ${projVer} → ${tplVer}`);
+            }
+            if (!dryRun) copyFileSync(abs, projFile);
+            console.log(`  ${dryTag}COPIED: ${rel2}`);
+            syncChanged++;
+          } else {
+            console.log(`  OK     ${rel2}  ${projVer}`);
+          }
+        } else {
+          // Unversioned file — template is canonical; compare by content hash.
+          if (!existsSync(projFile)) {
+            console.log(`  NEW   ${rel2}  (hash)`);
+            if (!dryRun) { mkdirSync(dirname(projFile), { recursive: true }); copyFileSync(abs, projFile); }
+            console.log(`  ${dryTag}COPIED: ${rel2}`);
+            syncChanged++;
+          } else if (fileHash(abs) !== fileHash(projFile)) {
+            if (isLocallyModified(projFile)) {
+              console.log(`  ⚠️  CONFLICT ${rel2}  (unversioned, local modifications exist — template will overwrite)`);
+            } else {
+              console.log(`  UPDATE ${rel2}  (hash changed)`);
+            }
+            if (!dryRun) copyFileSync(abs, projFile);
+            console.log(`  ${dryTag}COPIED: ${rel2}`);
+            syncChanged++;
+          } else {
+            console.log(`  OK     ${rel2}  (hash match)`);
+          }
+        }
+      }
+    }
+  };
+  syncVariantScripts(variantScriptsSrc, '');
+  // Preserve project-only variant scripts (files in the project not in the template).
+  const preserveVariantScripts = (dir: string, rel: string): void => {
+    if (!existsSync(dir)) return;
+    for (const entry of readdirSync(dir, { withFileTypes: true })) {
+      if (entry.name === '.git' || entry.name === 'node_modules' || entry.name === 'temp') continue;
+      const abs = join(dir, entry.name);
+      const entryRel = rel ? `${rel}/${entry.name}` : entry.name;
+      if (entry.isDirectory()) {
+        preserveVariantScripts(abs, entryRel);
+      } else if (entry.isFile() && (entry.name.endsWith('.ts') || entry.name.endsWith('.mjs')) && !seenVariantScripts.has(entryRel)) {
+        console.log(`  PRESERVE (project-only): scripts/${variant}/${entryRel}`);
+      }
+    }
+  };
+  preserveVariantScripts(variantScriptsDst, '');
+  // Sync the variant SCRIPTS.md registry from the template.
+  const variantRegSrc = join(variantScriptsSrc, 'SCRIPTS.md');
+  const variantRegDst = join(variantScriptsDst, 'SCRIPTS.md');
+  if (existsSync(variantRegSrc) && (!existsSync(variantRegDst) || fileHash(variantRegSrc) !== fileHash(variantRegDst))) {
+    console.log(`  UPDATE scripts/${variant}/SCRIPTS.md  (registry)`);
+    if (!dryRun) copyFileSync(variantRegSrc, variantRegDst);
+    console.log(`  ${dryTag}COPIED: scripts/${variant}/SCRIPTS.md`);
+    syncChanged++;
+  }
+  console.log('');
+}
+
 // ── SYNC_IF_NEWER: agents/ ────────────────────────────────────────────────────
+// Writes the template agent content over the project file, preserving the
+// project's local `lifecycle:` frontmatter block (L3 governance records).
+function writeAgentWithLifecycle(tplFile: string, projFile: string): void {
+  if (existsSync(projFile)) {
+    const merged = preserveLifecycleFrontmatter(readFileSync(tplFile, 'utf8'), readFileSync(projFile, 'utf8'));
+    writeFileSync(projFile, merged);
+  } else {
+    copyFileSync(tplFile, projFile);
+  }
+}
+
 console.log('--- SYNC_IF_NEWER: agents/ ---');
 const tplAgentsDirs = [join(templatesDir, 'agents'), join(commonDir, 'agents')];
 const seenAgents = new Set<string>();
@@ -723,7 +829,7 @@ for (const agentsDir of tplAgentsDirs) {
       syncChanged++;
     } else if (!projVer) {
       console.log(`  UPDATE ${rel}  (no version) → ${tplVer}`);
-      if (!dryRun) copyFileSync(tplFile, projFile);
+      if (!dryRun) writeAgentWithLifecycle(tplFile, projFile);
       console.log(`  ${dryTag}COPIED: ${rel}`);
       syncChanged++;
     } else if (semverGt(tplVer, projVer)) {
@@ -733,7 +839,7 @@ for (const agentsDir of tplAgentsDirs) {
       } else {
         console.log(`  UPDATE ${rel}  ${projVer} → ${tplVer}`);
       }
-      if (!dryRun) copyFileSync(tplFile, projFile);
+      if (!dryRun) writeAgentWithLifecycle(tplFile, projFile);
       console.log(`  ${dryTag}COPIED: ${rel}`);
       syncChanged++;
     } else {
@@ -813,6 +919,78 @@ if (existsSync(projSkillsDir)) {
   }
 }
 console.log('');
+
+// ── VARIANT SKILLS SYNC: skills/<variant>/ ───────────────────────────────────
+// Variant-specific skills (skills/<variant>/) are not in the L1 common pool;
+// mirror them from templates/<variant>/skills/<name>/ so skill improvements
+// (e.g. handbook skill content) reach the project. Version/hash-based on the
+// SKILL.md frontmatter; the whole skill directory is mirrored on update.
+const variantSkillsSrc = join(templatesDir, 'skills');
+if (existsSync(variantSkillsSrc)) {
+  console.log(`--- VARIANT SKILLS: skills/${variant}/ ---`);
+  for (const skillName of readdirSync(variantSkillsSrc)) {
+    const tplSkillFile = join(variantSkillsSrc, skillName, 'SKILL.md');
+    if (!existsSync(tplSkillFile)) continue;
+    const tplSkillDir = join(variantSkillsSrc, skillName);
+    const projSkillDir = join(projectDir, 'skills', skillName);
+    const projSkillFile = join(projSkillDir, 'SKILL.md');
+    const tplVer = extractFrontmatterVersion(tplSkillFile);
+    const projVer = existsSync(projSkillFile) ? extractFrontmatterVersion(projSkillFile) : '';
+    const copySkillDir = (): void => {
+      mkdirSync(projSkillDir, { recursive: true });
+      for (const entry of readdirSync(tplSkillDir, { withFileTypes: true })) {
+        const src = join(tplSkillDir, entry.name);
+        const dst = join(projSkillDir, entry.name);
+        if (entry.isDirectory()) {
+          mkdirSync(dst, { recursive: true });
+          for (const sub of readdirSync(src, { withFileTypes: true })) {
+            const subSrc = join(src, sub.name);
+            const subDst = join(dst, sub.name);
+            if (sub.isFile()) copyFileSync(subSrc, subDst);
+          }
+        } else if (entry.isFile()) {
+          copyFileSync(src, dst);
+        }
+      }
+    };
+    if (tplVer) {
+      if (!existsSync(projSkillFile)) {
+        console.log(`  NEW   skills/${skillName}/SKILL.md  (none) → ${tplVer}`);
+        if (!dryRun) copySkillDir();
+        console.log(`  ${dryTag}COPIED: skills/${skillName}/`);
+        syncChanged++;
+      } else if (semverGt(tplVer, projVer)) {
+        if (isLocallyModified(projSkillFile)) {
+          console.log(`  ⚠️  CONFLICT skills/${skillName}/SKILL.md  ${projVer} → ${tplVer}  (local modifications exist — template will overwrite)`);
+        } else {
+          console.log(`  UPDATE skills/${skillName}/SKILL.md  ${projVer} → ${tplVer}`);
+        }
+        if (!dryRun) copySkillDir();
+        console.log(`  ${dryTag}COPIED: skills/${skillName}/`);
+        syncChanged++;
+      } else {
+        console.log(`  OK     skills/${skillName}/SKILL.md  ${projVer}`);
+      }
+    } else {
+      const tplHash = fileHash(tplSkillFile);
+      const projHash = existsSync(projSkillFile) ? fileHash(projSkillFile) : '';
+      if (!existsSync(projSkillFile)) {
+        console.log(`  NEW   skills/${skillName}/SKILL.md  (hash)`);
+        if (!dryRun) copySkillDir();
+        console.log(`  ${dryTag}COPIED: skills/${skillName}/`);
+        syncChanged++;
+      } else if (tplHash !== projHash) {
+        console.log(`  UPDATE skills/${skillName}/SKILL.md  (content changed)`);
+        if (!dryRun) copySkillDir();
+        console.log(`  ${dryTag}COPIED: skills/${skillName}/`);
+        syncChanged++;
+      } else {
+        console.log(`  OK     skills/${skillName}/SKILL.md  (hash match)`);
+      }
+    }
+  }
+  console.log('');
+}
 
 // ── OVERWRITE: docs/_common/ (allowlist) ──────────────────────────────────────
 console.log('--- OVERWRITE: docs/_common/ (governance files) ---');

--- a/tests/unit/upgrade-versions.test.ts
+++ b/tests/unit/upgrade-versions.test.ts
@@ -1,0 +1,92 @@
+import { describe, test, expect, beforeAll, afterAll } from 'bun:test';
+import { mkdirSync, writeFileSync, rmSync, existsSync } from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import { extractScriptVersion, preserveLifecycleFrontmatter } from '../../scripts/helpers/upgrade-versions.ts';
+
+// ── extractScriptVersion ──────────────────────────────────────────────────────
+
+describe('extractScriptVersion', () => {
+  let dir = '';
+
+  beforeAll(() => {
+    dir = join(tmpdir(), `upgrade-versions-test-${Date.now()}`);
+    mkdirSync(dir, { recursive: true });
+    writeFileSync(join(dir, 'line.ts'), '#!/usr/bin/env bun\n// @version 1.2.3\nconsole.log("x");\n');
+    writeFileSync(join(dir, 'jsdoc.ts'), '/**\n * @version 2.0.1\n * Security validator\n */\nexport const x = 1;\n');
+    writeFileSync(join(dir, 'both.ts'), '// @version 3.0.0\n/**\n * @version 9.9.9 (dependency note, not the file version)\n */\nexport const x = 1;\n');
+    writeFileSync(join(dir, 'none.ts'), '// no version header here\nexport const x = 1;\n');
+  });
+
+  afterAll(() => {
+    if (existsSync(dir)) rmSync(dir, { recursive: true, force: true });
+  });
+
+  test('extracts line-comment // @version', () => {
+    expect(extractScriptVersion(join(dir, 'line.ts'))).toBe('1.2.3');
+  });
+
+  test('extracts JSDoc block * @version (security-validator.ts case)', () => {
+    expect(extractScriptVersion(join(dir, 'jsdoc.ts'))).toBe('2.0.1');
+  });
+
+  test('prefers line-comment version when both styles exist', () => {
+    expect(extractScriptVersion(join(dir, 'both.ts'))).toBe('3.0.0');
+  });
+
+  test('returns empty string when no version header exists', () => {
+    expect(extractScriptVersion(join(dir, 'none.ts'))).toBe('');
+  });
+
+  test('returns empty string for missing file', () => {
+    expect(extractScriptVersion(join(dir, 'missing.ts'))).toBe('');
+  });
+});
+
+// ── preserveLifecycleFrontmatter ──────────────────────────────────────────────
+
+describe('preserveLifecycleFrontmatter', () => {
+  const tpl = `---
+name: design
+version: 1.0.0
+status: active
+---
+# Design Agent
+template body`;
+  const projWithLifecycle = `---
+name: design
+version: 1.0.0
+status: active
+lifecycle:
+  phase: production
+  created: "2026-05-29"
+  last_updated: "2026-07-20"
+  governance: docs/lifecycle/agents/design.md
+---
+# Design Agent
+project body`;
+  const projPlain = `---
+name: design
+version: 1.0.0
+status: active
+---
+# Design Agent
+no lifecycle`;
+
+  test('inserts the project lifecycle block into template frontmatter', () => {
+    const merged = preserveLifecycleFrontmatter(tpl, projWithLifecycle);
+    expect(merged).toContain('lifecycle:');
+    expect(merged).toContain('  phase: production');
+    expect(merged).toContain('  governance: docs/lifecycle/agents/design.md');
+    // Template body preserved, project body not carried over.
+    expect(merged).toContain('template body');
+    expect(merged).not.toContain('project body');
+    // Frontmatter still closed exactly once before the body.
+    const head = merged.split('# Design Agent')[0];
+    expect(head.match(/^---$/gm)).toHaveLength(2);
+  });
+
+  test('returns template content unchanged when project has no lifecycle block', () => {
+    expect(preserveLifecycleFrontmatter(tpl, projPlain)).toBe(tpl);
+  });
+});


### PR DESCRIPTION
## Why

`upgrade-project.ts` silently failed to propagate template changes to L3 projects in three ways: (1) `extractScriptVersion` only matched `// @version` line comments, so files declaring versions in JSDoc blocks (notably `security-validator.ts`) were treated as "no version" and never synced — the root cause of the recurring `audit.ts` 2.13.0 / `security-validator.ts` 1.0.1 import crash (documented as a known limitation in `docs/designs/upgrade-project-content-sync-plan.md` §Known Limitations); (2) variant-specific content (`scripts/<variant>/`, `skills/<variant>/`) was never synced at all, so handbook scripts/skills had to be copied by hand; (3) agent overwrites destroyed project-local `lifecycle:` frontmatter (L3 governance records).

## What Changed

- **`scripts/upgrade-project.ts` 1.7.1 → 1.8.0**
  - `extractScriptVersion` now falls back to JSDoc `* @version` headers after the `// @version` line-comment check — files like `security-validator.ts`, `lifecycle-sync-audit.ts`, `compile-tokens.ts`, `validate-doc-folder.ts` are now detected and synced
  - **New: variant scripts sync** — `templates/<variant>/scripts/<variant>/` → project (version-based, hash-based fallback for unversioned files, project-only files preserved, variant `SCRIPTS.md` registry synced)
  - **New: variant skills sync** — `templates/<variant>/skills/<name>/` → project (SKILL.md frontmatter version/hash-based, whole skill dir mirrored)
  - **Agent overwrites preserve `lifecycle:` frontmatter** — the project's local lifecycle block is re-inserted into the template content instead of being lost
- **`scripts/helpers/upgrade-versions.ts` (new, 1.0.0)**: pure, testable implementations of `extractScriptVersion` + `preserveLifecycleFrontmatter`, imported by upgrade-project.ts
- **`tests/unit/upgrade-versions.test.ts` (new)**: 7 tests covering line/JSDoc/both/none/missing version cases + lifecycle frontmatter preservation
- **`docs/designs/upgrade-project-content-sync-plan.md`**: the "Known Limitations" section is marked resolved; documents the new variant sync scope
- **`scripts/SCRIPTS.md`**: upgrade-project.ts → 1.8.0, new helper registered

## Test Plan

- [x] `bun scripts/audit.ts` passes (✅ All checks passed)
- [x] `bun scripts/lifecycle-sync-audit.ts` passes (0 errors, 7 pre-existing warnings)
- [x] `bun test tests/unit/upgrade-versions.test.ts` — 7/7 pass
- [x] `bun scripts/upgrade-project.ts Projects/co-deck --dry-run` — variant scripts/skills sections now appear and detect `security-validator.ts 1.0.1 → 1.1.0`, `audit.ts 2.10.17 → 2.13.0`, and all variant handbook scripts
- [x] Full unit suite — only the known pre-existing flaky `hook-post-write-lifecycle.test.ts` "reads git diff" timeout fails (documented in CHANGELOG, unrelated)

## Security Checklist

- [ ] No secrets, credentials, or API keys committed
- [ ] No `.env` files staged
- [ ] Dependencies unchanged

## Notes

- The variant sync sections are no-ops for variants without `scripts/<variant>/` or `skills/<variant>/` directories. Agent lifecycle preservation is a no-op when the project file has no `lifecycle:` block.
- Variant docs (`docs/html-themes/`, `docs/designs/`) remain outside the automatic sync scope (generated/binary artifacts); tracked as follow-up.
- This PR is a prerequisite for the `Projects/co-deck` propagation fix (next PR): running the fixed tool syncs `security-validator.ts` 1.1.0 + `audit.ts` 2.13.0 and all variant handbook content automatically.
