### PR TITLE
docs: clarify co-price as multi-industry pricing simulator, not K-Beauty-specific

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
 
+### Fixed
+- **[2026-08-28]**: docs(readme): co-price was branded as a "K-Beauty pricing management & consulting simulator" in the top-level `README.md`/`README_ko.md`/`README_es.md`/`README_ja.md` and `templates/README.md`, but K-Beauty is only a bundled sample dataset (`getKBeautySampleState`) — co-price's own `README.md` and docs describe it as a multi-industry pricing simulator. Reworded all six occurrences across the four language READMEs and `templates/README.md` to "multi-industry pricing management & consulting simulator (K-Beauty sample dataset included)".
+
 ### Added
 - **[2026-08-25]**: feat(governance): **Evidence layer made real — `evidence-ledger` skill 1.0.0 → 1.1.0 gains the registry-backed overlay form, and the workspace's FIRST live ledger opens with four verified rows wired into both seeded decision records.** Gap #3 of the chain follow-through: the Evidence layer existed as a standard with zero instances. Three moves close it. **(1) Overlay forms codified**: the skill's Variant Overlays section now names the second legitimate overlay form alongside co-news's prose ledger — **registry-backed variants** carrying their evidence plane as formal variables in a schema-governed registry (row-per-VARIABLE, verification metadata, reversal via the registry's own amendment protocol), with the invariant that DEC `evidence_refs[]` must resolve INSIDE whichever form a variant uses. This retroactively legitimizes exactly how co-newbiz already operates. **(2) First live ledger**: `docs/evidence/ledger.md` opens with four VERIFIED rows (EV-20260825-001…004) documenting this week's real rulings and findings — the rootAllowlist stray-file gate firing, the direct-commit denial → /sync routing, consumes-inference precision 1/1 corroborated by a kill-criteria predicate, and the human-role registry resolution — each with source, ref, and verification method. **(3) DEC loop closed in practice**: DEC-20260825-01/02 `evidence_refs[]` now cite EV-001/EV-002 instead of empty arrays — the first decision records whose evidence citations resolve to a real ledger. Platform mirrors refreshed by the sync pipeline; no contract pins affected.
 - **[2026-08-25]**: revert(governance): **ADR seeds and Variant Anchor sections removed from templates — owner review found the application problematic (#691 follow-up; rationale recorded in `docs/audits/2026-08-25-…md` §5).** Three defects acknowledged: the seed README duplicated the context.md convention subsection (two homes for one rule = ADR-0050's drift problem); "likely first records" taxed every future project with speculative guidance about engagements that have not happened; and the organic project practices (69/18/5 records, no seeds) had been misread as a seeding need when they proved the opposite — git tracks no empty directories, so `docs/adr/` materializes exactly when a first record exists. Removed: 11 variant `docs/adr/README.md`, common seed README, all Variant Anchor sections. Restored: co-develop `.gitkeep` (pre-existing), common `.gitkeep` (untouched). Survives: the **Architecture Decision Records** subsection in `templates/common/docs/context.md` — now the single home of the convention — and the audit notes document, which gains a §5 owner-review postscript so the reversal reasoning outlives the session.
@@ -1338,7 +1341,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ---
 
-*Last Updated: 2026-08-26*
+*Last Updated: 2026-08-28*
 
 
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 ---
 sync_version: 1
-content_hash: 0afda165940a46f3788db21a9d8047ae41e5294219472b5e2c9289d4b8835f3b
+content_hash: bb6d16c7a2e60f39160df8b59d45e18de2c0c8a79b6f7b5cd2d9cc3fbb991a40
 ---
 
 **Languages**: [English](README.md) · [한국어](README_ko.md) · [Español](README_es.md) · [日本語](README_ja.md)
@@ -194,7 +194,7 @@ C:\git\ (workspace root - this repo)
     ├── co-abap/             # ✅ Stable — SAP ABAP development agent team
     ├── co-hr/                # 🔶 Beta — HR & labor-relations consulting agent team (KR country profile included)
     ├── co-safety/            # 🔶 Beta — EHS/GxP compliance platform agent team
-    └── co-price/            # ⚠️ Beta — K-Beauty pricing management & consulting simulator
+    └── co-price/            # ⚠️ Beta — pricing management & consulting simulator (K-Beauty sample dataset)
 ```
 
 Each sub-project lives in its own directory and git repository:
@@ -345,4 +345,4 @@ AGPL-3.0 - see [LICENSE](LICENSE)
 
 ---
 
-*Maintained by [@5throck](https://github.com/5throck) · Last Updated: 2026-08-27*
+*Maintained by [@5throck](https://github.com/5throck) · Last Updated: 2026-08-28*

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 ---
 sync_version: 1
-content_hash: bb6d16c7a2e60f39160df8b59d45e18de2c0c8a79b6f7b5cd2d9cc3fbb991a40
+content_hash: f295143e63e3671318db42ef87582991d2593ce96cf52a7a7db6dc78393b1015
 ---
 
 **Languages**: [English](README.md) · [한국어](README_ko.md) · [Español](README_es.md) · [日本語](README_ja.md)

--- a/README_es.md
+++ b/README_es.md
@@ -191,7 +191,7 @@ C:\git\ (raíz del workspace - este repo)
     ├── co-abap/             # ✅ Estable — equipo de agentes para desarrollo SAP ABAP
     ├── co-hr/               # 🔶 Beta — equipo de agentes para consultoría de RR. HH. y relaciones laborales (perfil de país KR incluido)
     ├── co-safety/           # 🔶 Beta — equipo de agentes para plataforma de cumplimiento EHS/GxP
-    └── co-price/            # ⚠️ Beta — simulador de gestión y consultoría de precios K-Beauty
+    └── co-price/            # ⚠️ Beta — simulador de gestión y consultoría de precios multi-industria (incluye dataset de muestra K-Beauty)
 ```
 
 Cada subproyecto vive en su propio directorio y repositorio git:

--- a/README_ja.md
+++ b/README_ja.md
@@ -195,7 +195,7 @@ C:\git\ (ワークスペースルート - このリポジトリ)
     ├── co-abap/             # ✅ 安定 — SAP ABAP開発エージェントチーム
     ├── co-hr/               # 🔶 ベータ — 労務・HRコンサルティングエージェントチーム（KR国プロファイル同梱）
     ├── co-safety/           # 🔶 ベータ — EHS/GxPコンプライアンスプラットフォームエージェントチーム
-    └── co-price/            # ⚠️ ベータ — K-Beauty価格管理・コンサルティングシミュレータ
+    └── co-price/            # ⚠️ ベータ — 多業種対応の価格管理・コンサルティングシミュレータ（K-Beautyサンプルデータ同梱）
 ```
 
 各サブプロジェクトは独自のディレクトリとGitリポジトリに存在します：
@@ -241,7 +241,7 @@ C:\git\
 - **co-abap**: PM主導のオーケストレーション、6つのSAPモジュールアナリスト（SD、MM、FI、CO、PP、LE）、技術実行エージェント、自動化QAチェーン（SyntaxCheck → RunUnitTests → GetCodeCoverage → RunATCCheck）を備えた6段階のSAP ABAP開発ワークフロー
 - **co-hr**: 案件インテーク、対象管轄の労働法コンプライアンス監査（docs/countries/配下の国プロファイル — KRプロファイル同梱）、HRM/HRD設計、組織再編・変革管理を網羅する4段階の労務・HRコンサルティングワークフロー（k-law/k-kosis規制リサーチ連携 — KRスコープのスキルでKR対象プロジェクトのみに付加、12エージェントロスター）
 - **co-safety**: A 6-phase EHS/GxP compliance workflow covering Korean occupational safety (OSHA-KR, SAPA), process safety management (PSM), GxP pharmaceutical quality (GMP/GLP/GDP/GCP/GVP), medical device safety (KGMP-MD, ISO 13485), and 15 industry-specific domains (chemical, construction, semiconductor, battery, shipbuilding, steelmaking, etc.) across a 40+ agent roster
-- **co-price**: 15人の専門エージェント（財務戦略、コスト管理、P&L監査、価格戦略、市場インテリジェンス、エンゲージメント・ディレクション等）を備えたK-Beauty価格管理・コンサルティングシミュレータ — 複数製品・複数チャネルの価格管理、複式簿記P&L予測、市場調査分析（Van Westendorp / Gabor-Granger）、コストショック感応度、流通トレードライン管理をカバー
+- **co-price**: 15人の専門エージェント（財務戦略、コスト管理、P&L監査、価格戦略、市場インテリジェンス、エンゲージメント・ディレクション等）を備えた多業種対応の価格管理・コンサルティングシミュレータ（K-Beautyサンプルデータ同梱） — 複数製品・複数チャネルの価格管理、複式簿記P&L予測、市場調査分析（Van Westendorp / Gabor-Granger）、コストショック感応度、流通トレードライン管理をカバー
 
 **💡 ワークフローの詳細確認方法**
 特定のエージェントロスターとガバナンスフェーズは、各生成プロジェクトのドキュメント内で管理されます。プロジェクトをスキャフォールド後、以下を確認してください：
@@ -268,7 +268,7 @@ C:\git\
 | `co-abap` | ✅ 安定 | SAP ABAP開発ワークフロー — PM、アーキテクト、コーダー、テスト実行者、DBA、DevOps管理者、SAP調査担当、モジュールアナリスト（SD、MM、FI、CO、PP、LE）、Interface/Fiori/Form専門家、セキュリティモニター |
 | `co-hr` | 🔶 ベータ | 労務・HRコンサルティングワークフロー — PM、労務コンプライアンスアナリスト、労働関係スペシャリスト、安全衛生担当、採用スペシャリスト、報酬・給与アナリスト、人事評価コンサルタント、L&Dスペシャリスト、キャリア・後継コンサルタント、組織設計コンサルタント、変革管理パートナー、データアナリスト。労働法の適用範囲は国プロファイル経由（KRプロファイル同梱） |
 | `co-safety` | 🔶 ベータ | EHS/GxP compliance platform workflow — PM/CSO, 40+ specialist agents (emergency, compliance, legal, training, PSM, risk, audit, 15 industry domains, 5 GxP domains), k-law regulatory research integration (KR-scoped) |
-| `co-price` | ⚠️ ベータ | K-Beauty価格管理・コンサルティングシミュレータ — PM、リードアーキテクト、コアエンジン開発、CPA監査、財務戦略リード、コスト・資産管理、UX、L10N監査、QA、DevOps、セキュリティ監査/モニター、価格戦略ストラテジスト、市場インテリジェンスアナリスト、エンゲージメントディレクター |
+| `co-price` | ⚠️ ベータ | 多業種対応の価格管理・コンサルティングシミュレータ（K-Beautyサンプルデータ同梱） — PM、リードアーキテクト、コアエンジン開発、CPA監査、財務戦略リード、コスト・資産管理、UX、L10N監査、QA、DevOps、セキュリティ監査/モニター、価格戦略ストラテジスト、市場インテリジェンスアナリスト、エンゲージメントディレクター |
 
 ### バージョンとバリアントの選択
 

--- a/README_ko.md
+++ b/README_ko.md
@@ -191,7 +191,7 @@ C:\git\ (워크스페이스 루트 - 현재 저장소)
     ├── co-abap/             # ✅ Stable — SAP ABAP 개발 에이전트 팀
     ├── co-hr/                # 🔶 Beta — 노무/HR 컨설팅 에이전트 팀 (KR 국가 프로필 포함)
     ├── co-safety/            # 🔶 Beta — EHS/GxP 컴플라이언스 플랫폼 에이전트 팀
-    └── co-price/            # ⚠️ Beta — K-Beauty 가격 관리 및 컨설팅 시뮬레이터
+    └── co-price/            # ⚠️ Beta — 가격 관리 및 컨설팅 시뮬레이터 (K-Beauty 샘플 데이터셋 포함)
 ```
 
 각 하위 프로젝트는 자체 디렉토리 및 개별 Git 저장소로 관리됩니다:
@@ -341,4 +341,4 @@ AGPL-3.0 - [LICENSE](LICENSE) 파일 참조
 
 ---
 
-*Maintained by [@5throck](https://github.com/5throck) · Last Updated: 2026-08-27*
+*Maintained by [@5throck](https://github.com/5throck) · Last Updated: 2026-08-28*

--- a/docs/VERSION_MANIFEST.md
+++ b/docs/VERSION_MANIFEST.md
@@ -1,6 +1,6 @@
 # VERSION_MANIFEST.md
 
-**Generated**: 2026-08-28T02:18:41.264Z
+**Generated**: 2026-08-28T02:28:34.408Z
 **Manifest Version**: 1.0
 **Location**: docs\VERSION_MANIFEST.md
 

--- a/docs/VERSION_MANIFEST.md
+++ b/docs/VERSION_MANIFEST.md
@@ -1,6 +1,6 @@
 # VERSION_MANIFEST.md
 
-**Generated**: 2026-08-28T02:28:34.408Z
+**Generated**: 2026-08-28T02:34:24.600Z
 **Manifest Version**: 1.0
 **Location**: docs\VERSION_MANIFEST.md
 

--- a/memory/2026-08-28.md
+++ b/memory/2026-08-28.md
@@ -435,3 +435,22 @@ refactor(co-deck): remove deprecated measure skill and bump version to 0.2.3
 
 ## Open Issues
 - None
+
+---
+
+## Session Summary
+docs: clarify co-price as multi-industry pricing simulator, not K-Beauty-specific
+
+## Changes
+- `M CHANGELOG.md` — modified
+- `README.md` — modified
+- `README_es.md` — modified
+- `README_ja.md` — modified
+- `README_ko.md` — modified
+- `templates/README.md` — modified
+
+## Decisions
+- None
+
+## Open Issues
+- None

--- a/memory/2026-08-28.md
+++ b/memory/2026-08-28.md
@@ -454,3 +454,17 @@ docs: clarify co-price as multi-industry pricing simulator, not K-Beauty-specifi
 
 ## Open Issues
 - None
+
+---
+
+## Session Summary
+chore: sync README.md content_hash after commit
+
+## Changes
+- `README.md` — modified
+
+## Decisions
+- None
+
+## Open Issues
+- None

--- a/templates/README.md
+++ b/templates/README.md
@@ -42,7 +42,7 @@ templates/
 | [`co-work`](co-work/) | ✅ Stable | General collaboration workflow with 7 agents (pm, analyst, content-writer, ms365-expert, etc.) |
 | [`co-security`](co-security/) | ✅ Stable | Security engagement workflow with 6 agents (pm, red-team-lead, pentester, threat-modeler, etc.) |
 | [`co-consult`](co-consult/) | ✅ Stable | Strategy consulting with 11 agents and 16 domain skills |
-| [`co-price`](co-price/) | ⚠️ Beta | K-Beauty pricing management & consulting simulator with 15 agents (PM, finance-strategy-lead, cpa-auditor, pricing-strategist, market-intelligence-analyst, engagement-director) and 21 skills (harness-verification, trade-promotion-roi, pricing-governance, map-channel-enforcement) |
+| [`co-price`](co-price/) | ⚠️ Beta | Multi-industry pricing management & consulting simulator (bundled K-Beauty sample dataset) with 15 agents (PM, finance-strategy-lead, cpa-auditor, pricing-strategist, market-intelligence-analyst, engagement-director) and 21 skills (harness-verification, trade-promotion-roi, pricing-governance, map-channel-enforcement) |
 | [`co-deck`](co-deck/) | 🔶 Beta | Lecture/presentation production with 13 agents and multi-theme HTML-to-PDF pipeline |
 | [`co-game`](co-game/) | ✅ Stable | Game development for HTML5 Canvas with Vanilla TypeScript and 13 agents |
 | [`co-export`](co-export/) | 🔶 Beta | Import/export trade-compliance workflow with 8 agents (HS classification, export control, FTA origin, duty drawback, logistics, market entry, foreign regulation monitoring, trade documentation) |
@@ -110,4 +110,4 @@ See [CHANGELOG.md](CHANGELOG.md) for full history.
 - **Minor** bump: new agents, new variants going stable, structural section changes
 - **Patch** bump: documentation and description updates
 
-*Last Updated: 2026-08-27*
+*Last Updated: 2026-08-28*


### PR DESCRIPTION
## Why
Top-level READMEs branded the `co-price` variant as a "K-Beauty pricing management & consulting simulator," implying the entire variant is K-Beauty-specific. In reality, K-Beauty is only a bundled sample dataset (`getKBeautySampleState`) loaded via `ScenarioLibrary` — co-price's own `README.md` and `docs/co-price.context.md` describe it as a multi-industry pricing simulator. This mislabels the variant's actual scope to anyone scanning the workspace README.

## What Changed
- `README.md`, `README_ko.md`, `README_es.md`, `README_ja.md`: reworded the co-price directory-tree description and (in `README_ja.md`) the detailed bullet and variant table row from "K-Beauty pricing management & consulting simulator" to "multi-industry pricing management & consulting simulator (K-Beauty sample dataset included)" in each language.
- `templates/README.md`: aligned the co-price table row description with the same phrasing, also resolving an internal inconsistency where the directory listing already said "Pricing management & consulting variant (beta)" without the K-Beauty branding while the table row further down said otherwise.
- `CHANGELOG.md`: added a `### Fixed` entry documenting the correction.

## Test Plan
- [ ] `bun scripts/audit.ts` passes
- [x] Manually verified `getKBeautySampleState` is a single sample-scenario loader in `templates/co-price/docs/commercial-operating-manual.md`, and co-price's own README/context docs describe the variant as multi-industry, confirming the K-Beauty branding was inaccurate.

## Security Checklist
- [x] No secrets, credentials, or API keys committed
- [x] No `.env` files staged (use `.env.sample` for templates)
- [x] Dependencies unchanged or reviewed for new CVEs

## Notes
Documentation-only change; no code, schema, or dependency impact.
