### PR TITLE
fix(co-price): add missing Gemini command counterparts for full platform parity

### DIFF
--- a/docs/VERSION_MANIFEST.md
+++ b/docs/VERSION_MANIFEST.md
@@ -1,6 +1,6 @@
 # VERSION_MANIFEST.md
 
-**Generated**: 2026-08-28T01:32:54.271Z
+**Generated**: 2026-08-28T01:38:51.852Z
 **Manifest Version**: 1.0
 **Location**: docs\VERSION_MANIFEST.md
 

--- a/memory/2026-08-28.md
+++ b/memory/2026-08-28.md
@@ -300,3 +300,29 @@ chore(specs): mark three implemented designs as implemented in spec registry
 
 ## Open Issues
 - None
+
+---
+
+## Session Summary
+fix(co-price): add missing Gemini command counterparts for full platform parity
+
+## Changes
+- `templates/co-price/.claude/commands/celebrate.md` — modified
+- `templates/co-price/.gemini/commands/changelog.md` — modified
+- `templates/co-price/.gemini/commands/double-entry-reconciliation.md` — modified
+- `templates/co-price/.gemini/commands/excel-export.md` — modified
+- `templates/co-price/.gemini/commands/financial-statement-prep.md` — modified
+- `templates/co-price/.gemini/commands/harness-verification.md` — modified
+- `templates/co-price/.gemini/commands/i18n-audit.md` — modified
+- `templates/co-price/.gemini/commands/math-function-plotter.md` — modified
+- `templates/co-price/.gemini/commands/pdf-export.md` — modified
+- `templates/co-price/.gemini/commands/prisma-7.md` — modified
+- `templates/co-price/.gemini/commands/security-check.md` — modified
+- `templates/co-price/.gemini/commands/sheet-model.md` — modified
+- `templates/co-price/.gemini/commands/ui-component-design.md` — modified
+
+## Decisions
+- None
+
+## Open Issues
+- None

--- a/templates/co-price/.claude/commands/celebrate.md
+++ b/templates/co-price/.claude/commands/celebrate.md
@@ -1,0 +1,18 @@
+---
+name: celebrate
+description: Celebrate the successful completion of a feature or milestone to boost team morale.
+argument-hint: "[celebration-message]"
+allowed-tools: ["Bash"]
+---
+
+# Celebrate
+
+Celebrate when a task or milestone is successfully completed.
+
+```bash
+echo "Task Completed Successfully!"
+echo "Feature deployed and PR merged."
+echo "Great work, Team!"
+```
+
+If $ARGUMENTS is provided, include it in the celebration message.

--- a/templates/co-price/.gemini/commands/changelog.md
+++ b/templates/co-price/.gemini/commands/changelog.md
@@ -1,0 +1,18 @@
+Add a changelog entry to CHANGELOG.md under the `## [Unreleased]` section.
+
+Arguments: $ARGUMENTS
+
+Steps:
+1. Read the current CHANGELOG.md.
+2. Locate the `## [Unreleased]` section.
+3. Determine the entry type from the argument text:
+   - "add / new / create / implement" → `### Added`
+   - "change / update / improve / refactor / rename" → `### Changed`
+   - "fix / bug / correct / repair" → `### Fixed`
+   - "remove / delete / drop / deprecate" → `### Removed`
+   - Unclear → add as a plain `- ` bullet directly under `## [Unreleased]`
+4. If the matching `### Type` subsection already exists under `[Unreleased]`, append the entry there.
+   If it does not exist, create it above any existing subsections.
+5. Write only the minimum edit — do not touch any other part of the file.
+
+Entry format: `- $ARGUMENTS` (one line, no trailing period)

--- a/templates/co-price/.gemini/commands/double-entry-reconciliation.md
+++ b/templates/co-price/.gemini/commands/double-entry-reconciliation.md
@@ -1,0 +1,12 @@
+---
+name: double-entry-reconciliation
+description: Use when simulation output is modified, BS/IS/CF calculations are changed, or A=L+E balance must be verified. Runs double-entry bookkeeping reconciliation checks.
+argument-hint: ""
+allowed-tools: ["Bash", "Read"]
+---
+
+Load and apply the Double-Entry Reconciliation skill from `skills/double-entry-reconciliation/SKILL.md`.
+
+Read the file at `skills/double-entry-reconciliation/SKILL.md` now and follow all instructions within it.
+
+After reading, confirm: "Double-Entry Reconciliation skill loaded."

--- a/templates/co-price/.gemini/commands/excel-export.md
+++ b/templates/co-price/.gemini/commands/excel-export.md
@@ -1,0 +1,12 @@
+---
+name: excel-export
+description: Use when user requests spreadsheet download, financial data export to .xlsx, or Excel report generation.
+argument-hint: ""
+allowed-tools: ["Bash", "Read", "Write", "Edit"]
+---
+
+Load and apply the Excel Export Workflow skill from `skills/excel-export/SKILL.md`.
+
+Read the file at `skills/excel-export/SKILL.md` now and follow all instructions within it.
+
+After reading, confirm: "Excel Export skill loaded."

--- a/templates/co-price/.gemini/commands/financial-statement-prep.md
+++ b/templates/co-price/.gemini/commands/financial-statement-prep.md
@@ -1,0 +1,12 @@
+---
+name: financial-statement-prep
+description: Use when preparing IS, BS, or CF statements, generating 3-statement model, or formatting audit-ready financials.
+argument-hint: ""
+allowed-tools: ["Bash", "Read", "Write", "Edit"]
+---
+
+Load and apply the Financial Statement Preparation skill from `skills/financial-statement-prep/SKILL.md`.
+
+Read the file at `skills/financial-statement-prep/SKILL.md` now and follow all instructions within it.
+
+After reading, confirm: "Financial Statement Prep skill loaded."

--- a/templates/co-price/.gemini/commands/harness-verification.md
+++ b/templates/co-price/.gemini/commands/harness-verification.md
@@ -1,0 +1,12 @@
+---
+name: harness-verification
+description: Use when engine code has changed, math logic was updated, or any BIZ_LOGIC formula was modified. Triggers full 5-gate validation.
+argument-hint: ""
+allowed-tools: ["Bash"]
+---
+
+Load and apply the Harness Verification Protocol from `skills/harness-verification/SKILL.md`.
+
+Read the file at `skills/harness-verification/SKILL.md` now and follow all instructions within it.
+
+After reading, confirm: "Harness Verification skill loaded."

--- a/templates/co-price/.gemini/commands/i18n-audit.md
+++ b/templates/co-price/.gemini/commands/i18n-audit.md
@@ -1,0 +1,12 @@
+---
+name: i18n-audit
+description: Use when translation keys are added, removed, or modified, or when locales/en.json changes. Verifies i18n key parity across all locale files.
+argument-hint: ""
+allowed-tools: ["Bash", "Read"]
+---
+
+Load and apply the I18N Audit & Synchronization skill from `skills/i18n-audit/SKILL.md`.
+
+Read the file at `skills/i18n-audit/SKILL.md` now and follow all instructions within it.
+
+After reading, confirm: "i18n Audit skill loaded."

--- a/templates/co-price/.gemini/commands/math-function-plotter.md
+++ b/templates/co-price/.gemini/commands/math-function-plotter.md
@@ -1,0 +1,12 @@
+---
+name: math-function-plotter
+description: Use when visualizing LaTeX formulas, plotting BIZ_LOGIC math functions, or generating formula graphs.
+argument-hint: ""
+allowed-tools: ["Bash", "Read", "Write"]
+---
+
+Load and apply the Math Function Plotter skill from `skills/math-function-plotter/SKILL.md`.
+
+Read the file at `skills/math-function-plotter/SKILL.md` now and follow all instructions within it.
+
+After reading, confirm: "Math Function Plotter skill loaded."

--- a/templates/co-price/.gemini/commands/pdf-export.md
+++ b/templates/co-price/.gemini/commands/pdf-export.md
@@ -1,0 +1,12 @@
+---
+name: pdf-export
+description: Use when user requests PDF report, printable financial statement, or investor-ready document export.
+argument-hint: ""
+allowed-tools: ["Bash", "Read", "Write"]
+---
+
+Load and apply the PDF Export Workflow skill from `skills/pdf-export/SKILL.md`.
+
+Read the file at `skills/pdf-export/SKILL.md` now and follow all instructions within it.
+
+After reading, confirm: "PDF Export skill loaded."

--- a/templates/co-price/.gemini/commands/prisma-7.md
+++ b/templates/co-price/.gemini/commands/prisma-7.md
@@ -1,0 +1,12 @@
+---
+name: prisma-7
+description: Use when modifying prisma/schema.prisma, running DB migrations, or upgrading Prisma version.
+argument-hint: ""
+allowed-tools: ["Bash", "Read", "Edit"]
+---
+
+Load and apply the Prisma 7 Migration Workflow from `skills/prisma-7/SKILL.md`.
+
+Read the file at `skills/prisma-7/SKILL.md` now and follow all instructions within it.
+
+After reading, confirm: "Prisma 7 Migration skill loaded."

--- a/templates/co-price/.gemini/commands/security-check.md
+++ b/templates/co-price/.gemini/commands/security-check.md
@@ -1,0 +1,22 @@
+---
+name: security-check
+description: Run security advisory scan (daily mode) or pre-PR advisory check (--pr flag).
+argument-hint: "[--pr]"
+allowed-tools: ["Bash", "Read", "Write", "Edit", "Glob", "Grep", "WebSearch"]
+---
+
+# Security Check
+
+Arguments: $ARGUMENTS
+
+Run the security monitor agent.
+
+- **No arguments** (or `--scan`): Run a full daily scan — local vulnerability scan, web advisory lookup, deduplication, save findings to `security/`, Dependabot auto-resolve, age cleanup.
+- **`--pr`**: Pre-PR advisory check — read-only. Report existing active advisories from `security/`. No new scan.
+
+Load and follow `agents/security-monitor.md` exactly.
+
+- For default/`--scan` mode: execute Workflow 1 (Daily Scan).
+- For `--pr` mode: execute Workflow 2 (Pre-PR Advisory Check).
+
+Report the results clearly to the user.

--- a/templates/co-price/.gemini/commands/sheet-model.md
+++ b/templates/co-price/.gemini/commands/sheet-model.md
@@ -1,0 +1,12 @@
+---
+name: sheet-model
+description: Use when cross-validating spreadsheet model outputs against simulation engine results, or verifying BEP calculations.
+argument-hint: ""
+allowed-tools: ["Bash", "Read"]
+---
+
+Load and apply the Sheet Model Validation skill from `skills/sheet-model/SKILL.md`.
+
+Read the file at `skills/sheet-model/SKILL.md` now and follow all instructions within it.
+
+After reading, confirm: "Sheet Model Validation skill loaded."

--- a/templates/co-price/.gemini/commands/ui-component-design.md
+++ b/templates/co-price/.gemini/commands/ui-component-design.md
@@ -1,0 +1,12 @@
+---
+name: ui-component-design
+description: Use when creating React components, applying Onyx 2.0 design tokens, styling dashboard cards, or building financial UI.
+argument-hint: ""
+allowed-tools: ["Read", "Write", "Edit"]
+---
+
+Load and apply the UI Component Design skill from `skills/ui-component-design/SKILL.md`.
+
+Read the file at `skills/ui-component-design/SKILL.md` now and follow all instructions within it.
+
+After reading, confirm: "UI Component Design skill loaded."


### PR DESCRIPTION
## Why
fix(co-price): add missing Gemini command counterparts for full platform parity

## What Changed
- docs/VERSION_MANIFEST.md
- memory/2026-08-28.md
- templates/co-price/.claude/commands/celebrate.md
- templates/co-price/.gemini/commands/changelog.md
- templates/co-price/.gemini/commands/double-entry-reconciliation.md
- templates/co-price/.gemini/commands/excel-export.md
- templates/co-price/.gemini/commands/financial-statement-prep.md
- templates/co-price/.gemini/commands/harness-verification.md
- templates/co-price/.gemini/commands/i18n-audit.md
- templates/co-price/.gemini/commands/math-function-plotter.md
- templates/co-price/.gemini/commands/pdf-export.md
- templates/co-price/.gemini/commands/prisma-7.md
- templates/co-price/.gemini/commands/security-check.md
- templates/co-price/.gemini/commands/sheet-model.md
- templates/co-price/.gemini/commands/ui-component-design.md

## Test Plan
- [ ] `bun scripts/audit.ts` passes
- [ ] CHANGELOG.md updated under `[Unreleased]`

## Security Checklist
- [ ] No secrets, credentials, or API keys committed
- [ ] No `.env` files staged (use `.env.sample` for templates)
- [ ] Dependencies unchanged or reviewed for new CVEs

## Notes
None

---