### PR TITLE
fix(co-price template): sync harness-verification SKILL.md frontmatter and co-price.context.md Review Model/Lifecycle Rules sections with project instance

### DIFF
--- a/docs/VERSION_MANIFEST.md
+++ b/docs/VERSION_MANIFEST.md
@@ -1,6 +1,6 @@
 # VERSION_MANIFEST.md
 
-**Generated**: 2026-08-28T06:43:48.050Z
+**Generated**: 2026-08-28T07:06:15.233Z
 **Manifest Version**: 1.0
 **Location**: docs\VERSION_MANIFEST.md
 

--- a/memory/2026-08-28.md
+++ b/memory/2026-08-28.md
@@ -770,3 +770,18 @@ chore(skills): promote 6 generic skills from co-safety/co-work duplicates to com
 
 ## Open Issues
 - None
+
+---
+
+## Session Summary
+fix(co-price template): sync harness-verification SKILL.md frontmatter and co-price.context.md Review Model/Lifecycle Rules sections with project instance
+
+## Changes
+- `M templates/co-price/docs/co-price.context.md` — modified
+- `templates/co-price/skills/harness-verification/SKILL.md` — modified
+
+## Decisions
+- None
+
+## Open Issues
+- None

--- a/templates/co-price/docs/co-price.context.md
+++ b/templates/co-price/docs/co-price.context.md
@@ -177,3 +177,21 @@ Use `bun scripts/dev-sync.ts "feat: …"` (or the `/sync` slash command) to comm
 - Channel strategy & Deal Desk process owned by `engagement-director` + `cpa-auditor` (exception log).
 - The LLM copilot cites engine-computed figures only; it never computes its own numbers.
 - Educational simulator only — no real customer/financial data; all samples are synthetic.
+
+## Review Model
+
+Three-stage review everywhere: AI 1st (formal) → AI 2nd (cross-domain AI) →
+human final. A same-domain second review is void. Silence is never approval.
+Per-PR verification chain: `cpa-auditor` · `security-auditor` · `security-monitor` ·
+`l10n-auditor` (+ `qa-tester` after UI; `copilot-onrails-audit` after AI-layer writes).
+
+## Lifecycle Rules
+
+| Modified file | Required follow-up |
+|---|---|
+| `docs/biz_logic.md` | new/updated `[Ref:]` tests before implementation |
+| `prisma/schema.prisma` | Zod sync via `security-auditor`; user approval pre-required |
+| `src/lib/simulation.ts`, `engine/*` | run `harness-verification` skill |
+| `src/lib/ai/**` | run `copilot-onrails-audit` skill |
+| `locales/*.json` | run `i18n-audit` skill |
+| UI components | `qa-tester` mounting checks; update user guides if flows changed |

--- a/templates/co-price/skills/harness-verification/SKILL.md
+++ b/templates/co-price/skills/harness-verification/SKILL.md
@@ -1,12 +1,21 @@
 ---
 name: harness-verification
-scope: co-price
-description: 5-gate engine certification pipeline
+description: >-
+  Authoritative Harness Engineering Protocol: machine-readable spec requirements,
+  documentation-to-test mapping, baseline-seed verification, runtime guardrails,
+  handover certification, and drift management — issuing a Harness Pass Certificate.
 version: "2.1.0"
-last_reviewed: 2026-08-25
+last_reviewed: "2026-08-25"
 status: active
+scope: co-price
 owner: cpa-auditor
 prerequisites: docs/biz_logic.md section anchors exist; ACME baseline seed available
+metadata:
+  type: quality
+  triggers:
+    - "verify engine"
+    - "harness pass"
+    - "run verification protocol"
 ---
 
 # Harness Engineering Protocol — AIG Agentic Standard


### PR DESCRIPTION
## Why
fix(co-price template): sync harness-verification SKILL.md frontmatter and co-price.context.md Review Model/Lifecycle Rules sections with project instance

## What Changed
- docs/VERSION_MANIFEST.md
- memory/2026-08-28.md
- templates/co-price/docs/co-price.context.md
- templates/co-price/skills/harness-verification/SKILL.md

## Test Plan
- [ ] `bun scripts/audit.ts` passes
- [ ] CHANGELOG.md updated under `[Unreleased]`

## Security Checklist
- [ ] No secrets, credentials, or API keys committed
- [ ] No `.env` files staged (use `.env.sample` for templates)
- [ ] Dependencies unchanged or reviewed for new CVEs

## Notes
None

---