### PR TITLE
fix(upgrade): equal-version core-script drift reconciliation (1.17.2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ## [Unreleased]
 
 ### Fixed
+- **[2026-08-29]**: fix(upgrade): **`upgrade-project.ts` 1.17.1 → 1.17.2 — equal-version core-script drift reconciliation.** SYNC_IF_NEWER skipped scripts whose version matched the project's even when content differed, so locally forked core scripts stayed invisible to every future upgrade (audit across Projects/co-* found drifted forks in 7 of 8 projects, e.g. `sync-md`, `team-builder`, `dispatch`, `gen-pr-body`). Same-version scripts are now hash-compared and the canonical L1 copy is restored with a `⚠️ DRIFT … restored to canonical` notice. This closes the promotion-integrity hole: drifted core scripts hard-fail the L3→variant pipeline's integrity check.
+
+### Fixed
 - **[2026-08-29]**: fix(upgrade): **`upgrade-project.ts` 1.17.0 → 1.17.1 — country-prune safety for manifest-declared skills.** The country-scoped prune pass deleted skills registered in the workspace `country_scoped_assets` registry whenever the project's detected country didn't match — including skills the project's own `variant.json` `skill_manifest.variant_specific` deliberately declares (surfaced when co-newbiz, lacking `template-version.txt`, would have had `k-law` — a manifest-declared KR asset — silently pruned). The prune now KEEPS manifest-declared skills with a `KEEP` notice; manifest adoption beats country inference. Plus project-side hardening in `Projects/co-newbiz`: `template-version.txt` created (`variant=co-newbiz, country=KR` — upgrades now run common-only mode and preserve KR assets), `docs/countries/ACTIVE.md` pointer added, `k-dart`/`k-kosis` added to the skill manifest alongside `k-law`, and a dangling `translate → documentation-writing` edge removed.
 
 ### Fixed

--- a/docs/VERSION_MANIFEST.md
+++ b/docs/VERSION_MANIFEST.md
@@ -1,6 +1,6 @@
 # VERSION_MANIFEST.md
 
-**Generated**: 2026-08-29T11:51:43.935Z
+**Generated**: 2026-08-29T12:38:21.251Z
 **Manifest Version**: 1.0
 **Location**: docs\VERSION_MANIFEST.md
 
@@ -137,7 +137,7 @@
 | test-variant-readiness.ts | 1.0.0 | scripts/test-variant-readiness.ts | N/A |
 | ticket.ts | 1.1.0 | scripts/ticket.ts | N/A |
 | translate-readme.ts | 1.0.0 | scripts/translate-readme.ts | bun, fs, path |
-| upgrade-project.ts | 1.17.1 | scripts/upgrade-project.ts | N/A |
+| upgrade-project.ts | 1.17.2 | scripts/upgrade-project.ts | N/A |
 | validate-agents.ts | 1.0.5 | scripts/validate-agents.ts | N/A |
 | validate-decisions.ts | 1.0.0 | scripts/validate-decisions.ts | js-yaml |
 | validate-doc-folder.ts | 1.1.0 | scripts/validate-doc-folder.ts | fs, path |

--- a/memory/2026-08-29.md
+++ b/memory/2026-08-29.md
@@ -1805,3 +1805,19 @@ fix(upgrade): country-prune safety for manifest-declared skills (1.17.1)
 
 ## Open Issues
 - None
+
+---
+
+## Session Summary
+fix(upgrade): equal-version core-script drift reconciliation (1.17.2)
+
+## Changes
+- `M CHANGELOG.md` — modified
+- `scripts/SCRIPTS.md` — modified
+- `scripts/upgrade-project.ts` — modified
+
+## Decisions
+- None
+
+## Open Issues
+- None

--- a/scripts/SCRIPTS.md
+++ b/scripts/SCRIPTS.md
@@ -199,7 +199,7 @@ bun run <alias>                     # via package.json alias (preferred for CI)
 | `test-runner.ts` | L0 | 1.1.0 | active | `--parallel`, `--sequential`, `--concurrency <n>`, `--timeout <ms>` | —| L0+L1 | —|
 | `translate-readme.ts` | L0 | 1.0.0 | active | —| —| L0+L1 | —|
 | `ticket.ts` | L0 | 1.1.0 | active | `create --not-before`, `list --kind`, `list --ready` | —| L0 | —|
-| `upgrade-project.ts` | L0 | 1.17.1 | active | `--variant`, `--platform`, `--dry-run`, `--prune-removed`, `--rollback`, `--yes` | —| L0 | —|
+| `upgrade-project.ts` | L0 | 1.17.2 | active | `--variant`, `--platform`, `--dry-run`, `--prune-removed`, `--rollback`, `--yes` | —| L0 | —|
 | `variant-feature.ts` | L0 | 1.0.0 | active | `--variant`, `--feature`, `--type` | —| L0 | —|
 | `validate-agents.ts` | L0 | 1.0.5 | active | —| —| L0+L1 | —|
 | `validate-doc-folder.ts` | L0 | 1.1.0 | active | —| —| L0+L1 | —|

--- a/scripts/upgrade-project.ts
+++ b/scripts/upgrade-project.ts
@@ -1,9 +1,12 @@
 #!/usr/bin/env bun
-// @version 1.17.1
+// @version 1.17.2
 // v1.17.0: Identity-separated fork support — a project whose variant.json self-declares a variant
 //           with no templates/<variant>/ dir (e.g. co-architect from co-work) is accepted in
 //           "common-only" sync mode: templates/common + project-owned files only, no readiness
 //           gate against a nonexistent variant template, variant-template passes no-op.
+// v1.17.2: Equal-version content-drift reconciliation — SYNC_IF_NEWER scripts pass now hashes
+//           same-version files and restores the canonical L1 copy when content differs (drifted
+//           local forks were invisible to version-gated sync forever).
 // v1.17.1: Country-prune safety — a skill the project variant.json registers in
 //           skill_manifest.variant_specific is kept (with a KEEP notice) even when the detected
 //           country doesn't match its scope; manifest adoption beats country inference.
@@ -975,6 +978,17 @@ for (const subDir of scriptSubDirs) {
         console.log(`  UPDATE ${rel}  ${projVer} → ${tplVer}`);
       }
       if (!dryRun) { copyFileSync(tplFile, projFile); reconcileScriptRegistry(rel); }
+      console.log(`  ${dryTag}COPIED: ${rel}`);
+      syncChanged++;
+    } else if (tplVer === projVer && fileHash(tplFile) !== fileHash(projFile)) {
+      // v1.17.2 drift reconciliation: equal version but content differs means a
+      // locally forked core script that upgrades could never see (version-gated
+      // sync skipped it forever — found across Projects/co-* on 2026-08-29 with
+      // 11 drifted forks in a single project). Core scripts are canonical: the
+      // template copy wins, unconditionally (the integrity rule "core scripts
+      // must not be modified" already forbids the local fork).
+      console.log(`  ⚠️  DRIFT  ${rel}  ${projVer} (content differs from L1 at same version) — restored to canonical`);
+      if (!dryRun) copyFileSync(tplFile, projFile);
       console.log(`  ${dryTag}COPIED: ${rel}`);
       syncChanged++;
     } else {


### PR DESCRIPTION
## Why
fix(upgrade): equal-version core-script drift reconciliation (1.17.2)

## What Changed
- CHANGELOG.md
- docs/VERSION_MANIFEST.md
- memory/2026-08-29.md
- scripts/SCRIPTS.md
- scripts/upgrade-project.ts

## Test Plan
- [ ] `bun scripts/audit.ts` passes
- [ ] CHANGELOG.md updated under `[Unreleased]`

## Security Checklist
- [ ] No secrets, credentials, or API keys committed
- [ ] No `.env` files staged (use `.env.sample` for templates)
- [ ] Dependencies unchanged or reviewed for new CVEs

## Notes
None

---