### PR TITLE
feat(procedures): guarantee procedure corpus at every project lifecycle boundary

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
 
+### Added
+- **[2026-08-29]**: feat(procedures): **Procedures guaranteed at every project lifecycle boundary (reledgev Addendum 3).** (1) `upgrade-project.ts` 1.14.0 → 1.15.0: new PROCEDURES SYNC pass — add-if-missing delivery of the variant procedure corpus (`procedures/` entries with project-owned preservation, `_output-types.yaml` seeding). (2) `scan-l3-project.ts`: new `procedures` scan category (`.yaml/.yml/.ts`) so the L3→variant promotion carries the workflow corpus. (3) `generate-skill-graph.ts` 1.7.0 → 1.7.1: namespace fix — procedure node ids now derive from `procedure_id` (strip trailing dirname) instead of the caller fallback, so project-local runs produce `procedure.co-abap.<name>` matching relations[] targets instead of ghost `l0`-namespace orphans; workspace graph unchanged at 542 nodes / 1,545 edges (identity-preserving), all 5 Projects/co-* graphs now verify with procedure nodes + step edges. (4) `tests/reflect-skill-graph-to-project.ts` extended with procedures adoption + context.md §Procedures; adopted into co-abap/co-consult/co-deck/co-price/co-safety (PRs #112/#21/#65/#76/#124, all merged).
+
 ### Fixed
 - **[2026-08-29]**: fix(skills): **Propagation-coupling fix during Projects/co-* adoption wave.** Removed three relation edges whose targets are L0-only (do not propagate to L1/L2): `sync→audit-workspace`, `validate-docs-links→audit-workspace`, `team-builder→create-variant` — they dangled as unknown targets in every project copy. `validate-skills.ts` gains the `relation-target-not-in-l1` warning enforcing ADR-0060 Amendment 6B for the L1 surface; L0-only skill pairs are unaffected. New `tests/reflect-skill-graph-to-project.ts` mirrors the graph feature into Projects/co-* repos (scripts, selective SKILL.md relates_to refresh, context.md section, per-project adoption ADR, graph regeneration + determinism verification).
 

--- a/docs/VERSION_MANIFEST.md
+++ b/docs/VERSION_MANIFEST.md
@@ -1,6 +1,6 @@
 # VERSION_MANIFEST.md
 
-**Generated**: 2026-08-29T07:21:39.618Z
+**Generated**: 2026-08-29T07:49:30.970Z
 **Manifest Version**: 1.0
 **Location**: docs\VERSION_MANIFEST.md
 
@@ -95,7 +95,7 @@
 | generate-ide-rules.ts | 1.0.0 | scripts/generate-ide-rules.ts | N/A |
 | generate-l3-readme.ts | 1.0.3 | scripts/generate-l3-readme.ts | fs, path |
 | generate-scripts-readme.ts | 1.0.3 | scripts/generate-scripts-readme.ts | N/A |
-| generate-skill-graph.ts | 1.7.0 | scripts/generate-skill-graph.ts | js-yaml |
+| generate-skill-graph.ts | 1.7.1 | scripts/generate-skill-graph.ts | js-yaml |
 | generate-version-manifest.ts | 1.2.0 | scripts/generate-version-manifest.ts | bun, js-yaml |
 | infer-graph-from-phases.ts | 0.1.0 | scripts/experiments/infer-graph-from-phases.ts | N/A |
 | ingest-external-skills.ts | 1.1.0 | scripts/ingest-external-skills.ts | N/A |
@@ -137,7 +137,7 @@
 | test-variant-readiness.ts | 1.0.0 | scripts/test-variant-readiness.ts | N/A |
 | ticket.ts | 1.1.0 | scripts/ticket.ts | N/A |
 | translate-readme.ts | 1.0.0 | scripts/translate-readme.ts | bun, fs, path |
-| upgrade-project.ts | 1.14.0 | scripts/upgrade-project.ts | N/A |
+| upgrade-project.ts | 1.15.0 | scripts/upgrade-project.ts | N/A |
 | validate-agents.ts | 1.0.5 | scripts/validate-agents.ts | N/A |
 | validate-decisions.ts | 1.0.0 | scripts/validate-decisions.ts | js-yaml |
 | validate-doc-folder.ts | 1.1.0 | scripts/validate-doc-folder.ts | fs, path |

--- a/docs/designs/2026-08-29-relation-graph-evolution-and-decision-chain-design.md
+++ b/docs/designs/2026-08-29-relation-graph-evolution-and-decision-chain-design.md
@@ -261,3 +261,27 @@ propagated L1/L2 copy. Three edges from the L0 wave were removed for this reason
 (`sync→audit-workspace`, `validate-docs-links→audit-workspace`,
 `team-builder→create-variant`; targets are L0-only skills). L0-only skills may
 still relate among themselves — their frontmatter never propagates.
+
+### Addendum 3 (2026-08-29): Procedures in Every Lifecycle Path + Project Namespace Fix
+
+User mandate: `procedures/` MUST be present at every project lifecycle boundary.
+- **New project creation** (`new-project.ts`): already covered — the generic common
+  copy + variant overlay include `procedures/` (common `procedures/_template` ships
+  as the authoring skeleton).
+- **L3 scaffold** (`create-l3-scaffold.ts`): covered by the default-include overlay.
+- **Project upgrade** (`upgrade-project.ts` v1.15.0): new PROCEDURES SYNC pass —
+  add-if-missing delivery of the variant workflow corpus with project-owned
+  preservation and `_output-types.yaml` seeding.
+- **L3→variant promotion** (`scan-l3-project.ts`): new `procedures` scan category
+  (`.yaml/.yml/.ts`) so the workflow corpus survives promotion into the variant
+  template.
+- **Project adoption** (`tests/reflect-skill-graph-to-project.ts`): copies missing
+  procedures into Projects/co-* repos.
+
+**Generator namespace fix** (`generate-skill-graph.ts` v1.7.1): project-local runs
+scanned `ROOT/procedures` with the fallback `l0` namespace while schemas carry
+variant-prefixed `procedure_id`s — relations[] referencing `procedure.<variant>.*`
+materialized ghost orphans. The namespace is now derived from `procedure_id`
+(strip the trailing `.<dirname>`), which is identity-preserving for the workspace
+graph and fixes project graphs (co-abap/co-consult/co-deck/co-price/co-safety all
+verify with procedure nodes + step edges).

--- a/memory/2026-08-29.md
+++ b/memory/2026-08-29.md
@@ -1654,3 +1654,24 @@ fix(skills): remove dangling cross-layer relation edges, add propagation-couplin
 
 ## Open Issues
 - None
+
+---
+
+## Session Summary
+feat(procedures): guarantee procedure corpus at every project lifecycle boundary
+
+## Changes
+- `M CHANGELOG.md` — modified
+- `docs/designs/2026-08-29-relation-graph-evolution-and-decision-chain-design.md` — modified
+- `scripts/SCRIPTS.md` — modified
+- `scripts/generate-skill-graph.ts` — modified
+- `scripts/helpers/scan-l3-project.ts` — modified
+- `scripts/upgrade-project.ts` — modified
+- `templates/common/scripts/SCRIPTS.md` — modified
+- `tests/reflect-skill-graph-to-project.ts` — modified
+
+## Decisions
+- None
+
+## Open Issues
+- None

--- a/scripts/SCRIPTS.md
+++ b/scripts/SCRIPTS.md
@@ -77,7 +77,7 @@ bun run <alias>                     # via package.json alias (preferred for CI)
 | `generate-ide-rules.ts` | L0 | 1.0.0 | active | —| —| L0+L1 | —|
 | `generate-l3-readme.ts` | L0 | 1.0.3 | active | —| —| L0 | —|
 | `generate-scripts-readme.ts` | L0 | 1.0.3 | active | —| —| L0 | —|
-| `generate-skill-graph.ts` | L0 | 1.7.0 | active | —| —| L0+L1 | —|
+| `generate-skill-graph.ts` | L0 | 1.7.1 | active | —| —| L0+L1 | —|
 | `generate-version-manifest.ts` | L0 | 1.2.0 | active | —| —| L0 | —|
 | `dispatch-parallel.ts` | L0 | 1.0.1 | active | —| —| L0+L1 | —|
 | `dispatch-serial.ts` | L0 | 1.0.1 | active | —| —| L0+L1 | —|
@@ -124,7 +124,7 @@ bun run <alias>                     # via package.json alias (preferred for CI)
 | `helpers/reconcile-with-l0-l1.ts` | L0 | 1.3.1 | active | —| —| L0 | —|
 | `helpers/normalize-agent-skills.ts` | L0 | 1.1.0 | active | —| —| L0 | —|
 | `helpers/prune-country-scoped-assets.ts` | L0 | 0.3.0 | active | —| —| L0 | —|
-| `helpers/scan-l3-project.ts` | L0 | 1.2.0 | active | —| —| L0 | —|
+| `helpers/scan-l3-project.ts` | L0 | 1.3.0 | active | —| —| L0 | —|
 | `helpers/substitute-placeholders.ts` | L0 | 1.2.0 | active | —| —| L0 | —|
 | `helpers/template-utils.ts` | L0 | 1.1.1 | active | —| —| L0+L1 | —|
 | `helpers/rollback-partial-project.ts` | L0 | 1.0.0 | active | —| —| L0 | —|
@@ -199,7 +199,7 @@ bun run <alias>                     # via package.json alias (preferred for CI)
 | `test-runner.ts` | L0 | 1.1.0 | active | `--parallel`, `--sequential`, `--concurrency <n>`, `--timeout <ms>` | —| L0+L1 | —|
 | `translate-readme.ts` | L0 | 1.0.0 | active | —| —| L0+L1 | —|
 | `ticket.ts` | L0 | 1.1.0 | active | `create --not-before`, `list --kind`, `list --ready` | —| L0 | —|
-| `upgrade-project.ts` | L0 | 1.14.0 | active | `--variant`, `--platform`, `--dry-run`, `--prune-removed`, `--rollback`, `--yes` | —| L0 | —|
+| `upgrade-project.ts` | L0 | 1.15.0 | active | `--variant`, `--platform`, `--dry-run`, `--prune-removed`, `--rollback`, `--yes` | —| L0 | —|
 | `variant-feature.ts` | L0 | 1.0.0 | active | `--variant`, `--feature`, `--type` | —| L0 | —|
 | `validate-agents.ts` | L0 | 1.0.5 | active | —| —| L0+L1 | —|
 | `validate-doc-folder.ts` | L0 | 1.1.0 | active | —| —| L0+L1 | —|

--- a/scripts/generate-skill-graph.ts
+++ b/scripts/generate-skill-graph.ts
@@ -1,7 +1,7 @@
 #!/usr/bin/env bun
 /**
  * Skill Relationship Graph Generator
- * @version 1.7.0
+ * @version 1.7.1
  *
  * Generates a skill relationship graph from multiple sources:
  * - SKILL.md files (prerequisites, relates_to frontmatter fields)
@@ -484,7 +484,17 @@ function deriveProceduresFromDir(
     }
     if (!data || typeof data !== 'object') continue;
 
-    const procId: string = `procedure.${namespace}.${entry.name}`;
+    // Namespace resolution: prefer the procedure_id's variant/l0 prefix so node ids
+    // match the `procedure.<ns>.<name>` targets used in relations[] — critical for
+    // project-local runs, where ROOT/procedures is scanned with the fallback 'l0'
+    // namespace but the schemas still carry their variant-prefixed procedure_ids
+    // (e.g. "co-abap-custom-dev-delivery" → procedure.co-abap.custom-dev-delivery).
+    const pidField = typeof data.procedure_id === 'string' ? data.procedure_id : '';
+    const ns = pidField.endsWith(`-${entry.name}`)
+      ? pidField.slice(0, pidField.length - entry.name.length - 1)
+      : namespace;
+
+    const procId: string = `procedure.${ns}.${entry.name}`;
     allNodes.set(procId, { id: procId, type: 'procedure', layer });
 
     const ensureOutputType = (type: string): void => {

--- a/scripts/helpers/scan-l3-project.ts
+++ b/scripts/helpers/scan-l3-project.ts
@@ -5,7 +5,7 @@
  * Recursively scans L3 project directories and classifies files
  * for variant conversion pipeline.
  *
- * @version 1.2.0
+ * @version 1.3.0
  * @phase 1: L3 Analysis
  *
  * Dependencies:
@@ -87,6 +87,9 @@ const SCAN_CATEGORIES = {
   configs: ['.claude', '.gemini'],
   scripts: ['scripts'],
   docs: ['docs'],
+  // Procedure Schema YAML workflows (ADR-0063) — MUST survive L3→variant promotion
+  // so promoted variants carry their (agent, phase) workflow corpus.
+  procedures: ['procedures'],
   root: ['CLAUDE.md', 'GEMINI.md', 'README.md', 'CHANGELOG.md', 'package.json'],
 } as const;
 
@@ -350,6 +353,7 @@ export async function scanL3Project(l3ProjectPath: string): Promise<L3ScanResult
         // Scan directory recursively
         const extensions = category === 'scripts' ? ['.ts', '.sh', '.ps1'] :
                          category === 'agents' || category === 'skills' ? ['.md'] :
+                         category === 'procedures' ? ['.yaml', '.yml', '.ts'] :
                          ['.md', '.json'];
         filesToScan = scanDirectoryRecursively(fullScanPath, l3ProjectPath, extensions);
       } else {

--- a/scripts/upgrade-project.ts
+++ b/scripts/upgrade-project.ts
@@ -1,5 +1,6 @@
 #!/usr/bin/env bun
-// @version 1.14.0
+// @version 1.15.0
+// v1.15.0: New PROCEDURES SYNC pass — add-if-missing delivery of the variant workflow corpus (ADR-0063); legacy projects scaffolded before the procedures wave receive procedures/ entries with project-owned preservation.
 // v1.13.0: New VARIANT-SCOPE SKILL PRUNE pass — a skill present in
 //           templates/common/skills/ AND in exactly one templates/co-*/skills/ is a
 //           variant-exclusive skill mistakenly duplicated into common; removed from
@@ -71,7 +72,7 @@
 // Migrated from upgrade-project.sh/ps1 per ADR-0036. No file permission manipulation.
 
 import {
-  existsSync, mkdirSync, copyFileSync, readFileSync, writeFileSync,
+  existsSync, mkdirSync, copyFileSync, cpSync, readFileSync, writeFileSync,
   readdirSync, statSync, rmSync,
 } from 'node:fs';
 import { resolve, join, dirname, basename, isAbsolute, relative } from 'node:path';
@@ -1334,6 +1335,58 @@ for (const fileName of GOVERNANCE_FILES) {
   console.log(`  ${dryTag}COPIED: ${fileName}`);
   govFilesCopied++;
   syncChanged++;
+}
+console.log('');
+
+// ── PROCEDURES SYNC: variant workflow corpus (add-if-missing) ─────────────────
+// Procedures (ADR-0063) are the canonical workflow source and MUST be present in
+// every project (reledgev pipeline-coverage review 2026-08-29). Legacy projects
+// scaffolded before the procedures wave lack them entirely, and no other pass
+// covers the procedures/ directory. Semantics: ADD-IF-MISSING per procedure entry —
+// a project that already has `procedures/<name>/` keeps its own (project-local
+// workflow edits are intentional); missing entries are copied whole from the
+// variant template first, then templates/common. `_output-types.yaml` is seeded
+// if absent (it is the closed output-type vocabulary validators rely on).
+console.log('--- PROCEDURES SYNC (add-if-missing) ---');
+let proceduresCopied = 0;
+{
+  const projProcDir = join(projectDir, 'procedures');
+  const variantProcDir = join(templatesDir, 'procedures');
+  const commonProcDir = join(commonDir, 'procedures');
+  const sources = [variantProcDir, commonProcDir];
+
+  // Seed _output-types.yaml if the project has no procedures vocabulary at all
+  if (!dryRun && !existsSync(projProcDir)) mkdirSync(projProcDir, { recursive: true });
+  const otypesDst = join(projProcDir, '_output-types.yaml');
+  if (!existsSync(otypesDst)) {
+    for (const srcDir of sources) {
+      const otypesSrc = join(srcDir, '_output-types.yaml');
+      if (existsSync(otypesSrc)) {
+        console.log(`  NEW    procedures/_output-types.yaml`);
+        if (!dryRun) copyFileSync(otypesSrc, otypesDst);
+        proceduresCopied++;
+        syncChanged++;
+        break;
+      }
+    }
+  }
+
+  for (const srcDir of sources) {
+    if (!existsSync(srcDir)) continue;
+    for (const entry of readdirSync(srcDir, { withFileTypes: true })) {
+      if (!entry.isDirectory() || entry.name.startsWith('_')) continue; // _template stays template-only
+      const dst = join(projProcDir, entry.name);
+      if (existsSync(dst)) {
+        console.log(`  OK     procedures/${entry.name}/  (project-owned — preserved)`);
+        continue;
+      }
+      console.log(`  NEW    procedures/${entry.name}/  (from ${srcDir === variantProcDir ? 'variant template' : 'templates/common'})`);
+      if (!dryRun) cpSync(join(srcDir, entry.name), dst, { recursive: true });
+      proceduresCopied++;
+      syncChanged++;
+    }
+  }
+  if (proceduresCopied === 0) console.log('  OK     procedures/ already in sync');
 }
 console.log('');
 

--- a/templates/common/scripts/SCRIPTS.md
+++ b/templates/common/scripts/SCRIPTS.md
@@ -77,7 +77,7 @@ bun run <alias>                     # via package.json alias (preferred for CI)
 | `generate-ide-rules.ts` | L0 | 1.0.0 | active | —| —| L0+L1 | —|
 | `generate-l3-readme.ts` | L0 | 1.0.3 | active | —| —| L0 | —|
 | `generate-scripts-readme.ts` | L0 | 1.0.3 | active | —| —| L0 | —|
-| `generate-skill-graph.ts` | L0 | 1.7.0 | active | —| —| L0+L1 | —|
+| `generate-skill-graph.ts` | L0 | 1.7.1 | active | —| —| L0+L1 | —|
 | `generate-version-manifest.ts` | L0 | 1.2.0 | active | —| —| L0 | —|
 | `dispatch-parallel.ts` | L0 | 1.0.1 | active | —| —| L0+L1 | —|
 | `dispatch-serial.ts` | L0 | 1.0.1 | active | —| —| L0+L1 | —|
@@ -123,7 +123,7 @@ bun run <alias>                     # via package.json alias (preferred for CI)
 | `helpers/reconcile-with-l0-l1.ts` | L0 | 1.3.0 | active | —| —| L0 | —|
 | `helpers/normalize-agent-skills.ts` | L0 | 1.1.0 | active | —| —| L0 | —|
 | `helpers/prune-country-scoped-assets.ts` | L0 | 0.2.0 | active | —| —| L0 | —|
-| `helpers/scan-l3-project.ts` | L0 | 1.2.0 | active | —| —| L0 | —|
+| `helpers/scan-l3-project.ts` | L0 | 1.3.0 | active | —| —| L0 | —|
 | `helpers/substitute-placeholders.ts` | L0 | 1.2.0 | active | —| —| L0 | —|
 | `helpers/template-utils.ts` | L0 | 1.1.1 | active | —| —| L0+L1 | —|
 | `helpers/rollback-partial-project.ts` | L0 | 1.0.0 | active | —| —| L0 | —|
@@ -197,7 +197,7 @@ bun run <alias>                     # via package.json alias (preferred for CI)
 | `test-runner.ts` | L0 | 1.1.0 | active | `--parallel`, `--sequential`, `--concurrency <n>`, `--timeout <ms>` | —| L0+L1 | —|
 | `translate-readme.ts` | L0 | 1.0.0 | active | —| —| L0+L1 | —|
 | `ticket.ts` | L0 | 1.1.0 | active | `create --not-before`, `list --kind`, `list --ready` | —| L0 | —|
-| `upgrade-project.ts` | L0 | 1.14.0 | active | `--variant`, `--platform`, `--dry-run`, `--prune-removed`, `--rollback`, `--yes` | —| L0 | —|
+| `upgrade-project.ts` | L0 | 1.15.0 | active | `--variant`, `--platform`, `--dry-run`, `--prune-removed`, `--rollback`, `--yes` | —| L0 | —|
 | `variant-feature.ts` | L0 | 1.0.0 | active | `--variant`, `--feature`, `--type` | —| L0 | —|
 | `validate-agents.ts` | L0 | 1.0.5 | active | —| —| L0+L1 | —|
 | `validate-doc-folder.ts` | L0 | 1.1.0 | active | —| —| L0+L1 | —|

--- a/templates/common/scripts/generate-skill-graph.ts
+++ b/templates/common/scripts/generate-skill-graph.ts
@@ -1,7 +1,7 @@
 #!/usr/bin/env bun
 /**
  * Skill Relationship Graph Generator
- * @version 1.7.0
+ * @version 1.7.1
  *
  * Generates a skill relationship graph from multiple sources:
  * - SKILL.md files (prerequisites, relates_to frontmatter fields)
@@ -484,7 +484,17 @@ function deriveProceduresFromDir(
     }
     if (!data || typeof data !== 'object') continue;
 
-    const procId: string = `procedure.${namespace}.${entry.name}`;
+    // Namespace resolution: prefer the procedure_id's variant/l0 prefix so node ids
+    // match the `procedure.<ns>.<name>` targets used in relations[] — critical for
+    // project-local runs, where ROOT/procedures is scanned with the fallback 'l0'
+    // namespace but the schemas still carry their variant-prefixed procedure_ids
+    // (e.g. "co-abap-custom-dev-delivery" → procedure.co-abap.custom-dev-delivery).
+    const pidField = typeof data.procedure_id === 'string' ? data.procedure_id : '';
+    const ns = pidField.endsWith(`-${entry.name}`)
+      ? pidField.slice(0, pidField.length - entry.name.length - 1)
+      : namespace;
+
+    const procId: string = `procedure.${ns}.${entry.name}`;
     allNodes.set(procId, { id: procId, type: 'procedure', layer });
 
     const ensureOutputType = (type: string): void => {

--- a/tests/reflect-skill-graph-to-project.ts
+++ b/tests/reflect-skill-graph-to-project.ts
@@ -61,6 +61,34 @@ Skill relations are the generated projection per ADR-0060: \`docs/skill-graph.js
     writeFileSync(ctxPath, c);
     contextUpdated = true;
   }
+  if (!c.includes('## Procedures') && /\n## Scripts/.test(c)) {
+    const proc = `## Procedures
+
+Structured workflows live in \`procedures/<name>/schema.yaml\` (ADR-0063, canonical workflow source). Validate with \`bun scripts/validate-procedures.ts\`; the skill graph derives procedure/output_type nodes and step edges from them.
+`;
+    c = c.replace(/\n## Scripts/, '\n' + proc + '\n## Scripts');
+    writeFileSync(ctxPath, c);
+    contextUpdated = true;
+  }
+}
+
+// 3b. procedures/ adoption (add-if-missing per entry; project-owned preserved)
+let proceduresCopied = 0;
+const projProcDir = join(projectPath, 'procedures');
+const variantProcDir = join(ROOT, 'templates', variant, 'procedures');
+if (!existsSync(projProcDir)) mkdirSync(projProcDir, { recursive: true });
+for (const srcDir of [variantProcDir, join(ROOT, 'templates', 'common', 'procedures')]) {
+  if (!existsSync(srcDir)) continue;
+  for (const entry of readdirSync(srcDir, { withFileTypes: true })) {
+    if (!entry.isDirectory() || entry.name.startsWith('_')) continue;
+    const dst = join(projProcDir, entry.name);
+    if (existsSync(dst)) continue;
+    cpSync(join(srcDir, entry.name), dst, { recursive: true });
+    proceduresCopied++;
+  }
+  const otypesSrc = join(srcDir, '_output-types.yaml');
+  const otypesDst = join(projProcDir, '_output-types.yaml');
+  if (existsSync(otypesSrc) && !existsSync(otypesDst)) { cpSync(otypesSrc, otypesDst); proceduresCopied++; }
 }
 
 // 4. Regenerate + verify project graph (project-local run auto-tags L3)
@@ -75,7 +103,8 @@ const skillsWithRel = relEdges.length;
 const adrDir = join(projectPath, 'docs', 'adr');
 mkdirSync(adrDir, { recursive: true });
 const existing = existsSync(adrDir) ? readdirSync(adrDir).filter(f => /^\d{4}-/.test(f)).sort() : [];
-const nextNum = String(existing.length + 1).padStart(4, '0');
+const priorAdoption = existing.find(f => f.includes('skill-graph-adoption'));
+const nextNum = priorAdoption ? priorAdoption.slice(0, 4) : String(existing.length + 1).padStart(4, '0');
 const date = new Date().toISOString().slice(0, 10);
 const adr = `---
 status: "Accepted"
@@ -129,6 +158,14 @@ Adopt the upstream skill-graph feature into this project:
 - ai_workspace \`docs/designs/2026-08-29-relation-graph-evolution-and-decision-chain-design.md\`
 - ai_workspace ADR-0063 — Procedure Schema as canonical workflow source
 `;
-writeFileSync(join(adrDir, `${nextNum}-skill-graph-adoption.md`), adr);
+const adoptionFile = join(adrDir, `${nextNum}-skill-graph-adoption.md`);
+if (!priorAdoption) writeFileSync(adoptionFile, adr);
 
-console.log(`[${proj}] scripts=4, skillsUpdated=${skillsUpdated}, contextUpdated=${contextUpdated}, graph=${graph.nodes.length}n/${graph.edges.length}e, adr=${nextNum}-skill-graph-adoption.md, verify-exit=${ver.status}`);
+// Addendum: record procedures adoption on an existing adoption ADR
+if (proceduresCopied > 0) {
+  const adrFile = join(adrDir, `${nextNum}-skill-graph-adoption.md`);
+  const addendum = `\n## Addendum (${date}): Procedures Adoption\n\nCopied ${proceduresCopied} procedure(s)/vocabulary file(s) from the variant template into \`procedures/\` (add-if-missing; project-owned entries preserved). Procedure/output_type nodes and step edges now participate in the regenerated graph. Upgrade projects carry the same corpus via the PROCEDURES SYNC pass (upgrade-project v1.15.0).\n`;
+  writeFileSync(adrFile, readFileSync(adrFile, 'utf-8') + addendum);
+}
+
+console.log(`[${proj}] scripts=4, skillsUpdated=${skillsUpdated}, proceduresCopied=${proceduresCopied}, contextUpdated=${contextUpdated}, graph=${graph.nodes.length}n/${graph.edges.length}e, adr=${nextNum}-skill-graph-adoption.md, verify-exit=${ver.status}`);


### PR DESCRIPTION
## Why
Guarantee that `procedures/` (ADR-0063 canonical workflow corpus) is present at every project lifecycle boundary, and fix a generator namespace bug surfaced by the Projects/co-* procedures adoption.

## What Changed
- `upgrade-project.ts` 1.14.0 → 1.15.0: new PROCEDURES SYNC pass — add-if-missing delivery of the variant procedure corpus (`procedures/<name>/` with project-owned preservation; `_output-types.yaml` seeding).
- `scripts/helpers/scan-l3-project.ts` 1.2.0 → 1.3.0: new `procedures` scan category (`.yaml/.yml/.ts`) so L3→variant promotion carries the workflow corpus.
- `generate-skill-graph.ts` 1.7.0 → 1.7.1: procedure node namespace now derived from `procedure_id` (strip trailing dirname) — fixes ghost `l0`-namespace orphans in project-local runs; identity-preserving for the workspace graph (542 nodes / 1,545 edges unchanged).
- `tests/reflect-skill-graph-to-project.ts`: procedures adoption + context.md §Procedures for Projects/co-*.
- Design doc Addendum 3; CHANGELOG entry; SCRIPTS.md rows (root + L1).

## Test Plan
- [x] `generate-skill-graph.ts` + `verify-skill-graph.ts --determinism` → workspace 0 drift
- [x] All 5 Projects/co-* graphs verify with procedure nodes + step edges after adoption
- [x] `bun scripts/audit.ts` → all checks passed
- [x] `validate-skills.ts` / `validate-decisions.ts` → exit 0

## Security Checklist
- [x] No secrets, credentials, or API keys committed
- [x] No `.env` files staged
- [x] Dependencies unchanged

## Notes
Projects/co-* procedures wave merged via co-abap #112, co-consult #21, co-deck #65, co-price #76, co-safety #124.

---
