### PR TITLE
chore(memory): record Phase 3 skill purge completion

### DIFF
--- a/docs/VERSION_MANIFEST.md
+++ b/docs/VERSION_MANIFEST.md
@@ -1,6 +1,6 @@
 # VERSION_MANIFEST.md
 
-**Generated**: 2026-08-28T13:29:26.214Z
+**Generated**: 2026-08-28T14:04:41.054Z
 **Manifest Version**: 1.0
 **Location**: docs\VERSION_MANIFEST.md
 

--- a/memory/2026-08-28.md
+++ b/memory/2026-08-28.md
@@ -1,4 +1,22 @@
 ## Session Summary
+chore(projects): Phase 3 — cross-variant skill leak purged from all projects, ko folder removed
+
+## Changes
+- Main repo: PR #750 (leak source fix + prune + README standard + layout gates), #751 (206 template skill README pairs authored; SKILL_README_ENFORCE=true) — merged.
+- Projects merged after prune upgrades: co-consult#15, co-hr#5, co-news#15 (incl. ko/ folder removal), co-price#70, co-abap#105, co-deck#58 (allowlist stale entry removed), co-abap-plugin#80, co-architect#269, co-newbiz#158/#159.
+- Manual: co-consult orphan dart-disclosure-parser removed; co-abap(10)+co-architect(4) missing scope frontmatter added; project SKILLS.md catalogs and skill graphs regenerated post-prune.
+
+## Decisions
+- Prune pass is registry-driven (`variant_scoped_skills` in workspace-schema.json); heuristic approach rejected after false-positiveing 14 genuine commons.
+- L0 sound-synth frontmatter corrected (scope: co-game + l2_propagate: false) — propagate was re-seeding common from the misdeclared L0 copy.
+
+## Open Issues
+- co-safety: language gate owner decision still blocks its /sync (prune+semver+registry fixes staged in working tree, 267 files).
+- Project-layer per-skill README backlog (581 folders) — next upgrade cycle.
+
+---
+
+## Session Summary
 feat(skills+templates): skill hygiene & layer conventions (leak source fix, variant-scope prune, README standard, layout gates)
 
 ## Changes
@@ -1724,6 +1742,20 @@ feat(skills+templates): skill hygiene - leak source fix, variant-scope prune, pe
 - `templates/common/skills/validate-docs-links/README_ko.md` — modified
 - `templates/common/skills/zod-contract-gate/README.md` — modified
 - `templates/common/skills/zod-contract-gate/README_ko.md` — modified
+
+## Decisions
+- None
+
+## Open Issues
+- None
+
+---
+
+## Session Summary
+chore(memory): record Phase 3 skill purge completion
+
+## Changes
+- `M memory/2026-08-28.md` — modified
 
 ## Decisions
 - None


### PR DESCRIPTION
## Why
chore(memory): record Phase 3 skill purge completion

## What Changed
- docs/VERSION_MANIFEST.md
- memory/2026-08-28.md

## Test Plan
- [ ] `bun scripts/audit.ts` passes
- [ ] CHANGELOG.md updated under `[Unreleased]`

## Security Checklist
- [ ] No secrets, credentials, or API keys committed
- [ ] No `.env` files staged (use `.env.sample` for templates)
- [ ] Dependencies unchanged or reviewed for new CVEs

## Notes
None

---