### PR TITLE
fix(templates): repair self-referencing docs link in common context.md blocking project link gates

### DIFF
--- a/docs/VERSION_MANIFEST.md
+++ b/docs/VERSION_MANIFEST.md
@@ -1,6 +1,6 @@
 # VERSION_MANIFEST.md
 
-**Generated**: 2026-08-28T11:01:58.185Z
+**Generated**: 2026-08-28T11:43:18.921Z
 **Manifest Version**: 1.0
 **Location**: docs\VERSION_MANIFEST.md
 

--- a/memory/2026-08-28.md
+++ b/memory/2026-08-28.md
@@ -1,4 +1,26 @@
 ## Session Summary
+chore(projects): Phase 5 rollout — 8 projects upgraded (v0.6.0), codegraph cleaned, project-local skill graphs
+
+## Changes
+- Projects/{co-abap,co-consult,co-deck,co-game,co-hr,co-news,co-price,co-safety} — working-tree changes, NOT yet committed (project pre-commit hooks require each project's own /sync pipeline, which pushes+PRs — deferred pending user request):
+  - upgrade-project.ts runs: LICENSE (add-if-missing; co-abap/co-price/co-safety preserved own), graph scripts v1.3.0, audit 2.26.0 / dev-sync 1.7.8, context.md v2.5, template-version.txt → 0.6.0
+  - codegraph cleanup: settings/.mcp.json/.codex/config.toml blocks, stale comments (co-architect/co-game), co-architect settings.local.json hooks, 9 .gitignore blocks, setup.ts opt-ins (co-abap, co-abap-plugin ×2), co-game local generate-variant.ts injection, co-consult schema entry; .codegraph/ SQLite dirs deleted (co-abap, co-abap-plugin, co-price)
+  - project-local docs/skill-graph.json(+.md, overrides seed) generated + verified in all 8; nodes tagged L3 (run-context auto-detect working)
+  - per-project verify-scripts: all 8 pass (co-price: SCRIPTS.md generated from scratch — legacy standalone layout had none; co-safety: stray scripts/node_modules (27MB, gitignored) removed)
+- `tests/tmp-project-codegraph-cleanup.ts` — one-off script, deleted after use
+- `memory/2026-08-28.md` — this block
+
+## Decisions
+- Project commits deferred: hooks enforce commit-via-/sync (=push+PR); plan scope was local-commits-only → surfaced for user decision (8 project /sync runs pending).
+- Upstream follow-up recorded: L0+L1 SCRIPTS.md `lib/context-md-schema.ts` row scope says `L0` while the file ships via L1 — projects' verifiers ignore L0-scoped rows, so every upgraded project needed its row flipped to `L0+L1`. One-line registry fix for a follow-up L0 PR.
+
+## Open Issues
+- 8 project /sync runs (commit+push+PR per project repo) — awaiting user request.
+- co-newbiz/co-abap-plugin/co-architect audit.ts codegraph example comments remain (not upgraded; harmless).
+
+---
+
+## Session Summary
 feat(graph): per-template skill graph artifacts + project-local generation (ADR-0060 Amendment 2)
 
 ## Changes
@@ -1010,6 +1032,21 @@ feat(graph): per-template skill graph artifacts + project-local generation (ADR-
 - `templates/co-security/docs/skill-graph.json` — modified
 - `templates/co-work/docs/skill-graph.json` — modified
 - `templates/common/docs/skill-graph.json` — modified
+
+## Decisions
+- None
+
+## Open Issues
+- None
+
+---
+
+## Session Summary
+fix(templates): repair self-referencing docs link in common context.md blocking project link gates
+
+## Changes
+- `M memory/2026-08-28.md` — modified
+- `templates/common/docs/context.md` — modified
 
 ## Decisions
 - None

--- a/templates/common/docs/context.md
+++ b/templates/common/docs/context.md
@@ -201,7 +201,7 @@ declare `lang: ko` + a valid `lang_reason` in frontmatter.
 - `SKILL.md` itself stays English-only and simply points to the reference file (e.g. "See `references/terms-ko.json` for the Korean-original DART terminology mapping").
 - This is the general mechanism for any skill needing source-language reference data — not specific to Korean.
 
-See [docs/context.md](docs/context.md) for the skill-lifecycle registration details.
+See [docs/context.md](context.md) for the skill-lifecycle registration details.
 
 #### Pluggable Variant Audit Hook
 


### PR DESCRIPTION
## Why
fix(templates): repair self-referencing docs link in common context.md blocking project link gates

## What Changed
- docs/VERSION_MANIFEST.md
- memory/2026-08-28.md
- templates/common/docs/context.md

## Test Plan
- [ ] `bun scripts/audit.ts` passes
- [ ] CHANGELOG.md updated under `[Unreleased]`

## Security Checklist
- [ ] No secrets, credentials, or API keys committed
- [ ] No `.env` files staged (use `.env.sample` for templates)
- [ ] Dependencies unchanged or reviewed for new CVEs

## Notes
None

---