### PR TITLE
chore(specs): mark three implemented designs as implemented in spec registry

### DIFF
--- a/docs/VERSION_MANIFEST.md
+++ b/docs/VERSION_MANIFEST.md
@@ -1,6 +1,6 @@
 # VERSION_MANIFEST.md
 
-**Generated**: 2026-08-28T01:23:22.471Z
+**Generated**: 2026-08-28T01:32:54.271Z
 **Manifest Version**: 1.0
 **Location**: docs\VERSION_MANIFEST.md
 

--- a/docs/designs/execution-plan-design-gate-design.md
+++ b/docs/designs/execution-plan-design-gate-design.md
@@ -1,7 +1,7 @@
 # Design: Execution Plan Design Gate
 
 **Date**: 2026-06-28
-**Status**: Approved
+**Status**: Implemented
 **Spec ID**: 2026-06-28-execution-plan-design-gate
 **Variant**: N/A (workspace-wide)
 **Scope**: AGENTS.md §5, CLAUDE.md §5, GEMINI.md §5, agents/pm.md, templates/common/

--- a/docs/designs/variant-registry-architecture-design.md
+++ b/docs/designs/variant-registry-architecture-design.md
@@ -1,7 +1,7 @@
 # Design: Variant Registry Architecture
 
 **Date**: 2026-07-08
-**Status**: Proposed
+**Status**: Implemented
 **Spec ID**: 2026-07-08-variant-registry-architecture
 **Scope**: scripts/helpers/registries/, scripts/helpers/plugins/, scripts/helpers/workspace-integration.ts, scripts/validators/, scripts/l2-to-variant-pipeline.ts, scripts/validate-templates.ts
 

--- a/docs/specs/registry.json
+++ b/docs/specs/registry.json
@@ -5,28 +5,28 @@
       "id": "2026-06-24-workflow-integrated-methodology-design",
       "title": "workflow integrated methodology design",
       "file": "docs/designs/workflow-integrated-methodology-design.md",
-      "status": "approved",
+      "status": "implemented",
       "source": "brainstorming",
       "created": "2026-06-24",
-      "last_updated": "2026-06-24"
+      "last_updated": "2026-08-28"
     },
     {
       "id": "2026-06-28-execution-plan-design-gate",
       "title": "execution plan design gate",
       "file": "docs/designs/execution-plan-design-gate-design.md",
-      "status": "approved",
+      "status": "implemented",
       "source": "brainstorming",
       "created": "2026-06-28",
-      "last_updated": "2026-06-28"
+      "last_updated": "2026-08-28"
     },
     {
       "id": "2026-07-08-variant-registry-architecture",
       "title": "variant registry architecture",
       "file": "docs/designs/variant-registry-architecture-design.md",
-      "status": "approved",
+      "status": "implemented",
       "source": "pm-orchestration",
       "created": "2026-07-08",
-      "last_updated": "2026-07-08"
+      "last_updated": "2026-08-28"
     },
     {
       "id": "2026-08-09-l2-pipeline-governance-fixes",

--- a/memory/2026-08-28.md
+++ b/memory/2026-08-28.md
@@ -284,3 +284,19 @@ feat(co-price): add co-price pricing & consulting variant template
 
 ## Open Issues
 - None
+
+---
+
+## Session Summary
+chore(specs): mark three implemented designs as implemented in spec registry
+
+## Changes
+- `M docs/designs/execution-plan-design-gate-design.md` — modified
+- `docs/designs/variant-registry-architecture-design.md` — modified
+- `docs/specs/registry.json` — modified
+
+## Decisions
+- None
+
+## Open Issues
+- None


### PR DESCRIPTION
## Why
chore(specs): mark three implemented designs as implemented in spec registry

## What Changed
- docs/VERSION_MANIFEST.md
- docs/designs/execution-plan-design-gate-design.md
- docs/designs/variant-registry-architecture-design.md
- docs/specs/registry.json
- memory/2026-08-28.md

## Test Plan
- [ ] `bun scripts/audit.ts` passes
- [ ] CHANGELOG.md updated under `[Unreleased]`

## Security Checklist
- [ ] No secrets, credentials, or API keys committed
- [ ] No `.env` files staged (use `.env.sample` for templates)
- [ ] Dependencies unchanged or reviewed for new CVEs

## Notes
None

---