### PR TITLE
docs: close ADR/CONSTITUTION.md gaps and add intro-to-ai-harness course to README Learning Resources

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
 
+### Added
+- **[2026-08-21]**: docs(readme): added the "Claude Code and Multi-Agent Harness" introductory course (https://5throck.github.io/intro-to-ai-harness/) to the Learning Resources section of all 4 README language variants (`README.md`, `README_ko.md`, `README_ja.md`, `README_es.md`), each with a translated description matching that file's language, positioned before the existing (more advanced) Multi-Agent Harness Engineering Handbook link as the recommended starting point for beginners.
+
+### Changed
+- **[2026-08-21]**: docs(constitution): closed 3 gaps between settled ADR decisions and `CONSTITUTION.md`'s delegated `docs/constitution/*.md` files, found via a full 39-ADR audit — ADR-0025 (Root Directory Protection / `workspace-schema.json § rootAllowlist` default-deny) added to `docs/constitution/01-folder-structure.md` §1.2; ADR-0026 (every new variant requires an ADR) and ADR-0028 (`PROMOTION_CHECKLIST.md` Universal vs. Domain-specific condition split) added to `docs/constitution/07-new-project.md` as new §7.6. The other 36 ADRs were confirmed already covered, superseded, or narrow single-script details not warranting workspace-wide policy documentation.
+
 ### Changed
 - **[2026-08-21]**: docs(governance): reflected this session's Context Commonization Review + WS-09 structure-standardization work into the design/governance docs: `docs/governance/variant-contract.md` gained a "Context.md Structure Standard" section (parallel to the existing "README Standard"/WS-08 section, documenting WS-09's slot schema, exemptions, and severity policy); `docs/adr/0050-variant-script-inheritance-and-golden-reference-ssot.md` gained two Implementation Status entries (the "Scripts" promotion + the `Hybrid Scripting` nested-subsection bug it surfaced, and the WS-09 structural-standardization decision); `docs/constitution/00-ssot-architecture.md`'s SSOT flow table gained a WS-09 row (explicitly noting it enforces structure only, not content — no single SSOT file the way `docs/context.md`/`README.md` have); `skills/context-commonization-review/SKILL.md` (1.0.0 → 1.1.0) documents the nested-`###`-subsection defect as a known caveat to check for before running `promote-context-section.ts` without `--dry-run`, and cross-references WS-09 as a related-but-distinct concern (content dedup vs. structural conformance).
 

--- a/README.md
+++ b/README.md
@@ -302,7 +302,13 @@ Checks: agent frontmatter completeness, required sections (`## Meeting Participa
 
 ## 📚 Learning Resources
 
-A comprehensive educational handbook is available for practitioners looking to master the multi-agent workflow of this workspace:
+New to this workspace? Start with the beginner-friendly introductory course:
+
+**[Claude Code and Multi-Agent Harness](https://5throck.github.io/intro-to-ai-harness/)**
+
+A practical, hands-on guide for AI beginners and Claude Desktop App users (macOS, Windows, Linux). 13 chapters across 4 parts — foundations, two hands-on projects (co-consult, co-deck), building custom agents/skills/teams, and workflow automation — each with step-by-step exercises.
+
+For practitioners ready to go deeper, a comprehensive educational handbook is also available:
 
 **[Multi-Agent Harness Engineering Handbook](https://5throck.github.io/multi-agent-harness-handbook/)**
 
@@ -332,4 +338,4 @@ AGPL-3.0 - see [LICENSE](LICENSE)
 
 ---
 
-*Maintained by [@5throck](https://github.com/5throck) · Last Updated: 2026-08-15*
+*Maintained by [@5throck](https://github.com/5throck) · Last Updated: 2026-08-21*

--- a/README_es.md
+++ b/README_es.md
@@ -291,7 +291,13 @@ Verifica: completitud del frontmatter del agente, secciones requeridas (`## Meet
 
 ## 📚 Recursos de Aprendizaje (Learning Resources)
 
-Un manual educativo completo está disponible para los profesionales que deseen dominar el flujo de trabajo multi-agente de este espacio de trabajo:
+¿Nuevo en este espacio de trabajo? Comienza con el curso introductorio para principiantes:
+
+**[Claude Code and Multi-Agent Harness](https://5throck.github.io/intro-to-ai-harness/)**
+
+Una guía práctica y aplicada para principiantes en IA y usuarios de Claude Desktop App (macOS, Windows, Linux). 13 capítulos en 4 partes — fundamentos, dos proyectos prácticos (co-consult, co-deck), creación de agentes/skills/equipos personalizados y automatización de flujos de trabajo — cada uno con ejercicios paso a paso.
+
+Para profesionales que buscan profundizar más, también está disponible un manual educativo completo:
 
 **[Manual de Multi-Agent Harness Engineering](https://5throck.github.io/multi-agent-harness-handbook/)**
 

--- a/README_ja.md
+++ b/README_ja.md
@@ -295,7 +295,13 @@ bun scripts/validate-templates.ts
 
 ## 📚 学習リソース (Learning Resources)
 
-本ワークスペースのマルチエージェントワークフローを習得したい実践者向けの包括的な教育ハンドブックがあります：
+このワークスペースが初めての方は、初心者向けの入門コースから始めてください：
+
+**[Claude Code and Multi-Agent Harness](https://5throck.github.io/intro-to-ai-harness/)**
+
+AI初心者およびClaude Desktop Appユーザー（macOS、Windows、Linux）向けの実践的なハンズオンガイドです。4パート・全13章で構成され、基礎概念、2つの実践プロジェクト（co-consult、co-deck）、カスタムエージェント/スキル/チームの構築、ワークフロー自動化をステップバイステップの演習とともに扱います。
+
+さらに深く学びたい実践者向けには、包括的な教育ハンドブックもあります：
 
 **[Multi-Agent Harness Engineering ハンドブック](https://5throck.github.io/multi-agent-harness-handbook/)**
 
@@ -325,4 +331,4 @@ AGPL-3.0 - [LICENSE](LICENSE)を参照
 
 ---
 
-*Maintained by [@5throck](https://github.com/5throck) · Last Updated: 2026-08-15*
+*Maintained by [@5throck](https://github.com/5throck) · Last Updated: 2026-08-21*

--- a/README_ko.md
+++ b/README_ko.md
@@ -299,7 +299,13 @@ bun scripts/validate-templates.ts
 
 ## 📚 학습 리소스 (Learning Resources)
 
-본 워크스페이스의 멀티 에이전트 워크플로를 습득하려는 실무자를 위한 종합 교육 핸드북이 제공됩니다:
+이 워크스페이스가 처음이라면, 초보자를 위한 입문 과정부터 시작하세요:
+
+**[Claude Code and Multi-Agent Harness](https://5throck.github.io/intro-to-ai-harness/)**
+
+AI 입문자 및 Claude Desktop App 사용자(macOS, Windows, Linux)를 위한 실습 중심 가이드입니다. 4개 파트, 13개 챕터로 구성되어 있으며 — 기초 개념, 두 가지 실습 프로젝트(co-consult, co-deck), 커스텀 에이전트/스킬/팀 구축, 워크플로 자동화를 각 단계별 실습과 함께 다룹니다.
+
+더 깊이 있는 학습을 원하는 실무자를 위해, 종합 교육 핸드북도 제공됩니다:
 
 **[Multi-Agent Harness Engineering 핸드북](https://5throck.github.io/multi-agent-harness-handbook/)**
 
@@ -329,4 +335,4 @@ AGPL-3.0 - [LICENSE](LICENSE) 파일 참조
 
 ---
 
-*Maintained by [@5throck](https://github.com/5throck) · Last Updated: 2026-08-15*
+*Maintained by [@5throck](https://github.com/5throck) · Last Updated: 2026-08-21*

--- a/docs/VERSION_MANIFEST.md
+++ b/docs/VERSION_MANIFEST.md
@@ -1,6 +1,6 @@
 # VERSION_MANIFEST.md
 
-**Generated**: 2026-08-21T02:41:43.648Z
+**Generated**: 2026-08-21T02:58:00.936Z
 **Manifest Version**: 1.0
 **Location**: docs\VERSION_MANIFEST.md
 

--- a/docs/constitution/01-folder-structure.md
+++ b/docs/constitution/01-folder-structure.md
@@ -59,3 +59,4 @@ Every project follows this layout. Omit folders that don't apply to the project 
 - **Orchestration**: `agents/pm.md` is always created - even for single-agent or simple projects.
 - **Agent Index**: `AGENTS.md` is always created at the project root - it is the canonical agent roster shared by all AI tools. Keep it in sync with `docs/context.md ## Agents` (or `CONSTITUTION.md` for the root workspace).
 - **Secrets**: `.env.sample` is always committed; `.env` is always in `.gitignore`.
+- **Root Directory Protection (ADR-0025)**: `docs/workspace-schema.json § rootAllowlist` (`files` + `dirs`) is the SSOT for what may exist at the workspace root — a default-deny allowlist. `audit.ts` fails on any root-level item not present in it. Test, debug, and temporary scripts MUST live under `tests/`, never at root; adding a new legitimate root item requires updating `rootAllowlist` in the same change.

--- a/docs/constitution/07-new-project.md
+++ b/docs/constitution/07-new-project.md
@@ -183,3 +183,8 @@ This table tracks the **variant-authoring** lifecycle specifically (creating a b
 > - `l2-to-variant-pipeline.ts` — promotes that L3 draft into an official L2 variant template at `templates/co-<name>/` (same naming-predates-L3 caveat; its helpers `helpers/scan-l3-project.ts` and `helpers/reconcile-with-l0-l1.ts` now use L3-correct identifiers internally, matching this document's terminology)
 > - `new-project.ts` — separately, creates an ordinary L3 project at `Projects/<name>/` from an *existing* L2 variant template — this is the everyday project-creation path, not variant authoring
 > - `propagate:apply` — syncs L0→L1(common); `propagate:docs` — syncs L1(common)→L2(variants)
+
+#### 7.6 New Variant Requirements
+
+- **ADR Requirement (ADR-0026)**: Every new variant addition MUST be accompanied by an ADR (`docs/adr/`) documenting the domain problem addressed, the rationale for the chosen agent roster, and how the variant differs from existing variants.
+- **PROMOTION_CHECKLIST.md Universal vs. Domain-specific conditions (ADR-0028)**: Conditions split into **Universal** (agent/`AGENTS.md` registration, `CLAUDE.md`↔`GEMINI.md` platform parity, `bun install`/setup success, human sign-off on `_ORIGIN.md` § Manual Phase B Steps — non-overridable by any variant) and **Domain-specific** (skill validation, domain artifact completeness, domain audit script — each variant must define its own; an unmodified `TODO:` placeholder blocks promotion).

--- a/memory/2026-08-21.md
+++ b/memory/2026-08-21.md
@@ -271,3 +271,23 @@ docs(governance): reflect Context Commonization Review + WS-09 structure standar
 
 ## Open Issues
 - None
+
+---
+
+## Session Summary
+docs: close ADR/CONSTITUTION.md gaps and add intro-to-ai-harness course to README Learning Resources
+
+## Changes
+- `M CHANGELOG.md` — modified
+- `README.md` — modified
+- `README_es.md` — modified
+- `README_ja.md` — modified
+- `README_ko.md` — modified
+- `docs/constitution/01-folder-structure.md` — modified
+- `docs/constitution/07-new-project.md` — modified
+
+## Decisions
+- None
+
+## Open Issues
+- None


### PR DESCRIPTION
## Why
Two follow-up requests: (1) close gaps between settled ADR decisions and CONSTITUTION.md's delegated docs — some ADRs establish durable workspace policy that was never actually reflected in the governance hub; (2) add the new beginner-friendly "Claude Code and Multi-Agent Harness" course to the README's Learning Resources section, in every language variant.

## What Changed
- `docs/constitution/01-folder-structure.md` §1.2: added ADR-0025's Root Directory Protection rule (`workspace-schema.json § rootAllowlist` default-deny)
- `docs/constitution/07-new-project.md`: new §7.6 "New Variant Requirements" — ADR-0026 (ADR required per new variant) + ADR-0028 (PROMOTION_CHECKLIST.md Universal vs. Domain-specific split)
- `README.md`, `README_ko.md`, `README_ja.md`, `README_es.md`: added the intro-to-ai-harness course link to Learning Resources, each with a description translated to that file's language, positioned before the existing (more advanced) handbook link

## Test Plan
- [x] `bun scripts/audit.ts` passes
- [x] `bun scripts/validate-docs-links.ts` passes (new URLs resolve)
- [x] Verified the intro-to-ai-harness course content via WebFetch before writing translated descriptions, to avoid fabricating details

## Security Checklist
- [x] No secrets, credentials, or API keys committed
- [x] No `.env` files staged (use `.env.sample` for templates)
- [x] Dependencies unchanged or reviewed for new CVEs

## Notes
The full 39-ADR audit (delegated to a research subagent) found only 3 genuine gaps; the remaining 36 ADRs were already covered, superseded by a later ADR, or narrow single-script details that don't warrant workspace-wide policy documentation.
