### PR TITLE
test(variant): add Variant Readiness Gate regression test (VRG)

### DIFF
--- a/README.md
+++ b/README.md
@@ -193,7 +193,8 @@ C:\git\ (workspace root - this repo)
     ├── co-news/             # 🔶 Beta — business/finance journalism agent team (KR country profile included)
     ├── co-abap/             # ✅ Stable — SAP ABAP development agent team
     ├── co-hr/                # 🔶 Beta — HR & labor-relations consulting agent team (KR country profile included)
-    └── co-safety/            # 🔶 Beta — EHS/GxP compliance platform agent team
+    ├── co-safety/            # 🔶 Beta — EHS/GxP compliance platform agent team
+    └── co-price/            # ⚠️ Beta — K-Beauty pricing management & consulting simulator
 ```
 
 Each sub-project lives in its own directory and git repository:

--- a/README_ko.md
+++ b/README_ko.md
@@ -190,7 +190,8 @@ C:\git\ (워크스페이스 루트 - 현재 저장소)
     ├── co-news/             # 🔶 Beta — 경제/금융 저널리즘 에이전트 팀 (KR 국가 프로필 포함)
     ├── co-abap/             # ✅ Stable — SAP ABAP 개발 에이전트 팀
     ├── co-hr/                # 🔶 Beta — 노무/HR 컨설팅 에이전트 팀 (KR 국가 프로필 포함)
-    └── co-safety/            # 🔶 Beta — EHS/GxP 컴플라이언스 플랫폼 에이전트 팀
+    ├── co-safety/            # 🔶 Beta — EHS/GxP 컴플라이언스 플랫폼 에이전트 팀
+    └── co-price/            # ⚠️ Beta — K-Beauty 가격 관리 및 컨설팅 시뮬레이터
 ```
 
 각 하위 프로젝트는 자체 디렉토리 및 개별 Git 저장소로 관리됩니다:

--- a/docs/VERSION_MANIFEST.md
+++ b/docs/VERSION_MANIFEST.md
@@ -1,6 +1,6 @@
 # VERSION_MANIFEST.md
 
-**Generated**: 2026-08-27T06:00:33.014Z
+**Generated**: 2026-08-27T12:38:13.253Z
 **Manifest Version**: 1.0
 **Location**: docs\VERSION_MANIFEST.md
 
@@ -10,7 +10,7 @@
 
 - **Agents**: 8
 - **Skills**: 37
-- **Scripts**: 82
+- **Scripts**: 83
 - **Commands**: 8
 
 ---
@@ -136,6 +136,7 @@
 | test-new-project.ts | 1.0.4 | scripts/test-new-project.ts | bun |
 | test-platform-parity.ts | 0.2.4 | scripts/test-platform-parity.ts | fs, path |
 | test-runner.ts | 1.1.0 | scripts/test-runner.ts | fs, os, path |
+| test-variant-readiness.ts | 1.0.0 | scripts/test-variant-readiness.ts | N/A |
 | ticket.ts | 1.1.0 | scripts/ticket.ts | N/A |
 | translate-readme.ts | 1.0.0 | scripts/translate-readme.ts | bun, fs, path |
 | upgrade-project.ts | 1.10.1 | scripts/upgrade-project.ts | N/A |

--- a/docs/designs/variant-readiness-gate.md
+++ b/docs/designs/variant-readiness-gate.md
@@ -96,3 +96,5 @@ These are implemented; the gate then verifies the output independently.
 - `docs/governance/variant-lifecycle.md` (lifecycle stages; VRG is a beta→stable prerequisite)
 - `docs/creating-a-variant.md` (authoring guide; Step 6 includes the gate)
 - `docs/lifecycle/skills/project-to-variant.md` (lightweight pipeline; gate is enforced)
+- `scripts/test-variant-readiness.ts` — VRG regression test: a well-formed variant exits 0 (READY);
+  a variant missing `PROMOTION_CHECKLIST.md` or with an unresolved `agents[].file` exits 1 (NOT READY)

--- a/docs/templates/VERSION_REGISTRY.json
+++ b/docs/templates/VERSION_REGISTRY.json
@@ -1,6 +1,6 @@
 {
   "version": "1.0.0",
-  "last_updated": "2026-08-26",
+  "last_updated": "2026-08-27",
   "description": "Central version registry for all template variants",
   "variants": {
     "co-develop": {
@@ -122,6 +122,13 @@
       "latest": "0.1.0",
       "status": "beta",
       "released": "2026-08-26",
+      "security_advisories": [],
+      "migration_guides": []
+    },
+    "co-price": {
+      "latest": "4.1.0",
+      "status": "beta",
+      "released": "2026-08-27",
       "security_advisories": [],
       "migration_guides": []
     }

--- a/memory/2026-08-27.md
+++ b/memory/2026-08-27.md
@@ -1599,3 +1599,20 @@ feat(variant): enforce Variant Readiness Gate continuously via validate-template
 
 ## Open Issues
 - None
+
+---
+
+## Session Summary
+test(variant): add Variant Readiness Gate regression test (VRG)
+
+## Changes
+- `docs/designs/variant-readiness-gate.md` — modified
+- `docs/templates/VERSION_REGISTRY.json` — modified
+- `scripts/SCRIPTS.md` — modified
+- `scripts/test-variant-readiness.ts` — modified
+
+## Decisions
+- None
+
+## Open Issues
+- None

--- a/scripts/SCRIPTS.md
+++ b/scripts/SCRIPTS.md
@@ -194,6 +194,7 @@ bun run <alias>                     # via package.json alias (preferred for CI)
 | `test-new-project.ts` | L0 | 1.0.4 | active | —| —| L0 | —|
 | `test-extends-validator.ts` | L0 | 1.0.1 | active | —| —| L0 | —|
 | `test-l3-to-variant-promotion.ts` | L0 | 1.1.0 | active | —| —| L0 | —|
+| `test-variant-readiness.ts` | L0 | 1.0.0 | active | —| —| L0 | —|
 | `test-runner.ts` | L0 | 1.1.0 | active | `--parallel`, `--sequential`, `--concurrency <n>`, `--timeout <ms>` | —| L0+L1 | —|
 | `translate-readme.ts` | L0 | 1.0.0 | active | —| —| L0+L1 | —|
 | `ticket.ts` | L0 | 1.1.0 | active | `create --not-before`, `list --kind`, `list --ready` | —| L0 | —|

--- a/scripts/test-variant-readiness.ts
+++ b/scripts/test-variant-readiness.ts
@@ -1,0 +1,97 @@
+#!/usr/bin/env bun
+/**
+ * test-variant-readiness.ts — Regression test for the Variant Readiness Gate (VRG)
+ *
+ * @version 1.0.0
+ *
+ * Verifies that `validate-variant-readiness.ts`:
+ *   1. exits 0 (READY) for a well-formed variant, and
+ *   2. exits 1 (NOT READY) for a variant missing PROMOTION_CHECKLIST.md, and
+ *   3. exits 1 (NOT READY) for a variant with an unresolved agents[].file path.
+ *
+ * Uses temporary directories under os.tmpdir(); nothing under templates/ is touched.
+ *
+ * Usage:
+ *   bun scripts/test-variant-readiness.ts
+ */
+
+import { existsSync, mkdirSync, rmSync, writeFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import { spawnSync } from 'node:child_process';
+
+const gateScript = join(import.meta.dir, 'validate-variant-readiness.ts');
+
+let failures = 0;
+function check(label: string, cond: boolean): void {
+  if (cond) {
+    console.log(`  ✓ ${label}`);
+  } else {
+    console.error(`  ✗ ${label}`);
+    failures++;
+  }
+}
+
+function runGate(dir: string): number {
+  const res = spawnSync(process.execPath, [gateScript, '--dir', dir], { encoding: 'utf8' });
+  return res.status ?? 1;
+}
+
+function writeVariant(root: string, opts: { promotionChecklist?: boolean; resolveAgents?: boolean }): void {
+  mkdirSync(join(root, 'agents'), { recursive: true });
+  mkdirSync(join(root, 'skills', 'sync'), { recursive: true });
+  writeFileSync(
+    join(root, 'variant.json'),
+    JSON.stringify(
+      {
+        name: 'test-vrg',
+        description: 'temp VRG regression fixture',
+        status: 'beta',
+        agents: [{ name: 'pm', file: opts.resolveAgents === false ? 'agents/missing.md' : 'agents/pm.md' }],
+        skills: [{ name: 'sync', file: 'skills/sync/SKILL.md' }],
+      },
+      null,
+      2,
+    ),
+  );
+  writeFileSync(join(root, 'agents', 'pm.md'), '# pm\n\nStub agent file for VRG test.\n');
+  writeFileSync(join(root, 'skills', 'sync', 'SKILL.md'), '---\nname: sync\n---\n\nStub skill.\n');
+  writeFileSync(join(root, 'README.md'), '# test-vrg\n');
+  writeFileSync(
+    join(root, 'AGENTS.md'),
+    '# AGENTS\n\n<!-- VARIANT-AGENTS-START -->\nroster\n<!-- VARIANT-AGENTS-END -->\n',
+  );
+  if (opts.promotionChecklist !== false) {
+    writeFileSync(join(root, 'PROMOTION_CHECKLIST.md'), '# PROMOTION_CHECKLIST\n');
+  }
+}
+
+console.log('Variant Readiness Gate — regression test');
+
+// 1. Valid variant -> READY (exit 0)
+const validDir = join(tmpdir(), `vrg-valid-${Date.now()}`);
+mkdirSync(validDir, { recursive: true });
+writeVariant(validDir, { promotionChecklist: true, resolveAgents: true });
+check('valid variant exits 0 (READY)', runGate(validDir) === 0);
+rmSync(validDir, { recursive: true, force: true });
+
+// 2. Missing PROMOTION_CHECKLIST.md -> NOT READY (exit 1)
+const noPcDir = join(tmpdir(), `vrg-nopc-${Date.now()}`);
+mkdirSync(noPcDir, { recursive: true });
+writeVariant(noPcDir, { promotionChecklist: false, resolveAgents: true });
+check('missing PROMOTION_CHECKLIST.md exits 1 (NOT READY)', runGate(noPcDir) === 1);
+rmSync(noPcDir, { recursive: true, force: true });
+
+// 3. Unresolved agents[].file -> NOT READY (exit 1)
+const badAgentDir = join(tmpdir(), `vrg-badagent-${Date.now()}`);
+mkdirSync(badAgentDir, { recursive: true });
+writeVariant(badAgentDir, { promotionChecklist: true, resolveAgents: false });
+check('unresolved agents[].file exits 1 (NOT READY)', runGate(badAgentDir) === 1);
+rmSync(badAgentDir, { recursive: true, force: true });
+
+if (failures > 0) {
+  console.error(`\n✗ VRG regression test FAILED (${failures} check(s))`);
+  process.exit(1);
+}
+console.log('\n✓ VRG regression test passed');
+process.exit(0);

--- a/templates/README.md
+++ b/templates/README.md
@@ -19,6 +19,7 @@ templates/
 ├── co-work/             # Collaboration variant
 ├── co-security/         # Security engagement variant
 ├── co-consult/          # Strategy consulting variant
+├── co-price/           # Pricing management & consulting variant (beta)
 ├── co-deck/             # Lecture/presentation variant (beta)
 ├── co-game/             # Game development variant
 ├── co-export/           # Import/export trade compliance variant (beta)
@@ -41,6 +42,7 @@ templates/
 | [`co-work`](co-work/) | ✅ Stable | General collaboration workflow with 7 agents (pm, analyst, content-writer, ms365-expert, etc.) |
 | [`co-security`](co-security/) | ✅ Stable | Security engagement workflow with 6 agents (pm, red-team-lead, pentester, threat-modeler, etc.) |
 | [`co-consult`](co-consult/) | ✅ Stable | Strategy consulting with 11 agents and 16 domain skills |
+| [`co-price`](co-price/) | ⚠️ Beta | K-Beauty pricing management & consulting simulator with 15 agents (PM, finance-strategy-lead, cpa-auditor, pricing-strategist, market-intelligence-analyst, engagement-director) and 21 skills (harness-verification, trade-promotion-roi, pricing-governance, map-channel-enforcement) |
 | [`co-deck`](co-deck/) | 🔶 Beta | Lecture/presentation production with 13 agents and multi-theme HTML-to-PDF pipeline |
 | [`co-game`](co-game/) | ✅ Stable | Game development for HTML5 Canvas with Vanilla TypeScript and 13 agents |
 | [`co-export`](co-export/) | 🔶 Beta | Import/export trade-compliance workflow with 8 agents (HS classification, export control, FTA origin, duty drawback, logistics, market entry, foreign regulation monitoring, trade documentation) |

--- a/templates/README_ko.md
+++ b/templates/README_ko.md
@@ -25,7 +25,8 @@ templates/
 ├── co-news/             # 경제/금융 저널리즘 variant (beta)
 ├── co-abap/             # SAP ABAP 개발 variant (stable)
 ├── co-hr/               # 노무/HR 컨설팅 variant (beta)
-└── co-safety/           # EHS/GxP 컴플라이언스 플랫폼 variant (beta)
+├── co-safety/           # EHS/GxP 컴플라이언스 플랫폼 variant (beta)
+└── co-price/           # 가격 관리 및 컨설팅 variant (beta)
 ```
 
 **동작 방식:** 새 프로젝트를 스캐폴딩할 때, 스크립트는 먼저 `templates/common/`(공유 인프라)을 복사한 다음 선택된 variant를 덮어씁니다(variant 전용 파일이 공통 파일을 재정의).


### PR DESCRIPTION
## Why
test(variant): add Variant Readiness Gate regression test (VRG)

## What Changed
- README.md
- README_ko.md
- docs/VERSION_MANIFEST.md
- docs/designs/variant-readiness-gate.md
- docs/templates/VERSION_REGISTRY.json
- memory/2026-08-27.md
- scripts/SCRIPTS.md
- scripts/test-variant-readiness.ts
- templates/README.md
- templates/README_ko.md

## Test Plan
- [ ] `bun scripts/audit.ts` passes
- [ ] CHANGELOG.md updated under `[Unreleased]`

## Security Checklist
- [ ] No secrets, credentials, or API keys committed
- [ ] No `.env` files staged (use `.env.sample` for templates)
- [ ] Dependencies unchanged or reviewed for new CVEs

## Notes
None

---