### PR TITLE
docs(adr): ADR-0060 Amendment 7 (generator v1.8.3 upstream), upgrade-guide asset gate, ADR-0073 reconciliation

### DIFF
--- a/docs/VERSION_MANIFEST.md
+++ b/docs/VERSION_MANIFEST.md
@@ -1,6 +1,6 @@
 # VERSION_MANIFEST.md
 
-**Generated**: 2026-08-29T11:04:23.957Z
+**Generated**: 2026-08-29T11:10:11.317Z
 **Manifest Version**: 1.0
 **Location**: docs\VERSION_MANIFEST.md
 

--- a/docs/adr/0060-skill-relationship-graph-generated-projection.md
+++ b/docs/adr/0060-skill-relationship-graph-generated-projection.md
@@ -439,3 +439,32 @@ projection) is now enforced end-to-end:
   are required on every entry (missing → verification failure); `since` older than
   90 days → warning (promote to frontmatter `relates_to` or drop). The legacy
   `last_reviewed` 12-month staleness warning remains for pre-existing entries.
+
+## Amendment 2026-08-29 — Generator v1.8.3: Upstreaming the co-newbiz Fork Adaptations (Amendment 7)
+
+`generate-skill-graph.ts` 1.7.1 → 1.8.3 upstreams the three adaptations
+co-newbiz had carried as a project-local fork (v1.8.2; local ADR-0073 §b), so
+scaffolded projects no longer maintain a generator fork:
+
+1. **L0/L3 run-context detection keys on `templates/common`** instead of
+   `templates/` — projects carrying content template directories
+   (co-newbiz's `templates/deliverables/`) were being mis-tagged L0 in their
+   own project graphs.
+2. **Source 3b — project-local `variant.json`**: the manifest loop previously
+   read `templates/co-*` only, which exist solely at the workspace root, so a
+   scaffolded project's own `skill_manifest` never yielded `used_by`/`phase`
+   edges. Source 3b now reads the project-local manifest in project context
+   (targets validated against the project's local skill/agent sets).
+3. **Agent discovery excludes `README*.md` and `_*` files** — project `agents/`
+   directories carry folder READMEs that were counted as phantom agent nodes.
+
+**Propagation and verification**: propagated to `templates/common/scripts/`;
+co-newbiz's fork replaced with the canonical L0 copy (logic diff 0; the
+project's ADR-0073 "re-apply when re-copying upstream" maintenance rule for
+these three adaptations is retired). L0 + all 14 scope graphs regenerate
+byte-identical (0 drift, 542 nodes / 1,545 edges); the co-newbiz project graph
+regenerates and verifies at 223 nodes / 661 edges with manifest edges
+(`used_by` 117, `phase` 71) preserved by the upstreamed Source 3b. Remaining
+Projects/co-* projects pick up Source 3b edges on their next project-local
+regeneration. Adoption record:
+`docs/designs/2026-08-29-skill-graph-generator-upstream-design.md`.

--- a/docs/project-upgrade-guide.md
+++ b/docs/project-upgrade-guide.md
@@ -96,6 +96,30 @@ Scripts, agents, and skills are updated only when the template version is newer:
 - **Agents** (`.md` files): Compared via YAML frontmatter `version:` field
 - **Skills** (`SKILL.md`): Compared via YAML frontmatter `version:` or MD5 hash
 
+##### Project Asset Allowlist Gate (v1.16.0)
+
+Brand-**new** common assets are only injected when the project's own
+`variant.json` registers them — the project registry is the SSOT for what the
+project wants:
+
+| Asset | Registry consulted | Behavior when unregistered |
+|-------|--------------------|----------------------------|
+| Common skill (`templates/common/skills/`) | `skill_manifest.allowlist` | `SKIP (not in variant.json skill allowlist)` |
+| Common agent (`templates/common/agents/`) | `agents[].file` | `SKIP (not in variant.json agent registry)` |
+
+- Updates to **already-present** assets are never gated; registration is
+  consulted only for brand-new additions.
+- The variant-skills pass (`templates/<variant>/skills/` → `skills/`) is exempt —
+  the variant template is the authority for variant-owned skills.
+- Projects without a `variant.json` keep the ungated behavior.
+
+To adopt a new common asset, add its slug to `variant.json`
+(`skill_manifest.allowlist`) or the agent file to `agents[]`, then re-run the
+upgrade. Rationale: without this gate the 0.6.0 i18n wave injected
+`i18n-specialist` / `i18n-audit` into projects whose rosters never registered
+them, tripping `audit-variant.ts` allowlist/parity checks. See
+`docs/designs/2026-08-29-upgrade-asset-allowlist-gate-design.md`.
+
 #### 🛡️ PRESERVE Files (Never Touched)
 
 These files are always preserved — local modifications are safe:

--- a/memory/2026-08-29.md
+++ b/memory/2026-08-29.md
@@ -1716,3 +1716,18 @@ fix(pipeline): project asset allowlist gate in upgrade-project, .bat nul-lint ex
 
 ## Open Issues
 - None
+
+---
+
+## Session Summary
+docs(adr): ADR-0060 Amendment 7 (generator v1.8.3 upstream), upgrade-guide asset gate, ADR-0073 reconciliation
+
+## Changes
+- `M docs/adr/0060-skill-relationship-graph-generated-projection.md` — modified
+- `docs/project-upgrade-guide.md` — modified
+
+## Decisions
+- None
+
+## Open Issues
+- None


### PR DESCRIPTION
## Why
docs(adr): ADR-0060 Amendment 7 (generator v1.8.3 upstream), upgrade-guide asset gate, ADR-0073 reconciliation

## What Changed
- docs/VERSION_MANIFEST.md
- docs/adr/0060-skill-relationship-graph-generated-projection.md
- docs/project-upgrade-guide.md
- memory/2026-08-29.md

## Test Plan
- [ ] `bun scripts/audit.ts` passes
- [ ] CHANGELOG.md updated under `[Unreleased]`

## Security Checklist
- [ ] No secrets, credentials, or API keys committed
- [ ] No `.env` files staged (use `.env.sample` for templates)
- [ ] Dependencies unchanged or reviewed for new CVEs

## Notes
None

---