### PR TITLE
feat(graph): apply Amendment 8 agent co-use derivation to workspace and all variant templates

### DIFF
--- a/.agents/skills/audit-workspace/SKILL.md
+++ b/.agents/skills/audit-workspace/SKILL.md
@@ -11,6 +11,18 @@ prerequisites: PowerShell or Bash
 relates_to:
   - skill: security-scan
     type: composes_with
+  - skill: team-builder
+    type: composes_with
+  - skill: create-variant
+    type: composes_with
+  - skill: project-to-variant
+    type: composes_with
+  - skill: promote-variant
+    type: follows
+  - skill: sync
+    type: composes_with
+  - skill: upgrade-project
+    type: composes_with
 metadata:
   type: process
   triggers:

--- a/.agents/skills/context-commonization-review/SKILL.md
+++ b/.agents/skills/context-commonization-review/SKILL.md
@@ -15,6 +15,8 @@ last_reviewed: 2026-08-21
 relates_to:
   - skill: promote-variant
     type: follows
+  - skill: meeting-facilitation
+    type: follows
 metadata:
   type: process
   triggers:

--- a/.agents/skills/create-variant/SKILL.md
+++ b/.agents/skills/create-variant/SKILL.md
@@ -12,6 +12,8 @@ last_reviewed: 2026-08-24
 relates_to:
   - skill: promote-variant
     type: enables
+  - skill: documentation-writing
+    type: follows
 metadata:
   type: process
   triggers:

--- a/.agents/skills/documentation-writing/SKILL.md
+++ b/.agents/skills/documentation-writing/SKILL.md
@@ -10,6 +10,11 @@ status: active
 owner: pm
 last_reviewed: 2026-07-19
 prerequisites: none
+relates_to:
+  - skill: team-builder
+    type: composes_with
+  - skill: audit-workspace
+    type: follows
 gemini-parity: skip
 metadata:
   type: implementation

--- a/.agents/skills/meeting-facilitation/SKILL.md
+++ b/.agents/skills/meeting-facilitation/SKILL.md
@@ -10,6 +10,9 @@ owner: pm
 version: 1.4.0
 last_reviewed: 2026-06-05
 prerequisites: []
+relates_to:
+  - skill: context-commonization-review
+    type: follows
 metadata:
   type: process
   triggers:

--- a/.agents/skills/promote-variant/SKILL.md
+++ b/.agents/skills/promote-variant/SKILL.md
@@ -12,6 +12,8 @@ last_reviewed: 2026-08-24
 relates_to:
   - skill: create-variant
     type: follows
+  - skill: sync
+    type: follows
 metadata:
   type: process
   triggers:

--- a/.agents/skills/team-builder/SKILL.md
+++ b/.agents/skills/team-builder/SKILL.md
@@ -10,6 +10,9 @@ status: active
 scope: common
 owner: pm
 prerequisites: none
+relates_to:
+  - skill: create-variant
+    type: follows
 last_reviewed: 2026-06-13
 metadata:
   type: process

--- a/.claude/commands/meeting.md
+++ b/.claude/commands/meeting.md
@@ -10,6 +10,9 @@ owner: pm
 version: 1.4.0
 last_reviewed: 2026-06-05
 prerequisites: []
+relates_to:
+  - skill: context-commonization-review
+    type: follows
 metadata:
   type: process
   triggers:

--- a/.claude/skills/audit-workspace/SKILL.md
+++ b/.claude/skills/audit-workspace/SKILL.md
@@ -11,6 +11,18 @@ prerequisites: PowerShell or Bash
 relates_to:
   - skill: security-scan
     type: composes_with
+  - skill: team-builder
+    type: composes_with
+  - skill: create-variant
+    type: composes_with
+  - skill: project-to-variant
+    type: composes_with
+  - skill: promote-variant
+    type: follows
+  - skill: sync
+    type: composes_with
+  - skill: upgrade-project
+    type: composes_with
 metadata:
   type: process
   triggers:

--- a/.claude/skills/context-commonization-review/SKILL.md
+++ b/.claude/skills/context-commonization-review/SKILL.md
@@ -15,6 +15,8 @@ last_reviewed: 2026-08-21
 relates_to:
   - skill: promote-variant
     type: follows
+  - skill: meeting-facilitation
+    type: follows
 metadata:
   type: process
   triggers:

--- a/.claude/skills/create-variant/SKILL.md
+++ b/.claude/skills/create-variant/SKILL.md
@@ -12,6 +12,8 @@ last_reviewed: 2026-08-24
 relates_to:
   - skill: promote-variant
     type: enables
+  - skill: documentation-writing
+    type: follows
 metadata:
   type: process
   triggers:

--- a/.claude/skills/documentation-writing/SKILL.md
+++ b/.claude/skills/documentation-writing/SKILL.md
@@ -10,6 +10,11 @@ status: active
 owner: pm
 last_reviewed: 2026-07-19
 prerequisites: none
+relates_to:
+  - skill: team-builder
+    type: composes_with
+  - skill: audit-workspace
+    type: follows
 gemini-parity: skip
 metadata:
   type: implementation

--- a/.claude/skills/meeting-facilitation/SKILL.md
+++ b/.claude/skills/meeting-facilitation/SKILL.md
@@ -10,6 +10,9 @@ owner: pm
 version: 1.4.0
 last_reviewed: 2026-06-05
 prerequisites: []
+relates_to:
+  - skill: context-commonization-review
+    type: follows
 metadata:
   type: process
   triggers:

--- a/.claude/skills/promote-variant/SKILL.md
+++ b/.claude/skills/promote-variant/SKILL.md
@@ -12,6 +12,8 @@ last_reviewed: 2026-08-24
 relates_to:
   - skill: create-variant
     type: follows
+  - skill: sync
+    type: follows
 metadata:
   type: process
   triggers:

--- a/.claude/skills/team-builder/SKILL.md
+++ b/.claude/skills/team-builder/SKILL.md
@@ -10,6 +10,9 @@ status: active
 scope: common
 owner: pm
 prerequisites: none
+relates_to:
+  - skill: create-variant
+    type: follows
 last_reviewed: 2026-06-13
 metadata:
   type: process

--- a/.gemini/commands/meeting.md
+++ b/.gemini/commands/meeting.md
@@ -10,6 +10,9 @@ owner: pm
 version: 1.4.0
 last_reviewed: 2026-06-05
 prerequisites: []
+relates_to:
+  - skill: context-commonization-review
+    type: follows
 metadata:
   type: process
   triggers:

--- a/.gemini/skills/audit-workspace/SKILL.md
+++ b/.gemini/skills/audit-workspace/SKILL.md
@@ -11,6 +11,18 @@ prerequisites: PowerShell or Bash
 relates_to:
   - skill: security-scan
     type: composes_with
+  - skill: team-builder
+    type: composes_with
+  - skill: create-variant
+    type: composes_with
+  - skill: project-to-variant
+    type: composes_with
+  - skill: promote-variant
+    type: follows
+  - skill: sync
+    type: composes_with
+  - skill: upgrade-project
+    type: composes_with
 metadata:
   type: process
   triggers:

--- a/.gemini/skills/context-commonization-review/SKILL.md
+++ b/.gemini/skills/context-commonization-review/SKILL.md
@@ -15,6 +15,8 @@ last_reviewed: 2026-08-21
 relates_to:
   - skill: promote-variant
     type: follows
+  - skill: meeting-facilitation
+    type: follows
 metadata:
   type: process
   triggers:

--- a/.gemini/skills/create-variant/SKILL.md
+++ b/.gemini/skills/create-variant/SKILL.md
@@ -12,6 +12,8 @@ last_reviewed: 2026-08-24
 relates_to:
   - skill: promote-variant
     type: enables
+  - skill: documentation-writing
+    type: follows
 metadata:
   type: process
   triggers:

--- a/.gemini/skills/documentation-writing/SKILL.md
+++ b/.gemini/skills/documentation-writing/SKILL.md
@@ -10,6 +10,11 @@ status: active
 owner: pm
 last_reviewed: 2026-07-19
 prerequisites: none
+relates_to:
+  - skill: team-builder
+    type: composes_with
+  - skill: audit-workspace
+    type: follows
 gemini-parity: skip
 metadata:
   type: implementation

--- a/.gemini/skills/meeting-facilitation/SKILL.md
+++ b/.gemini/skills/meeting-facilitation/SKILL.md
@@ -10,6 +10,9 @@ owner: pm
 version: 1.4.0
 last_reviewed: 2026-06-05
 prerequisites: []
+relates_to:
+  - skill: context-commonization-review
+    type: follows
 metadata:
   type: process
   triggers:

--- a/.gemini/skills/promote-variant/SKILL.md
+++ b/.gemini/skills/promote-variant/SKILL.md
@@ -12,6 +12,8 @@ last_reviewed: 2026-08-24
 relates_to:
   - skill: create-variant
     type: follows
+  - skill: sync
+    type: follows
 metadata:
   type: process
   triggers:

--- a/.gemini/skills/team-builder/SKILL.md
+++ b/.gemini/skills/team-builder/SKILL.md
@@ -10,6 +10,9 @@ status: active
 scope: common
 owner: pm
 prerequisites: none
+relates_to:
+  - skill: create-variant
+    type: follows
 last_reviewed: 2026-06-13
 metadata:
   type: process

--- a/docs/VERSION_MANIFEST.md
+++ b/docs/VERSION_MANIFEST.md
@@ -1,6 +1,6 @@
 # VERSION_MANIFEST.md
 
-**Generated**: 2026-08-29T13:36:50.483Z
+**Generated**: 2026-08-29T13:41:22.762Z
 **Manifest Version**: 1.0
 **Location**: docs\VERSION_MANIFEST.md
 

--- a/docs/constitution/06-skill-lifecycle.md
+++ b/docs/constitution/06-skill-lifecycle.md
@@ -142,6 +142,8 @@ Per ADR-0060 (Amendments 3–6) and the `reledgev` design (`docs/designs/2026-08
 
 **Direction policy (ADR-0060 Amendment 6B)**: relations flow variant skill → L1 (`templates/common/skills/`) or same-variant targets only. Variant-specific edges are never written into L1 common skills, and L0-only skills are never targets of variant edges.
 
+**Derivation sources (ADR-0060 Amendments 6 & 8)**: typed relations are derived, in order of precedence, from (1) procedure step adjacency — consecutive steps → `follows`, co-use within one procedure → `composes_with` (declared once, alphabetically-first skill), and (2) **agent co-use** (Amendment 8) — skills co-declared in one agent's `required_skills` → `composes_with`, declared on **both** sides. `tests/add-variant-relations.ts` is the idempotent migrator for both template and project (`--project <path>`) surfaces; already-declared relations are never overwritten.
+
 **Pipeline integration**: the relation graph is regenerated at every lifecycle boundary — L0 `/sync` step 4.65 (all scopes), L3 scaffold (`new-project.ts` step 7.6), L3→variant promotion (`l3-to-variant-pipeline.ts` Phase 6.5), and project upgrade (`upgrade-project.ts` post-upgrade step). `validate-skills.ts` and `validate-decisions.ts` (ADR-0061 chain) run as fail-closed gates in `/sync` step 3.96.
 
 #### 6.3 Skill Body Structure

--- a/docs/designs/2026-08-29-amendment-8-agent-co-use-design.md
+++ b/docs/designs/2026-08-29-amendment-8-agent-co-use-design.md
@@ -1,0 +1,42 @@
+# Design: Amendment 8 — Agent Co-use `composes_with` Derivation + Project Backfill Mode
+
+- **Date**: 2026-08-29
+- **Status**: Implemented
+- **Related**: ADR-0060 (Amendment 8 section), docs/constitution/06-skill-lifecycle.md §6.2.1
+
+## Problem
+
+The Amendment 6 ruleset derives relations only from procedure participants, so
+coverage saturates at procedure membership: co-newbiz 52/125, co-architect
+4/32, co-safety 4/33. An additional, already-tracked source — agent
+`required_skills` frontmatter (agent → skill, ADR-0060) — was not used for
+skill ↔ skill derivation.
+
+## Decision
+
+**Amendment 8 adds the agent co-use derivation**: skills co-declared in one
+agent's `required_skills` gain a symmetric `composes_with`, declared on **both**
+sides (the Amendment 6 single-side convention existed for dedup; both-sides is
+required to raise per-skill coverage). Skip rules: directional `follows`
+between the pair wins; already-declared relations are never overwritten.
+
+**Tool**: `tests/add-variant-relations.ts` gains `--project <path>` mode —
+recursive procedure walk (shared + entity/region overrides), inline `[a, b]`
+and block `required_skills` parsing, CRLF normalization. Templates mode is
+unchanged; L1 `templates/common/skills/` is never written.
+
+## Applied
+
+| Surface | Coverage | Notes |
+|---------|----------|-------|
+| Projects/co-newbiz | 52 → 72/125 (+400 edges; 232n/1,029e) | `graph-map --check` holds |
+| Projects/co-architect | 4 → 10/32 (+9 edges) | |
+| templates/co-* + workspace root | see verification below | |
+
+## Trade-offs
+
+- Both-sides declaration doubles symmetric edges vs the single-side convention
+  — accepted: the metric that matters is per-skill coverage, and symmetric
+  `composes_with` is true by construction.
+- Agent-required co-use is weaker evidence than procedure adjacency — mitigated
+  by the conservative `composes_with` type (never `follows`).

--- a/docs/skill-graph.json
+++ b/docs/skill-graph.json
@@ -3351,6 +3351,18 @@
       }
     },
     {
+      "type": "composes_with",
+      "from": "ai-tell-reduction",
+      "to": "financial-journalism-style",
+      "source": "relates_to",
+      "symmetric": true,
+      "provenance": {
+        "file": "templates/co-news/skills/ai-tell-reduction/SKILL.md",
+        "field": "relates_to",
+        "index": 0
+      }
+    },
+    {
       "type": "references",
       "from": "ai-tell-reduction",
       "to": "financial-journalism-style",
@@ -3533,6 +3545,18 @@
       "source": "prose"
     },
     {
+      "type": "composes_with",
+      "from": "audit-workspace",
+      "to": "create-variant",
+      "source": "relates_to",
+      "symmetric": true,
+      "provenance": {
+        "file": "skills/audit-workspace/SKILL.md",
+        "field": "relates_to",
+        "index": 2
+      }
+    },
+    {
       "type": "produces",
       "from": "audit-workspace",
       "to": "output_type.promotion_checklist_result",
@@ -3547,6 +3571,29 @@
     {
       "type": "composes_with",
       "from": "audit-workspace",
+      "to": "project-to-variant",
+      "source": "relates_to",
+      "symmetric": true,
+      "provenance": {
+        "file": "skills/audit-workspace/SKILL.md",
+        "field": "relates_to",
+        "index": 3
+      }
+    },
+    {
+      "type": "follows",
+      "from": "audit-workspace",
+      "to": "promote-variant",
+      "source": "relates_to",
+      "provenance": {
+        "file": "skills/audit-workspace/SKILL.md",
+        "field": "relates_to",
+        "index": 4
+      }
+    },
+    {
+      "type": "composes_with",
+      "from": "audit-workspace",
       "to": "security-scan",
       "source": "relates_to",
       "symmetric": true,
@@ -3554,6 +3601,42 @@
         "file": "skills/audit-workspace/SKILL.md",
         "field": "relates_to",
         "index": 0
+      }
+    },
+    {
+      "type": "composes_with",
+      "from": "audit-workspace",
+      "to": "sync",
+      "source": "relates_to",
+      "symmetric": true,
+      "provenance": {
+        "file": "skills/audit-workspace/SKILL.md",
+        "field": "relates_to",
+        "index": 5
+      }
+    },
+    {
+      "type": "composes_with",
+      "from": "audit-workspace",
+      "to": "team-builder",
+      "source": "relates_to",
+      "symmetric": true,
+      "provenance": {
+        "file": "skills/audit-workspace/SKILL.md",
+        "field": "relates_to",
+        "index": 1
+      }
+    },
+    {
+      "type": "composes_with",
+      "from": "audit-workspace",
+      "to": "upgrade-project",
+      "source": "relates_to",
+      "symmetric": true,
+      "provenance": {
+        "file": "skills/audit-workspace/SKILL.md",
+        "field": "relates_to",
+        "index": 6
       }
     },
     {
@@ -3698,6 +3781,18 @@
       "source": "skill_manifest"
     },
     {
+      "type": "composes_with",
+      "from": "change-impact-assessment",
+      "to": "org-readiness-assessment",
+      "source": "relates_to",
+      "symmetric": true,
+      "provenance": {
+        "file": "templates/co-consult/skills/change-impact-assessment/SKILL.md",
+        "field": "relates_to",
+        "index": 2
+      }
+    },
+    {
       "type": "requires",
       "from": "change-impact-assessment",
       "to": "org-readiness-assessment",
@@ -3735,6 +3830,18 @@
         "file": "templates/co-consult/skills/change-impact-assessment/SKILL.md",
         "field": "relates_to",
         "index": 0
+      }
+    },
+    {
+      "type": "composes_with",
+      "from": "change-impact-assessment",
+      "to": "stakeholder-alignment",
+      "source": "relates_to",
+      "symmetric": true,
+      "provenance": {
+        "file": "templates/co-consult/skills/change-impact-assessment/SKILL.md",
+        "field": "relates_to",
+        "index": 1
       }
     },
     {
@@ -3798,6 +3905,30 @@
       "source": "skill_manifest"
     },
     {
+      "type": "composes_with",
+      "from": "code-review",
+      "to": "refactoring",
+      "source": "relates_to",
+      "symmetric": true,
+      "provenance": {
+        "file": "templates/co-develop/skills/code-review/SKILL.md",
+        "field": "relates_to",
+        "index": 0
+      }
+    },
+    {
+      "type": "composes_with",
+      "from": "company-intelligence",
+      "to": "competitive-intelligence",
+      "source": "relates_to",
+      "symmetric": true,
+      "provenance": {
+        "file": "templates/co-consult/skills/company-intelligence/SKILL.md",
+        "field": "relates_to",
+        "index": 4
+      }
+    },
+    {
       "type": "used_by",
       "from": "company-intelligence",
       "to": "data-analyst",
@@ -3817,6 +3948,18 @@
         "file": "templates/co-consult/skills/company-intelligence/SKILL.md",
         "field": "relates_to",
         "index": 2
+      }
+    },
+    {
+      "type": "composes_with",
+      "from": "company-intelligence",
+      "to": "financial-statement-analysis",
+      "source": "relates_to",
+      "symmetric": true,
+      "provenance": {
+        "file": "templates/co-consult/skills/company-intelligence/SKILL.md",
+        "field": "relates_to",
+        "index": 3
       }
     },
     {
@@ -3898,6 +4041,18 @@
       "from": "company-intelligence",
       "to": "strategy-analyst",
       "source": "skill_manifest"
+    },
+    {
+      "type": "composes_with",
+      "from": "company-intelligence",
+      "to": "technical-feasibility",
+      "source": "relates_to",
+      "symmetric": true,
+      "provenance": {
+        "file": "templates/co-consult/skills/company-intelligence/SKILL.md",
+        "field": "relates_to",
+        "index": 5
+      }
     },
     {
       "type": "used_by",
@@ -4089,6 +4244,30 @@
       "source": "skill_manifest"
     },
     {
+      "type": "composes_with",
+      "from": "competitive-intelligence",
+      "to": "company-intelligence",
+      "source": "relates_to",
+      "symmetric": true,
+      "provenance": {
+        "file": "templates/co-consult/skills/competitive-intelligence/SKILL.md",
+        "field": "relates_to",
+        "index": 0
+      }
+    },
+    {
+      "type": "composes_with",
+      "from": "competitive-intelligence",
+      "to": "financial-modeling",
+      "source": "relates_to",
+      "symmetric": true,
+      "provenance": {
+        "file": "templates/co-consult/skills/competitive-intelligence/SKILL.md",
+        "field": "relates_to",
+        "index": 1
+      }
+    },
+    {
       "type": "used_by",
       "from": "competitive-intelligence",
       "to": "industry-expert",
@@ -4104,6 +4283,18 @@
       "from": "competitive-intelligence",
       "to": "industry-expert",
       "source": "skill_manifest"
+    },
+    {
+      "type": "composes_with",
+      "from": "competitive-intelligence",
+      "to": "insight-synthesis",
+      "source": "relates_to",
+      "symmetric": true,
+      "provenance": {
+        "file": "templates/co-consult/skills/competitive-intelligence/SKILL.md",
+        "field": "relates_to",
+        "index": 2
+      }
     },
     {
       "type": "references",
@@ -4164,6 +4355,30 @@
       "source": "skill_manifest"
     },
     {
+      "type": "composes_with",
+      "from": "consulting-report-writing",
+      "to": "executive-presentation",
+      "source": "relates_to",
+      "symmetric": true,
+      "provenance": {
+        "file": "templates/co-consult/skills/consulting-report-writing/SKILL.md",
+        "field": "relates_to",
+        "index": 1
+      }
+    },
+    {
+      "type": "composes_with",
+      "from": "consulting-report-writing",
+      "to": "narrative-framework",
+      "source": "relates_to",
+      "symmetric": true,
+      "provenance": {
+        "file": "templates/co-consult/skills/consulting-report-writing/SKILL.md",
+        "field": "relates_to",
+        "index": 0
+      }
+    },
+    {
       "type": "requires",
       "from": "consulting-report-writing",
       "to": "narrative-framework",
@@ -4196,6 +4411,17 @@
       "from": "context-commonization-review",
       "to": "create-variant",
       "source": "prose"
+    },
+    {
+      "type": "follows",
+      "from": "context-commonization-review",
+      "to": "meeting-facilitation",
+      "source": "relates_to",
+      "provenance": {
+        "file": "skills/context-commonization-review/SKILL.md",
+        "field": "relates_to",
+        "index": 1
+      }
     },
     {
       "type": "produces",
@@ -4332,6 +4558,17 @@
       "from": "create-variant",
       "to": "design",
       "source": "prose"
+    },
+    {
+      "type": "follows",
+      "from": "create-variant",
+      "to": "documentation-writing",
+      "source": "relates_to",
+      "provenance": {
+        "file": "skills/create-variant/SKILL.md",
+        "field": "relates_to",
+        "index": 1
+      }
     },
     {
       "type": "references",
@@ -4606,6 +4843,17 @@
       "source": "skill_manifest"
     },
     {
+      "type": "follows",
+      "from": "documentation-writing",
+      "to": "audit-workspace",
+      "source": "relates_to",
+      "provenance": {
+        "file": "skills/documentation-writing/SKILL.md",
+        "field": "relates_to",
+        "index": 1
+      }
+    },
+    {
       "type": "used_by",
       "from": "documentation-writing",
       "to": "content-writer",
@@ -4651,6 +4899,18 @@
       "from": "documentation-writing",
       "to": "output_type.ui_specification",
       "source": "procedure_schema"
+    },
+    {
+      "type": "composes_with",
+      "from": "documentation-writing",
+      "to": "team-builder",
+      "source": "relates_to",
+      "symmetric": true,
+      "provenance": {
+        "file": "skills/documentation-writing/SKILL.md",
+        "field": "relates_to",
+        "index": 0
+      }
     },
     {
       "type": "used_by",
@@ -4873,6 +5133,18 @@
     {
       "type": "composes_with",
       "from": "executive-presentation",
+      "to": "consulting-report-writing",
+      "source": "relates_to",
+      "symmetric": true,
+      "provenance": {
+        "file": "templates/co-consult/skills/executive-presentation/SKILL.md",
+        "field": "relates_to",
+        "index": 4
+      }
+    },
+    {
+      "type": "composes_with",
+      "from": "executive-presentation",
       "to": "financial-modeling",
       "source": "relates_to",
       "symmetric": true,
@@ -4890,6 +5162,18 @@
       "provenance": {
         "file": "templates/co-consult/skills/executive-presentation/SKILL.md",
         "field": "prerequisites"
+      }
+    },
+    {
+      "type": "composes_with",
+      "from": "executive-presentation",
+      "to": "narrative-framework",
+      "source": "relates_to",
+      "symmetric": true,
+      "provenance": {
+        "file": "templates/co-consult/skills/executive-presentation/SKILL.md",
+        "field": "relates_to",
+        "index": 3
       }
     },
     {
@@ -5120,6 +5404,18 @@
     {
       "type": "composes_with",
       "from": "financial-journalism-style",
+      "to": "ai-tell-reduction",
+      "source": "relates_to",
+      "symmetric": true,
+      "provenance": {
+        "file": "templates/co-news/skills/financial-journalism-style/SKILL.md",
+        "field": "relates_to",
+        "index": 2
+      }
+    },
+    {
+      "type": "composes_with",
+      "from": "financial-journalism-style",
       "to": "financial-narrative-brief",
       "source": "relates_to",
       "symmetric": true,
@@ -5188,6 +5484,18 @@
       "source": "skill_manifest"
     },
     {
+      "type": "composes_with",
+      "from": "financial-modeling",
+      "to": "competitive-intelligence",
+      "source": "relates_to",
+      "symmetric": true,
+      "provenance": {
+        "file": "templates/co-consult/skills/financial-modeling/SKILL.md",
+        "field": "relates_to",
+        "index": 5
+      }
+    },
+    {
       "type": "used_by",
       "from": "financial-modeling",
       "to": "data-analyst",
@@ -5220,6 +5528,18 @@
       "from": "financial-modeling",
       "to": "executive-presentation",
       "source": "prose"
+    },
+    {
+      "type": "composes_with",
+      "from": "financial-modeling",
+      "to": "financial-statement-analysis",
+      "source": "relates_to",
+      "symmetric": true,
+      "provenance": {
+        "file": "templates/co-consult/skills/financial-modeling/SKILL.md",
+        "field": "relates_to",
+        "index": 4
+      }
     },
     {
       "type": "follows",
@@ -5391,6 +5711,18 @@
       }
     },
     {
+      "type": "composes_with",
+      "from": "financial-statement-analysis",
+      "to": "company-intelligence",
+      "source": "relates_to",
+      "symmetric": true,
+      "provenance": {
+        "file": "templates/co-consult/skills/financial-statement-analysis/SKILL.md",
+        "field": "relates_to",
+        "index": 0
+      }
+    },
+    {
       "type": "used_by",
       "from": "financial-statement-analysis",
       "to": "data-analyst",
@@ -5408,19 +5740,44 @@
       "source": "skill_manifest"
     },
     {
+      "type": "composes_with",
+      "from": "financial-statement-analysis",
+      "to": "financial-modeling",
+      "source": "relates_to",
+      "symmetric": true,
+      "provenance": {
+        "file": "templates/co-consult/skills/financial-statement-analysis/SKILL.md",
+        "field": "relates_to",
+        "index": 1
+      }
+    },
+    {
+      "type": "composes_with",
+      "from": "financial-statement-analysis",
+      "to": "insight-synthesis",
+      "source": "relates_to",
+      "symmetric": true,
+      "provenance": {
+        "file": "templates/co-consult/skills/financial-statement-analysis/SKILL.md",
+        "field": "relates_to",
+        "index": 2
+      }
+    },
+    {
       "type": "references",
       "from": "financial-statement-analysis",
       "to": "k-dart",
       "source": "prose"
     },
     {
-      "type": "requires",
+      "type": "relates_to",
       "from": "financial-statement-analysis",
       "to": "k-dart",
-      "source": "prerequisites",
+      "source": "relates_to",
       "provenance": {
         "file": "templates/co-consult/skills/financial-statement-analysis/SKILL.md",
-        "field": "prerequisites"
+        "field": "relates_to",
+        "index": 3
       }
     },
     {
@@ -6194,6 +6551,18 @@
     {
       "type": "composes_with",
       "from": "hs-classification-workflow",
+      "to": "landed-cost-calculation",
+      "source": "relates_to",
+      "symmetric": true,
+      "provenance": {
+        "file": "templates/co-export/skills/hs-classification-workflow/SKILL.md",
+        "field": "relates_to",
+        "index": 5
+      }
+    },
+    {
+      "type": "composes_with",
+      "from": "hs-classification-workflow",
       "to": "logistics-coordination",
       "source": "relates_to",
       "symmetric": true,
@@ -6608,6 +6977,18 @@
       "source": "prose"
     },
     {
+      "type": "composes_with",
+      "from": "insight-synthesis",
+      "to": "competitive-intelligence",
+      "source": "relates_to",
+      "symmetric": true,
+      "provenance": {
+        "file": "templates/co-consult/skills/insight-synthesis/SKILL.md",
+        "field": "relates_to",
+        "index": 3
+      }
+    },
+    {
       "type": "used_by",
       "from": "insight-synthesis",
       "to": "data-analyst",
@@ -6623,6 +7004,18 @@
       "from": "insight-synthesis",
       "to": "data-analyst",
       "source": "skill_manifest"
+    },
+    {
+      "type": "composes_with",
+      "from": "insight-synthesis",
+      "to": "financial-statement-analysis",
+      "source": "relates_to",
+      "symmetric": true,
+      "provenance": {
+        "file": "templates/co-consult/skills/insight-synthesis/SKILL.md",
+        "field": "relates_to",
+        "index": 2
+      }
     },
     {
       "type": "follows",
@@ -6852,6 +7245,18 @@
       "source": "skill_manifest"
     },
     {
+      "type": "composes_with",
+      "from": "landed-cost-calculation",
+      "to": "hs-classification-workflow",
+      "source": "relates_to",
+      "symmetric": true,
+      "provenance": {
+        "file": "templates/co-export/skills/landed-cost-calculation/SKILL.md",
+        "field": "relates_to",
+        "index": 0
+      }
+    },
+    {
       "type": "references",
       "from": "landed-cost-calculation",
       "to": "hs-classification-workflow",
@@ -6865,6 +7270,18 @@
       "provenance": {
         "file": "templates/co-export/skills/landed-cost-calculation/SKILL.md",
         "field": "prerequisites"
+      }
+    },
+    {
+      "type": "composes_with",
+      "from": "landed-cost-calculation",
+      "to": "logistics-coordination",
+      "source": "relates_to",
+      "symmetric": true,
+      "provenance": {
+        "file": "templates/co-export/skills/landed-cost-calculation/SKILL.md",
+        "field": "relates_to",
+        "index": 1
       }
     },
     {
@@ -7051,6 +7468,18 @@
       "source": "prose"
     },
     {
+      "type": "composes_with",
+      "from": "logistics-coordination",
+      "to": "landed-cost-calculation",
+      "source": "relates_to",
+      "symmetric": true,
+      "provenance": {
+        "file": "templates/co-export/skills/logistics-coordination/SKILL.md",
+        "field": "relates_to",
+        "index": 1
+      }
+    },
+    {
       "type": "used_by",
       "from": "logistics-coordination",
       "to": "logistics-coordinator",
@@ -7203,6 +7632,17 @@
       "source": "skill_manifest"
     },
     {
+      "type": "follows",
+      "from": "meeting-facilitation",
+      "to": "context-commonization-review",
+      "source": "relates_to",
+      "provenance": {
+        "file": "skills/meeting-facilitation/SKILL.md",
+        "field": "relates_to",
+        "index": 0
+      }
+    },
+    {
       "type": "produces",
       "from": "meeting-facilitation",
       "to": "output_type.governance_actions",
@@ -7236,6 +7676,30 @@
       "from": "narrative-framework",
       "to": "communications-lead",
       "source": "skill_manifest"
+    },
+    {
+      "type": "composes_with",
+      "from": "narrative-framework",
+      "to": "consulting-report-writing",
+      "source": "relates_to",
+      "symmetric": true,
+      "provenance": {
+        "file": "templates/co-consult/skills/narrative-framework/SKILL.md",
+        "field": "relates_to",
+        "index": 0
+      }
+    },
+    {
+      "type": "composes_with",
+      "from": "narrative-framework",
+      "to": "executive-presentation",
+      "source": "relates_to",
+      "symmetric": true,
+      "provenance": {
+        "file": "templates/co-consult/skills/narrative-framework/SKILL.md",
+        "field": "relates_to",
+        "index": 1
+      }
     },
     {
       "type": "phase",
@@ -7331,6 +7795,18 @@
       }
     },
     {
+      "type": "composes_with",
+      "from": "org-readiness-assessment",
+      "to": "change-impact-assessment",
+      "source": "relates_to",
+      "symmetric": true,
+      "provenance": {
+        "file": "templates/co-consult/skills/org-readiness-assessment/SKILL.md",
+        "field": "relates_to",
+        "index": 2
+      }
+    },
+    {
       "type": "used_by",
       "from": "org-readiness-assessment",
       "to": "change-management-partner",
@@ -7405,6 +7881,18 @@
       "from": "org-readiness-assessment",
       "to": "phase2",
       "source": "skill_manifest"
+    },
+    {
+      "type": "composes_with",
+      "from": "org-readiness-assessment",
+      "to": "stakeholder-alignment",
+      "source": "relates_to",
+      "symmetric": true,
+      "provenance": {
+        "file": "templates/co-consult/skills/org-readiness-assessment/SKILL.md",
+        "field": "relates_to",
+        "index": 1
+      }
     },
     {
       "type": "references",
@@ -11105,6 +11593,30 @@
       }
     },
     {
+      "type": "composes_with",
+      "from": "project-delivery",
+      "to": "stakeholder-alignment",
+      "source": "relates_to",
+      "symmetric": true,
+      "provenance": {
+        "file": "templates/co-consult/skills/project-delivery/SKILL.md",
+        "field": "relates_to",
+        "index": 2
+      }
+    },
+    {
+      "type": "composes_with",
+      "from": "project-delivery",
+      "to": "stakeholder-review-management",
+      "source": "relates_to",
+      "symmetric": true,
+      "provenance": {
+        "file": "templates/co-consult/skills/project-delivery/SKILL.md",
+        "field": "relates_to",
+        "index": 1
+      }
+    },
+    {
       "type": "follows",
       "from": "project-delivery",
       "to": "technical-feasibility",
@@ -11180,10 +11692,33 @@
       }
     },
     {
+      "type": "follows",
+      "from": "promote-variant",
+      "to": "sync",
+      "source": "relates_to",
+      "provenance": {
+        "file": "skills/promote-variant/SKILL.md",
+        "field": "relates_to",
+        "index": 1
+      }
+    },
+    {
       "type": "references",
       "from": "red-team-lead",
       "to": "verify-authorization",
       "source": "prose"
+    },
+    {
+      "type": "composes_with",
+      "from": "refactoring",
+      "to": "code-review",
+      "source": "relates_to",
+      "symmetric": true,
+      "provenance": {
+        "file": "templates/co-develop/skills/refactoring/SKILL.md",
+        "field": "relates_to",
+        "index": 0
+      }
     },
     {
       "type": "used_by",
@@ -12665,6 +13200,18 @@
       "source": "prose"
     },
     {
+      "type": "composes_with",
+      "from": "stakeholder-alignment",
+      "to": "change-impact-assessment",
+      "source": "relates_to",
+      "symmetric": true,
+      "provenance": {
+        "file": "templates/co-consult/skills/stakeholder-alignment/SKILL.md",
+        "field": "relates_to",
+        "index": 2
+      }
+    },
+    {
       "type": "used_by",
       "from": "stakeholder-alignment",
       "to": "change-management-partner",
@@ -12696,6 +13243,18 @@
         "file": "templates/co-consult/skills/stakeholder-alignment/SKILL.md",
         "field": "relates_to",
         "index": 0
+      }
+    },
+    {
+      "type": "composes_with",
+      "from": "stakeholder-alignment",
+      "to": "org-readiness-assessment",
+      "source": "relates_to",
+      "symmetric": true,
+      "provenance": {
+        "file": "templates/co-consult/skills/stakeholder-alignment/SKILL.md",
+        "field": "relates_to",
+        "index": 1
       }
     },
     {
@@ -12747,6 +13306,18 @@
       "source": "skill_manifest"
     },
     {
+      "type": "composes_with",
+      "from": "stakeholder-alignment",
+      "to": "project-delivery",
+      "source": "relates_to",
+      "symmetric": true,
+      "provenance": {
+        "file": "templates/co-consult/skills/stakeholder-alignment/SKILL.md",
+        "field": "relates_to",
+        "index": 3
+      }
+    },
+    {
       "type": "used_by",
       "from": "stakeholder-alignment",
       "to": "workstream-lead",
@@ -12795,6 +13366,18 @@
       "from": "stakeholder-review-management",
       "to": "phase4",
       "source": "skill_manifest"
+    },
+    {
+      "type": "composes_with",
+      "from": "stakeholder-review-management",
+      "to": "project-delivery",
+      "source": "relates_to",
+      "symmetric": true,
+      "provenance": {
+        "file": "templates/co-consult/skills/stakeholder-review-management/SKILL.md",
+        "field": "relates_to",
+        "index": 0
+      }
     },
     {
       "type": "requires",
@@ -13056,6 +13639,17 @@
       "source": "prose"
     },
     {
+      "type": "follows",
+      "from": "team-builder",
+      "to": "create-variant",
+      "source": "relates_to",
+      "provenance": {
+        "file": "skills/team-builder/SKILL.md",
+        "field": "relates_to",
+        "index": 0
+      }
+    },
+    {
       "type": "references",
       "from": "team-builder",
       "to": "insight-synthesis",
@@ -13088,6 +13682,18 @@
         "file": "templates/co-consult/skills/technical-feasibility/SKILL.md",
         "field": "relates_to",
         "index": 2
+      }
+    },
+    {
+      "type": "composes_with",
+      "from": "technical-feasibility",
+      "to": "company-intelligence",
+      "source": "relates_to",
+      "symmetric": true,
+      "provenance": {
+        "file": "templates/co-consult/skills/technical-feasibility/SKILL.md",
+        "field": "relates_to",
+        "index": 3
       }
     },
     {

--- a/docs/skill-graph.md
+++ b/docs/skill-graph.md
@@ -12,40 +12,40 @@
 | `abap-dev` | variant:co-abap | architect, code-writer, sap-investigator, test-runner | phase1, phase2, phase3, phase4 | dump-monitor (composes_with), research-analysis (composes_with), sap-co (composes_with), sap-co (composes_with), sap-fi (composes_with), sap-fi (follows), sap-le (composes_with), sap-le (composes_with), sap-mm (composes_with), sap-mm (composes_with), sap-pp (composes_with), sap-pp (composes_with), sap-sd (composes_with), sap-sd (composes_with) | — | — |
 | `accessibility-audit` | variant:co-design | ux-researcher, visual-designer | phase2, phase4 | — | — | — |
 | `agent-lifecycle-manager` | L0 | — | — | skill-lifecycle-manager (composes_with) | — | — |
-| `ai-tell-reduction` | variant:co-news | style-editor, style-editor | phase4 | — | — | — |
+| `ai-tell-reduction` | variant:co-news | style-editor, style-editor | phase4 | financial-journalism-style (composes_with) | — | — |
 | `api-documentation` | L0 | technical-writer | — | — | — | — |
 | `arcade-physics` | variant:co-game | game-debugger, game-developer, game-developer | phase4 | code-review (composes_with), documentation-writing (composes_with), research-analysis (composes_with), sound-synth (follows), test-driven-development (composes_with) | — | — |
-| `audit-workspace` | L0 | — | — | security-scan (composes_with) | — | — |
+| `audit-workspace` | L0 | — | — | create-variant (composes_with), project-to-variant (composes_with), promote-variant (follows), security-scan (composes_with), sync (composes_with), team-builder (composes_with), upgrade-project (composes_with) | — | — |
 | `career-path-succession-planning` | variant:co-hr | career-succession-consultant, career-succession-consultant | phase2 | compensation-benchmarking (composes_with), learning-curriculum-design (composes_with), org-design-framework (composes_with), org-readiness-assessment (composes_with), stakeholder-alignment (follows), talent-acquisition-strategy (composes_with) | — | — |
-| `change-impact-assessment` | variant:co-consult | change-management-partner, change-management-partner | phase1, phase2 | solution-design (composes_with) | — | — |
-| `code-review` | variant:co-develop | code-writer, game-debugger, game-developer | phase3, phase4, phase5 | — | — | — |
-| `company-intelligence` | variant:co-consult | data-analyst, industry-expert, pm, sme, strategy-analyst, strategy-analyst | phase1 | financial-modeling (follows), insight-synthesis (follows), org-readiness-assessment (composes_with) | — | — |
+| `change-impact-assessment` | variant:co-consult | change-management-partner, change-management-partner | phase1, phase2 | org-readiness-assessment (composes_with), solution-design (composes_with), stakeholder-alignment (composes_with) | — | — |
+| `code-review` | variant:co-develop | code-writer, game-debugger, game-developer | phase3, phase4, phase5 | refactoring (composes_with) | — | — |
+| `company-intelligence` | variant:co-consult | data-analyst, industry-expert, pm, sme, strategy-analyst, strategy-analyst | phase1 | competitive-intelligence (composes_with), financial-modeling (follows), financial-statement-analysis (composes_with), insight-synthesis (follows), org-readiness-assessment (composes_with), technical-feasibility (composes_with) | — | — |
 | `compensation-benchmarking` | variant:co-hr | compensation-benefits-analyst, compensation-benefits-analyst | phase2 | consulting-report-writing (composes_with), hr-metrics-analysis (follows), learning-curriculum-design (follows), org-design-framework (composes_with), org-readiness-assessment (composes_with), performance-system-design (composes_with), stakeholder-alignment (composes_with) | — | — |
 | `competency-modeling` | variant:co-hr | career-succession-consultant, learning-development-specialist, performance-management-consultant | phase2 | — | — | — |
-| `competitive-intelligence` | variant:co-consult | industry-expert, industry-expert, strategy-analyst, strategy-analyst | phase1, phase2 | — | — | — |
-| `consulting-report-writing` | variant:co-consult | communications-lead, communications-lead, pm | phase3, phase3 | — | — | — |
-| `context-commonization-review` | L0 | — | — | promote-variant (follows) | — | — |
+| `competitive-intelligence` | variant:co-consult | industry-expert, industry-expert, strategy-analyst, strategy-analyst | phase1, phase2 | company-intelligence (composes_with), financial-modeling (composes_with), insight-synthesis (composes_with) | — | — |
+| `consulting-report-writing` | variant:co-consult | communications-lead, communications-lead, pm | phase3, phase3 | executive-presentation (composes_with), narrative-framework (composes_with) | — | — |
+| `context-commonization-review` | L0 | — | — | meeting-facilitation (follows), promote-variant (follows) | — | — |
 | `cost-shock-analysis` | variant:co-price | — | — | double-entry-reconciliation (composes_with), financial-statement-prep (composes_with), harness-verification (composes_with), harness-verification (follows), price-waterfall-analysis (composes_with), pricing-governance (composes_with), pricing-playbook (composes_with), prisma-7 (composes_with) | — | — |
-| `create-variant` | L0 | — | — | promote-variant (enables) | — | — |
+| `create-variant` | L0 | — | — | documentation-writing (follows), promote-variant (enables) | — | — |
 | `customs-duty-drawback-workflow` | variant:co-export | customs-duty-drawback-specialist, customs-duty-drawback-specialist | phase3, phase4 | landed-cost-calculation (follows) | — | — |
 | `daily/audit-preparation` | variant:co-safety | — | — | — | — | — |
 | `daily/compliance-gap` | variant:co-safety | — | — | — | — | — |
 | `daily/risk-assessment` | variant:co-safety | — | — | — | — | — |
 | `decision-record` | common | — | — | — | — | — |
 | `desktop-app-fallback` | variant:co-abap | code-writer, test-runner | phase3, phase4 | — | — | — |
-| `documentation-writing` | L0 | content-writer, technical-writer | — | — | — | — |
+| `documentation-writing` | L0 | content-writer, technical-writer | — | audit-workspace (follows), team-builder (composes_with) | — | — |
 | `double-entry-reconciliation` | variant:co-price | — | — | financial-statement-prep (composes_with), harness-verification (composes_with), i18n-audit (follows), pricing-playbook (composes_with) | — | — |
 | `dump-monitor` | variant:co-abap | devops-admin, pm | phase1, phase6 | abap-dev (follows), research-analysis (composes_with), sap-co (composes_with), sap-fi (composes_with), sap-le (composes_with), sap-mm (composes_with), sap-sd (composes_with) | — | — |
 | `evidence-ledger` | common | — | — | — | — | — |
 | `excel-export` | variant:co-price | — | — | — | — | — |
-| `executive-presentation` | variant:co-consult | communications-lead, communications-lead | phase3 | financial-modeling (composes_with), org-readiness-assessment (composes_with), technical-feasibility (composes_with) | complexity-grades, business-case, readiness-scores | executive-deck |
+| `executive-presentation` | variant:co-consult | communications-lead, communications-lead | phase3 | consulting-report-writing (composes_with), financial-modeling (composes_with), narrative-framework (composes_with), org-readiness-assessment (composes_with), technical-feasibility (composes_with) | complexity-grades, business-case, readiness-scores | executive-deck |
 | `explain-me` | L0 | — | — | — | — | — |
 | `export-control-screening` | variant:co-export | export-control-compliance-specialist, export-control-compliance-specialist | phase1, phase2 | fta-origin-determination (composes_with), halal-certification-workflow (composes_with), hs-classification-workflow (composes_with), hs-classification-workflow (follows), market-entry-strategy (composes_with), roo-qualification-worksheet (composes_with) | — | — |
 | `financial-infographic-svg` | variant:co-news | visual-editor, visual-editor | phase5 | — | — | — |
-| `financial-journalism-style` | variant:co-news | reporter, reporter, style-editor, style-editor | phase3, phase4 | financial-narrative-brief (composes_with), source-verification-ledger (composes_with) | — | — |
-| `financial-modeling` | variant:co-consult | data-analyst, data-analyst, strategy-analyst, strategy-analyst | phase1, phase3 | executive-presentation (enables), insight-synthesis (follows), stakeholder-alignment (follows), technical-feasibility (composes_with) | complexity-grades, readiness-scores, change-mgmt-cost-estimates | roi-analysis, npv-irr-payback, business-case |
+| `financial-journalism-style` | variant:co-news | reporter, reporter, style-editor, style-editor | phase3, phase4 | ai-tell-reduction (composes_with), financial-narrative-brief (composes_with), source-verification-ledger (composes_with) | — | — |
+| `financial-modeling` | variant:co-consult | data-analyst, data-analyst, strategy-analyst, strategy-analyst | phase1, phase3 | competitive-intelligence (composes_with), executive-presentation (enables), financial-statement-analysis (composes_with), insight-synthesis (follows), stakeholder-alignment (follows), technical-feasibility (composes_with) | complexity-grades, readiness-scores, change-mgmt-cost-estimates | roi-analysis, npv-irr-payback, business-case |
 | `financial-narrative-brief` | variant:co-news | financial-analyst, financial-analyst | phase1 | source-verification-ledger (follows) | — | — |
-| `financial-statement-analysis` | variant:co-consult | data-analyst, data-analyst | phase1, phase3 | — | — | — |
+| `financial-statement-analysis` | variant:co-consult | data-analyst, data-analyst | phase1, phase3 | company-intelligence (composes_with), financial-modeling (composes_with), insight-synthesis (composes_with), k-dart | — | — |
 | `financial-statement-prep` | variant:co-price | — | — | harness-verification (composes_with), harness-verification (follows), i18n-audit (composes_with), pricing-playbook (follows), prisma-7 (composes_with), scenario-comparison (composes_with) | — | — |
 | `finding-reconciliation` | variant:co-security | pentester, pentester, report-writer, report-writer | phase3, phase5, phase6 | sarif-exporter (composes_with), spdx-sbom (follows) | — | — |
 | `foreign-regulation-monitoring` | variant:co-export | foreign-regulatory-intelligence-analyst, foreign-regulatory-intelligence-analyst | phase1 | export-control-screening (follows), fta-origin-determination (composes_with), halal-certification-workflow (composes_with), hs-classification-workflow (composes_with) | — | — |
@@ -56,29 +56,29 @@
 | `handbook` | variant:co-deck | handbook-reviewer, handbook-reviewer, handbook-writer, handbook-writer | phaseH-2, phaseH-3, phaseH-4, phaseH-5 | — | — | — |
 | `harness-verification` | variant:co-price | — | — | double-entry-reconciliation (follows), i18n-audit (composes_with), i18n-audit (composes_with), pricing-playbook (composes_with), prisma-7 (composes_with), scenario-comparison (composes_with), ui-component-design (composes_with) | — | — |
 | `hr-metrics-analysis` | variant:co-hr | data-analyst | phase1, phase3 | consulting-report-writing (follows) | — | — |
-| `hs-classification-workflow` | variant:co-export | hs-classification-specialist, hs-classification-specialist | phase1, phase2 | fta-origin-determination (follows), logistics-coordination (composes_with), market-entry-strategy (composes_with), roo-qualification-worksheet (follows), trade-documentation-checklist (composes_with) | — | — |
+| `hs-classification-workflow` | variant:co-export | hs-classification-specialist, hs-classification-specialist | phase1, phase2 | fta-origin-determination (follows), landed-cost-calculation (composes_with), logistics-coordination (composes_with), market-entry-strategy (composes_with), roo-qualification-worksheet (follows), trade-documentation-checklist (composes_with) | — | — |
 | `hwp-document-processing` | variant:co-consult | communications-lead | phase3, phase4 | — | — | — |
 | `i18n-audit` | common | i18n-specialist | — | — | — | — |
 | `i18n-formatting` | common | i18n-specialist | — | — | — | — |
 | `i18n-layout` | common | i18n-specialist | — | — | — | — |
 | `i18n-locale-config` | common | i18n-specialist | — | — | — | — |
-| `insight-synthesis` | variant:co-consult | data-analyst, data-analyst, strategy-analyst, strategy-analyst | phase1, phase3 | org-readiness-assessment (follows), solution-design (composes_with) | — | — |
+| `insight-synthesis` | variant:co-consult | data-analyst, data-analyst, strategy-analyst, strategy-analyst | phase1, phase3 | competitive-intelligence (composes_with), financial-statement-analysis (composes_with), org-readiness-assessment (follows), solution-design (composes_with) | — | — |
 | `investigation/hazop-analysis` | variant:co-safety | — | — | — | — | — |
 | `k-dart` | common | — | — | — | — | — |
 | `k-kosis` | common | — | — | — | — | — |
 | `k-law` | common | — | — | — | — | — |
 | `labor-compliance-audit` | variant:co-hr | labor-compliance-analyst, labor-compliance-analyst, labor-relations-specialist, labor-relations-specialist, safety-health-officer, safety-health-officer | phase1, phase2 | org-readiness-assessment (follows), stakeholder-alignment (composes_with) | — | — |
-| `landed-cost-calculation` | variant:co-export | hs-classification-specialist, hs-classification-specialist, logistics-coordinator, logistics-coordinator | phase1, phase2 | — | — | — |
+| `landed-cost-calculation` | variant:co-export | hs-classification-specialist, hs-classification-specialist, logistics-coordinator, logistics-coordinator | phase1, phase2 | hs-classification-workflow (composes_with), logistics-coordination (composes_with) | — | — |
 | `learning-curriculum-design` | variant:co-hr | learning-development-specialist, learning-development-specialist | phase2 | org-design-framework (composes_with), org-readiness-assessment (composes_with), performance-system-design (follows), stakeholder-alignment (composes_with), talent-acquisition-strategy (composes_with) | — | — |
-| `logistics-coordination` | variant:co-export | logistics-coordinator, logistics-coordinator | phase3, phase4 | market-entry-strategy (follows) | — | — |
+| `logistics-coordination` | variant:co-export | logistics-coordinator, logistics-coordinator | phase3, phase4 | landed-cost-calculation (composes_with), market-entry-strategy (follows) | — | — |
 | `map-channel-enforcement` | variant:co-price | — | — | — | — | — |
 | `market-entry-strategy` | variant:co-export | market-entry-strategist, market-entry-strategist | phase1, phase3, phase4 | foreign-regulation-monitoring (follows) | — | — |
 | `math-function-plotter` | variant:co-price | — | — | — | — | — |
 | `mece-logic-auditor` | variant:co-consult | strategy-analyst | phase1 | — | — | — |
-| `meeting-facilitation` | L0 | — | — | — | — | — |
-| `narrative-framework` | variant:co-consult | communications-lead, communications-lead | phase3 | — | — | — |
+| `meeting-facilitation` | L0 | — | — | context-commonization-review (follows) | — | — |
+| `narrative-framework` | variant:co-consult | communications-lead, communications-lead | phase3 | consulting-report-writing (composes_with), executive-presentation (composes_with) | — | — |
 | `org-design-framework` | variant:co-hr | org-design-consultant, org-design-consultant | phase2, phase3 | hr-metrics-analysis (follows), org-readiness-assessment (composes_with), performance-system-design (composes_with), stakeholder-alignment (composes_with), talent-acquisition-strategy (follows) | — | — |
-| `org-readiness-assessment` | variant:co-consult | change-management-partner, change-management-partner, change-management-partner | phase1, phase1, phase2, phase2 | financial-modeling (enables) | — | readiness-scores, capability-gap-analysis, change-mgmt-cost-estimates |
+| `org-readiness-assessment` | variant:co-consult | change-management-partner, change-management-partner, change-management-partner | phase1, phase1, phase2, phase2 | change-impact-assessment (composes_with), financial-modeling (enables), stakeholder-alignment (composes_with) | — | readiness-scores, capability-gap-analysis, change-mgmt-cost-estimates |
 | `performance-system-design` | variant:co-hr | performance-management-consultant, performance-management-consultant | phase2 | career-path-succession-planning (follows), stakeholder-alignment (composes_with), talent-acquisition-strategy (composes_with) | — | — |
 | `performance-tuning` | variant:co-abap | architect, dba, sap-investigator | phase1, phase2, phase4 | — | — | — |
 | `post-write-chain` | variant:co-abap | code-writer, pm, test-runner | phase3, phase4 | — | — | — |
@@ -88,11 +88,11 @@
 | `pricing-governance` | variant:co-price | — | — | price-waterfall-analysis (follows), ui-component-design (composes_with) | approval-record | exception-log, guardrail-status |
 | `pricing-playbook` | variant:co-price | — | — | scenario-comparison (enables) | elasticity-reading, price-corridor | pricing-policy-set, scenario-snapshots |
 | `prisma-7` | variant:co-price | — | — | pricing-governance (follows), ui-component-design (composes_with) | — | — |
-| `project-delivery` | variant:co-consult | delivery-manager, delivery-manager, workstream-lead, workstream-lead | phase4 | technical-feasibility (follows) | — | — |
+| `project-delivery` | variant:co-consult | delivery-manager, delivery-manager, workstream-lead, workstream-lead | phase4 | stakeholder-alignment (composes_with), stakeholder-review-management (composes_with), technical-feasibility (follows) | — | — |
 | `project-review` | L0 | — | — | — | — | — |
 | `project-to-variant` | L0 | — | — | promote-variant (composes_with) | — | — |
-| `promote-variant` | L0 | — | — | create-variant (follows) | — | — |
-| `refactoring` | variant:co-develop | code-writer, game-debugger, game-developer | phase3, phase4, phase5 | — | — | — |
+| `promote-variant` | L0 | — | — | create-variant (follows), sync (follows) | — | — |
+| `refactoring` | variant:co-develop | code-writer, game-debugger, game-developer | phase3, phase4, phase5 | code-review (composes_with) | — | — |
 | `research-analysis` | L0 | analyst | — | documentation-writing (enables) | — | — |
 | `roo-qualification-worksheet` | variant:co-export | fta-origin-analyst | phase1, phase2 | halal-certification-workflow (follows) | — | — |
 | `samm-maturity` | variant:co-security | threat-modeler | phase1, phase2 | — | — | — |
@@ -118,16 +118,16 @@
 | `source-command-celebrate` | variant:co-abap | pm | phase6 | — | — | — |
 | `source-verification-ledger` | variant:co-news | fact-checker, fact-checker | phase2 | — | — | — |
 | `spdx-sbom` | variant:co-security | patch-engineer, report-writer | phase3, phase5 | — | — | — |
-| `stakeholder-alignment` | variant:co-consult | change-management-partner, change-management-partner, change-management-partner, workstream-lead, workstream-lead | phase1, phase1, phase2, phase2, phase4 | insight-synthesis (follows) | — | — |
-| `stakeholder-review-management` | variant:co-consult | delivery-manager, delivery-manager | phase4 | — | — | — |
+| `stakeholder-alignment` | variant:co-consult | change-management-partner, change-management-partner, change-management-partner, workstream-lead, workstream-lead | phase1, phase1, phase2, phase2, phase4 | change-impact-assessment (composes_with), insight-synthesis (follows), org-readiness-assessment (composes_with), project-delivery (composes_with) | — | — |
+| `stakeholder-review-management` | variant:co-consult | delivery-manager, delivery-manager | phase4 | project-delivery (composes_with) | — | — |
 | `standup-synthesizer` | L0 | project-coordinator | phase4 | — | — | — |
 | `stride-threat-matrix` | variant:co-security | threat-modeler | phase1, phase2 | finding-reconciliation (follows) | — | — |
 | `style-lint-checklist` | variant:co-news | style-editor | phase4 | — | — | — |
 | `swe-solve` | variant:co-develop | pm | phase4 | — | — | — |
 | `sync` | L0 | — | — | — | — | — |
 | `talent-acquisition-strategy` | variant:co-hr | talent-acquisition-specialist, talent-acquisition-specialist | phase2 | compensation-benchmarking (follows) | — | — |
-| `team-builder` | L0 | — | — | — | — | — |
-| `technical-feasibility` | variant:co-consult | sme, sme, solutions-architect, solutions-architect, technology-specialist, technology-specialist | phase1, phase2, phase3, phase4 | change-impact-assessment (follows), executive-presentation (enables), project-delivery (follows) | — | complexity-grades, risk-cost-ranges, preconditions |
+| `team-builder` | L0 | — | — | create-variant (follows) | — | — |
+| `technical-feasibility` | variant:co-consult | sme, sme, solutions-architect, solutions-architect, technology-specialist, technology-specialist | phase1, phase2, phase3, phase4 | change-impact-assessment (follows), company-intelligence (composes_with), executive-presentation (enables), project-delivery (follows) | — | complexity-grades, risk-cost-ranges, preconditions |
 | `test-driven-development` | variant:co-develop | game-debugger, game-developer, test-runner, test-runner | phase3, phase4, phase5 | code-review (follows) | — | — |
 | `theme-authoring` | variant:co-deck | pm | — | — | — | — |
 | `ticket-run` | L0 | — | — | — | — | — |

--- a/memory/2026-08-29.md
+++ b/memory/2026-08-29.md
@@ -1842,3 +1842,52 @@ feat(graph): ADR-0060 Amendment 8 — agent co-use composes_with derivation + pr
 
 ## Open Issues
 - None
+
+---
+
+## Session Summary
+feat(graph): apply Amendment 8 agent co-use derivation to workspace and all variant templates
+
+## Changes
+- `M docs/constitution/06-skill-lifecycle.md` — modified
+- `docs/skill-graph.json` — modified
+- `docs/skill-graph.md` — modified
+- `skills/audit-workspace/SKILL.md` — modified
+- `skills/context-commonization-review/SKILL.md` — modified
+- `skills/create-variant/SKILL.md` — modified
+- `skills/documentation-writing/SKILL.md` — modified
+- `skills/meeting-facilitation/SKILL.md` — modified
+- `skills/promote-variant/SKILL.md` — modified
+- `skills/team-builder/SKILL.md` — modified
+- `templates/co-consult/docs/skill-graph.json` — modified
+- `templates/co-consult/skills/change-impact-assessment/SKILL.md` — modified
+- `templates/co-consult/skills/company-intelligence/SKILL.md` — modified
+- `templates/co-consult/skills/competitive-intelligence/SKILL.md` — modified
+- `templates/co-consult/skills/consulting-report-writing/SKILL.md` — modified
+- `templates/co-consult/skills/executive-presentation/SKILL.md` — modified
+- `templates/co-consult/skills/financial-modeling/SKILL.md` — modified
+- `templates/co-consult/skills/financial-statement-analysis/SKILL.md` — modified
+- `templates/co-consult/skills/insight-synthesis/SKILL.md` — modified
+- `templates/co-consult/skills/narrative-framework/SKILL.md` — modified
+- `templates/co-consult/skills/org-readiness-assessment/SKILL.md` — modified
+- `templates/co-consult/skills/project-delivery/SKILL.md` — modified
+- `templates/co-consult/skills/stakeholder-alignment/SKILL.md` — modified
+- `templates/co-consult/skills/stakeholder-review-management/SKILL.md` — modified
+- `templates/co-consult/skills/technical-feasibility/SKILL.md` — modified
+- `templates/co-develop/docs/skill-graph.json` — modified
+- `templates/co-develop/skills/code-review/SKILL.md` — modified
+- `templates/co-develop/skills/refactoring/SKILL.md` — modified
+- `templates/co-export/docs/skill-graph.json` — modified
+- `templates/co-export/skills/hs-classification-workflow/SKILL.md` — modified
+- `templates/co-export/skills/landed-cost-calculation/SKILL.md` — modified
+- `templates/co-export/skills/logistics-coordination/SKILL.md` — modified
+- `templates/co-news/docs/skill-graph.json` — modified
+- `templates/co-news/skills/ai-tell-reduction/SKILL.md` — modified
+- `templates/co-news/skills/financial-journalism-style/SKILL.md` — modified
+- `docs/designs/2026-08-29-amendment-8-agent-co-use-design.md` — modified
+
+## Decisions
+- None
+
+## Open Issues
+- None

--- a/skills/audit-workspace/SKILL.md
+++ b/skills/audit-workspace/SKILL.md
@@ -11,6 +11,18 @@ prerequisites: PowerShell or Bash
 relates_to:
   - skill: security-scan
     type: composes_with
+  - skill: team-builder
+    type: composes_with
+  - skill: create-variant
+    type: composes_with
+  - skill: project-to-variant
+    type: composes_with
+  - skill: promote-variant
+    type: follows
+  - skill: sync
+    type: composes_with
+  - skill: upgrade-project
+    type: composes_with
 metadata:
   type: process
   triggers:

--- a/skills/context-commonization-review/SKILL.md
+++ b/skills/context-commonization-review/SKILL.md
@@ -15,6 +15,8 @@ last_reviewed: 2026-08-21
 relates_to:
   - skill: promote-variant
     type: follows
+  - skill: meeting-facilitation
+    type: follows
 metadata:
   type: process
   triggers:

--- a/skills/create-variant/SKILL.md
+++ b/skills/create-variant/SKILL.md
@@ -12,6 +12,8 @@ last_reviewed: 2026-08-24
 relates_to:
   - skill: promote-variant
     type: enables
+  - skill: documentation-writing
+    type: follows
 metadata:
   type: process
   triggers:

--- a/skills/documentation-writing/SKILL.md
+++ b/skills/documentation-writing/SKILL.md
@@ -10,6 +10,11 @@ status: active
 owner: pm
 last_reviewed: 2026-07-19
 prerequisites: none
+relates_to:
+  - skill: team-builder
+    type: composes_with
+  - skill: audit-workspace
+    type: follows
 gemini-parity: skip
 metadata:
   type: implementation

--- a/skills/meeting-facilitation/SKILL.md
+++ b/skills/meeting-facilitation/SKILL.md
@@ -10,6 +10,9 @@ owner: pm
 version: 1.4.0
 last_reviewed: 2026-06-05
 prerequisites: []
+relates_to:
+  - skill: context-commonization-review
+    type: follows
 metadata:
   type: process
   triggers:

--- a/skills/promote-variant/SKILL.md
+++ b/skills/promote-variant/SKILL.md
@@ -12,6 +12,8 @@ last_reviewed: 2026-08-24
 relates_to:
   - skill: create-variant
     type: follows
+  - skill: sync
+    type: follows
 metadata:
   type: process
   triggers:

--- a/skills/team-builder/SKILL.md
+++ b/skills/team-builder/SKILL.md
@@ -10,6 +10,9 @@ status: active
 scope: common
 owner: pm
 prerequisites: none
+relates_to:
+  - skill: create-variant
+    type: follows
 last_reviewed: 2026-06-13
 metadata:
   type: process

--- a/templates/co-consult/docs/skill-graph.json
+++ b/templates/co-consult/docs/skill-graph.json
@@ -309,6 +309,18 @@
       "source": "skill_manifest"
     },
     {
+      "type": "composes_with",
+      "from": "change-impact-assessment",
+      "to": "org-readiness-assessment",
+      "source": "relates_to",
+      "symmetric": true,
+      "provenance": {
+        "file": "templates/co-consult/skills/change-impact-assessment/SKILL.md",
+        "field": "relates_to",
+        "index": 2
+      }
+    },
+    {
       "type": "requires",
       "from": "change-impact-assessment",
       "to": "org-readiness-assessment",
@@ -349,6 +361,30 @@
       }
     },
     {
+      "type": "composes_with",
+      "from": "change-impact-assessment",
+      "to": "stakeholder-alignment",
+      "source": "relates_to",
+      "symmetric": true,
+      "provenance": {
+        "file": "templates/co-consult/skills/change-impact-assessment/SKILL.md",
+        "field": "relates_to",
+        "index": 1
+      }
+    },
+    {
+      "type": "composes_with",
+      "from": "company-intelligence",
+      "to": "competitive-intelligence",
+      "source": "relates_to",
+      "symmetric": true,
+      "provenance": {
+        "file": "templates/co-consult/skills/company-intelligence/SKILL.md",
+        "field": "relates_to",
+        "index": 4
+      }
+    },
+    {
       "type": "used_by",
       "from": "company-intelligence",
       "to": "data-analyst",
@@ -363,6 +399,18 @@
         "file": "templates/co-consult/skills/company-intelligence/SKILL.md",
         "field": "relates_to",
         "index": 2
+      }
+    },
+    {
+      "type": "composes_with",
+      "from": "company-intelligence",
+      "to": "financial-statement-analysis",
+      "source": "relates_to",
+      "symmetric": true,
+      "provenance": {
+        "file": "templates/co-consult/skills/company-intelligence/SKILL.md",
+        "field": "relates_to",
+        "index": 3
       }
     },
     {
@@ -431,6 +479,42 @@
       "source": "skill_manifest"
     },
     {
+      "type": "composes_with",
+      "from": "company-intelligence",
+      "to": "technical-feasibility",
+      "source": "relates_to",
+      "symmetric": true,
+      "provenance": {
+        "file": "templates/co-consult/skills/company-intelligence/SKILL.md",
+        "field": "relates_to",
+        "index": 5
+      }
+    },
+    {
+      "type": "composes_with",
+      "from": "competitive-intelligence",
+      "to": "company-intelligence",
+      "source": "relates_to",
+      "symmetric": true,
+      "provenance": {
+        "file": "templates/co-consult/skills/competitive-intelligence/SKILL.md",
+        "field": "relates_to",
+        "index": 0
+      }
+    },
+    {
+      "type": "composes_with",
+      "from": "competitive-intelligence",
+      "to": "financial-modeling",
+      "source": "relates_to",
+      "symmetric": true,
+      "provenance": {
+        "file": "templates/co-consult/skills/competitive-intelligence/SKILL.md",
+        "field": "relates_to",
+        "index": 1
+      }
+    },
+    {
       "type": "used_by",
       "from": "competitive-intelligence",
       "to": "industry-expert",
@@ -441,6 +525,18 @@
       "from": "competitive-intelligence",
       "to": "industry-expert",
       "source": "skill_manifest"
+    },
+    {
+      "type": "composes_with",
+      "from": "competitive-intelligence",
+      "to": "insight-synthesis",
+      "source": "relates_to",
+      "symmetric": true,
+      "provenance": {
+        "file": "templates/co-consult/skills/competitive-intelligence/SKILL.md",
+        "field": "relates_to",
+        "index": 2
+      }
     },
     {
       "type": "references",
@@ -485,6 +581,30 @@
       "source": "skill_manifest"
     },
     {
+      "type": "composes_with",
+      "from": "consulting-report-writing",
+      "to": "executive-presentation",
+      "source": "relates_to",
+      "symmetric": true,
+      "provenance": {
+        "file": "templates/co-consult/skills/consulting-report-writing/SKILL.md",
+        "field": "relates_to",
+        "index": 1
+      }
+    },
+    {
+      "type": "composes_with",
+      "from": "consulting-report-writing",
+      "to": "narrative-framework",
+      "source": "relates_to",
+      "symmetric": true,
+      "provenance": {
+        "file": "templates/co-consult/skills/consulting-report-writing/SKILL.md",
+        "field": "relates_to",
+        "index": 0
+      }
+    },
+    {
       "type": "requires",
       "from": "consulting-report-writing",
       "to": "narrative-framework",
@@ -515,6 +635,18 @@
     {
       "type": "composes_with",
       "from": "executive-presentation",
+      "to": "consulting-report-writing",
+      "source": "relates_to",
+      "symmetric": true,
+      "provenance": {
+        "file": "templates/co-consult/skills/executive-presentation/SKILL.md",
+        "field": "relates_to",
+        "index": 4
+      }
+    },
+    {
+      "type": "composes_with",
+      "from": "executive-presentation",
       "to": "financial-modeling",
       "source": "relates_to",
       "symmetric": true,
@@ -532,6 +664,18 @@
       "provenance": {
         "file": "templates/co-consult/skills/executive-presentation/SKILL.md",
         "field": "prerequisites"
+      }
+    },
+    {
+      "type": "composes_with",
+      "from": "executive-presentation",
+      "to": "narrative-framework",
+      "source": "relates_to",
+      "symmetric": true,
+      "provenance": {
+        "file": "templates/co-consult/skills/executive-presentation/SKILL.md",
+        "field": "relates_to",
+        "index": 3
       }
     },
     {
@@ -585,6 +729,18 @@
       }
     },
     {
+      "type": "composes_with",
+      "from": "financial-modeling",
+      "to": "competitive-intelligence",
+      "source": "relates_to",
+      "symmetric": true,
+      "provenance": {
+        "file": "templates/co-consult/skills/financial-modeling/SKILL.md",
+        "field": "relates_to",
+        "index": 5
+      }
+    },
+    {
       "type": "used_by",
       "from": "financial-modeling",
       "to": "data-analyst",
@@ -612,6 +768,18 @@
       "from": "financial-modeling",
       "to": "executive-presentation",
       "source": "prose"
+    },
+    {
+      "type": "composes_with",
+      "from": "financial-modeling",
+      "to": "financial-statement-analysis",
+      "source": "relates_to",
+      "symmetric": true,
+      "provenance": {
+        "file": "templates/co-consult/skills/financial-modeling/SKILL.md",
+        "field": "relates_to",
+        "index": 4
+      }
     },
     {
       "type": "follows",
@@ -716,6 +884,18 @@
       }
     },
     {
+      "type": "composes_with",
+      "from": "financial-statement-analysis",
+      "to": "company-intelligence",
+      "source": "relates_to",
+      "symmetric": true,
+      "provenance": {
+        "file": "templates/co-consult/skills/financial-statement-analysis/SKILL.md",
+        "field": "relates_to",
+        "index": 0
+      }
+    },
+    {
       "type": "used_by",
       "from": "financial-statement-analysis",
       "to": "data-analyst",
@@ -728,19 +908,44 @@
       "source": "skill_manifest"
     },
     {
+      "type": "composes_with",
+      "from": "financial-statement-analysis",
+      "to": "financial-modeling",
+      "source": "relates_to",
+      "symmetric": true,
+      "provenance": {
+        "file": "templates/co-consult/skills/financial-statement-analysis/SKILL.md",
+        "field": "relates_to",
+        "index": 1
+      }
+    },
+    {
+      "type": "composes_with",
+      "from": "financial-statement-analysis",
+      "to": "insight-synthesis",
+      "source": "relates_to",
+      "symmetric": true,
+      "provenance": {
+        "file": "templates/co-consult/skills/financial-statement-analysis/SKILL.md",
+        "field": "relates_to",
+        "index": 2
+      }
+    },
+    {
       "type": "references",
       "from": "financial-statement-analysis",
       "to": "k-dart",
       "source": "prose"
     },
     {
-      "type": "requires",
+      "type": "relates_to",
       "from": "financial-statement-analysis",
       "to": "k-dart",
-      "source": "prerequisites",
+      "source": "relates_to",
       "provenance": {
         "file": "templates/co-consult/skills/financial-statement-analysis/SKILL.md",
-        "field": "prerequisites"
+        "field": "relates_to",
+        "index": 3
       }
     },
     {
@@ -786,6 +991,18 @@
       "source": "skill_manifest"
     },
     {
+      "type": "composes_with",
+      "from": "insight-synthesis",
+      "to": "competitive-intelligence",
+      "source": "relates_to",
+      "symmetric": true,
+      "provenance": {
+        "file": "templates/co-consult/skills/insight-synthesis/SKILL.md",
+        "field": "relates_to",
+        "index": 3
+      }
+    },
+    {
       "type": "used_by",
       "from": "insight-synthesis",
       "to": "data-analyst",
@@ -796,6 +1013,18 @@
       "from": "insight-synthesis",
       "to": "data-analyst",
       "source": "skill_manifest"
+    },
+    {
+      "type": "composes_with",
+      "from": "insight-synthesis",
+      "to": "financial-statement-analysis",
+      "source": "relates_to",
+      "symmetric": true,
+      "provenance": {
+        "file": "templates/co-consult/skills/insight-synthesis/SKILL.md",
+        "field": "relates_to",
+        "index": 2
+      }
     },
     {
       "type": "follows",
@@ -905,10 +1134,46 @@
       "source": "skill_manifest"
     },
     {
+      "type": "composes_with",
+      "from": "narrative-framework",
+      "to": "consulting-report-writing",
+      "source": "relates_to",
+      "symmetric": true,
+      "provenance": {
+        "file": "templates/co-consult/skills/narrative-framework/SKILL.md",
+        "field": "relates_to",
+        "index": 0
+      }
+    },
+    {
+      "type": "composes_with",
+      "from": "narrative-framework",
+      "to": "executive-presentation",
+      "source": "relates_to",
+      "symmetric": true,
+      "provenance": {
+        "file": "templates/co-consult/skills/narrative-framework/SKILL.md",
+        "field": "relates_to",
+        "index": 1
+      }
+    },
+    {
       "type": "phase",
       "from": "narrative-framework",
       "to": "phase3",
       "source": "skill_manifest"
+    },
+    {
+      "type": "composes_with",
+      "from": "org-readiness-assessment",
+      "to": "change-impact-assessment",
+      "source": "relates_to",
+      "symmetric": true,
+      "provenance": {
+        "file": "templates/co-consult/skills/org-readiness-assessment/SKILL.md",
+        "field": "relates_to",
+        "index": 2
+      }
     },
     {
       "type": "used_by",
@@ -950,6 +1215,18 @@
       "from": "org-readiness-assessment",
       "to": "phase2",
       "source": "skill_manifest"
+    },
+    {
+      "type": "composes_with",
+      "from": "org-readiness-assessment",
+      "to": "stakeholder-alignment",
+      "source": "relates_to",
+      "symmetric": true,
+      "provenance": {
+        "file": "templates/co-consult/skills/org-readiness-assessment/SKILL.md",
+        "field": "relates_to",
+        "index": 1
+      }
     },
     {
       "type": "step_by_agent",
@@ -1238,6 +1515,30 @@
       }
     },
     {
+      "type": "composes_with",
+      "from": "project-delivery",
+      "to": "stakeholder-alignment",
+      "source": "relates_to",
+      "symmetric": true,
+      "provenance": {
+        "file": "templates/co-consult/skills/project-delivery/SKILL.md",
+        "field": "relates_to",
+        "index": 2
+      }
+    },
+    {
+      "type": "composes_with",
+      "from": "project-delivery",
+      "to": "stakeholder-review-management",
+      "source": "relates_to",
+      "symmetric": true,
+      "provenance": {
+        "file": "templates/co-consult/skills/project-delivery/SKILL.md",
+        "field": "relates_to",
+        "index": 1
+      }
+    },
+    {
       "type": "follows",
       "from": "project-delivery",
       "to": "technical-feasibility",
@@ -1407,6 +1708,18 @@
       "source": "skill_manifest"
     },
     {
+      "type": "composes_with",
+      "from": "stakeholder-alignment",
+      "to": "change-impact-assessment",
+      "source": "relates_to",
+      "symmetric": true,
+      "provenance": {
+        "file": "templates/co-consult/skills/stakeholder-alignment/SKILL.md",
+        "field": "relates_to",
+        "index": 2
+      }
+    },
+    {
       "type": "used_by",
       "from": "stakeholder-alignment",
       "to": "change-management-partner",
@@ -1427,6 +1740,18 @@
         "file": "templates/co-consult/skills/stakeholder-alignment/SKILL.md",
         "field": "relates_to",
         "index": 0
+      }
+    },
+    {
+      "type": "composes_with",
+      "from": "stakeholder-alignment",
+      "to": "org-readiness-assessment",
+      "source": "relates_to",
+      "symmetric": true,
+      "provenance": {
+        "file": "templates/co-consult/skills/stakeholder-alignment/SKILL.md",
+        "field": "relates_to",
+        "index": 1
       }
     },
     {
@@ -1452,6 +1777,18 @@
       "from": "stakeholder-alignment",
       "to": "phase4",
       "source": "skill_manifest"
+    },
+    {
+      "type": "composes_with",
+      "from": "stakeholder-alignment",
+      "to": "project-delivery",
+      "source": "relates_to",
+      "symmetric": true,
+      "provenance": {
+        "file": "templates/co-consult/skills/stakeholder-alignment/SKILL.md",
+        "field": "relates_to",
+        "index": 3
+      }
     },
     {
       "type": "used_by",
@@ -1494,6 +1831,18 @@
       "source": "skill_manifest"
     },
     {
+      "type": "composes_with",
+      "from": "stakeholder-review-management",
+      "to": "project-delivery",
+      "source": "relates_to",
+      "symmetric": true,
+      "provenance": {
+        "file": "templates/co-consult/skills/stakeholder-review-management/SKILL.md",
+        "field": "relates_to",
+        "index": 0
+      }
+    },
+    {
       "type": "requires",
       "from": "stakeholder-review-management",
       "to": "stakeholder-alignment",
@@ -1512,6 +1861,18 @@
         "file": "templates/co-consult/skills/technical-feasibility/SKILL.md",
         "field": "relates_to",
         "index": 2
+      }
+    },
+    {
+      "type": "composes_with",
+      "from": "technical-feasibility",
+      "to": "company-intelligence",
+      "source": "relates_to",
+      "symmetric": true,
+      "provenance": {
+        "file": "templates/co-consult/skills/technical-feasibility/SKILL.md",
+        "field": "relates_to",
+        "index": 3
       }
     },
     {

--- a/templates/co-consult/skills/change-impact-assessment/SKILL.md
+++ b/templates/co-consult/skills/change-impact-assessment/SKILL.md
@@ -14,6 +14,10 @@ prerequisites: org-readiness-assessment
 relates_to:
   - skill: solution-design
     type: composes_with
+  - skill: stakeholder-alignment
+    type: composes_with
+  - skill: org-readiness-assessment
+    type: composes_with
 metadata:
   type: process
   triggers:

--- a/templates/co-consult/skills/company-intelligence/SKILL.md
+++ b/templates/co-consult/skills/company-intelligence/SKILL.md
@@ -17,6 +17,12 @@ relates_to:
     type: composes_with
   - skill: financial-modeling
     type: follows
+  - skill: financial-statement-analysis
+    type: composes_with
+  - skill: competitive-intelligence
+    type: composes_with
+  - skill: technical-feasibility
+    type: composes_with
 metadata:
   source: workspace
   type: research

--- a/templates/co-consult/skills/competitive-intelligence/SKILL.md
+++ b/templates/co-consult/skills/competitive-intelligence/SKILL.md
@@ -11,6 +11,13 @@ last_reviewed: 2026-06-13
 status: active
 owner: strategy-analyst
 prerequisites: none
+relates_to:
+  - skill: company-intelligence
+    type: composes_with
+  - skill: financial-modeling
+    type: composes_with
+  - skill: insight-synthesis
+    type: composes_with
 metadata:
   type: domain
   triggers:

--- a/templates/co-consult/skills/consulting-report-writing/SKILL.md
+++ b/templates/co-consult/skills/consulting-report-writing/SKILL.md
@@ -11,6 +11,11 @@ last_reviewed: 2026-06-13
 status: active
 owner: communications-lead
 prerequisites: narrative-framework
+relates_to:
+  - skill: narrative-framework
+    type: composes_with
+  - skill: executive-presentation
+    type: composes_with
 metadata:
   type: process
   triggers:

--- a/templates/co-consult/skills/executive-presentation/SKILL.md
+++ b/templates/co-consult/skills/executive-presentation/SKILL.md
@@ -18,6 +18,10 @@ relates_to:
     type: composes_with
   - skill: financial-modeling
     type: composes_with
+  - skill: narrative-framework
+    type: composes_with
+  - skill: consulting-report-writing
+    type: composes_with
 inputs: [complexity-grades, business-case, readiness-scores]
 outputs: [executive-deck]
 metadata:

--- a/templates/co-consult/skills/financial-modeling/SKILL.md
+++ b/templates/co-consult/skills/financial-modeling/SKILL.md
@@ -20,6 +20,10 @@ relates_to:
     type: follows
   - skill: stakeholder-alignment
     type: follows
+  - skill: financial-statement-analysis
+    type: composes_with
+  - skill: competitive-intelligence
+    type: composes_with
 inputs: [complexity-grades, readiness-scores, change-mgmt-cost-estimates]
 outputs: [roi-analysis, npv-irr-payback, business-case]
 metadata:

--- a/templates/co-consult/skills/financial-statement-analysis/SKILL.md
+++ b/templates/co-consult/skills/financial-statement-analysis/SKILL.md
@@ -17,7 +17,15 @@ owner: data-analyst
 version: 1.3.1
 last_reviewed: 2026-07-19
 prerequisites:
-  - k-dart
+relates_to:
+  - skill: company-intelligence
+    type: composes_with
+  - skill: financial-modeling
+    type: composes_with
+  - skill: insight-synthesis
+    type: composes_with
+  - skill: k-dart
+    type: relates_to
 metadata:
   type: analysis
   tier: medium

--- a/templates/co-consult/skills/insight-synthesis/SKILL.md
+++ b/templates/co-consult/skills/insight-synthesis/SKILL.md
@@ -16,6 +16,10 @@ relates_to:
     type: follows
   - skill: solution-design
     type: composes_with
+  - skill: financial-statement-analysis
+    type: composes_with
+  - skill: competitive-intelligence
+    type: composes_with
 metadata:
   type: process
   triggers:

--- a/templates/co-consult/skills/narrative-framework/SKILL.md
+++ b/templates/co-consult/skills/narrative-framework/SKILL.md
@@ -12,6 +12,11 @@ last_reviewed: 2026-06-13
 status: active
 owner: communications-lead
 prerequisites: none
+relates_to:
+  - skill: consulting-report-writing
+    type: composes_with
+  - skill: executive-presentation
+    type: composes_with
 metadata:
   type: process
   triggers:

--- a/templates/co-consult/skills/org-readiness-assessment/SKILL.md
+++ b/templates/co-consult/skills/org-readiness-assessment/SKILL.md
@@ -14,6 +14,10 @@ prerequisites: none
 relates_to:
   - skill: financial-modeling
     type: enables
+  - skill: stakeholder-alignment
+    type: composes_with
+  - skill: change-impact-assessment
+    type: composes_with
 outputs: [readiness-scores, capability-gap-analysis, change-mgmt-cost-estimates]
 metadata:
   type: domain

--- a/templates/co-consult/skills/project-delivery/SKILL.md
+++ b/templates/co-consult/skills/project-delivery/SKILL.md
@@ -14,6 +14,10 @@ prerequisites: solution-design
 relates_to:
   - skill: technical-feasibility
     type: follows
+  - skill: stakeholder-review-management
+    type: composes_with
+  - skill: stakeholder-alignment
+    type: composes_with
 metadata:
   type: process
   triggers:

--- a/templates/co-consult/skills/stakeholder-alignment/SKILL.md
+++ b/templates/co-consult/skills/stakeholder-alignment/SKILL.md
@@ -13,6 +13,12 @@ prerequisites: none
 relates_to:
   - skill: insight-synthesis
     type: follows
+  - skill: org-readiness-assessment
+    type: composes_with
+  - skill: change-impact-assessment
+    type: composes_with
+  - skill: project-delivery
+    type: composes_with
 metadata:
   type: process
   triggers:

--- a/templates/co-consult/skills/stakeholder-review-management/SKILL.md
+++ b/templates/co-consult/skills/stakeholder-review-management/SKILL.md
@@ -11,6 +11,9 @@ last_reviewed: 2026-06-13
 status: active
 owner: delivery-manager
 prerequisites: stakeholder-alignment, consulting-report-writing
+relates_to:
+  - skill: project-delivery
+    type: composes_with
 metadata:
   type: process
   triggers:

--- a/templates/co-consult/skills/technical-feasibility/SKILL.md
+++ b/templates/co-consult/skills/technical-feasibility/SKILL.md
@@ -19,6 +19,8 @@ relates_to:
     type: follows
   - skill: change-impact-assessment
     type: follows
+  - skill: company-intelligence
+    type: composes_with
 outputs: [complexity-grades, risk-cost-ranges, preconditions]
 metadata:
   type: process

--- a/templates/co-develop/docs/skill-graph.json
+++ b/templates/co-develop/docs/skill-graph.json
@@ -189,6 +189,18 @@
       "source": "skill_manifest"
     },
     {
+      "type": "composes_with",
+      "from": "code-review",
+      "to": "refactoring",
+      "source": "relates_to",
+      "symmetric": true,
+      "provenance": {
+        "file": "templates/co-develop/skills/code-review/SKILL.md",
+        "field": "relates_to",
+        "index": 0
+      }
+    },
+    {
       "type": "references",
       "from": "designer",
       "to": "code-review",
@@ -421,6 +433,18 @@
       "from": "procedure.co-develop.technical-planning",
       "to": "stack-setup",
       "source": "procedure_schema"
+    },
+    {
+      "type": "composes_with",
+      "from": "refactoring",
+      "to": "code-review",
+      "source": "relates_to",
+      "symmetric": true,
+      "provenance": {
+        "file": "templates/co-develop/skills/refactoring/SKILL.md",
+        "field": "relates_to",
+        "index": 0
+      }
     },
     {
       "type": "used_by",

--- a/templates/co-develop/skills/code-review/SKILL.md
+++ b/templates/co-develop/skills/code-review/SKILL.md
@@ -10,6 +10,9 @@ status: active
 owner: pm
 last_reviewed: 2026-07-19
 prerequisites: none
+relates_to:
+  - skill: refactoring
+    type: composes_with
 gemini-parity: skip
 metadata:
   type: process

--- a/templates/co-develop/skills/refactoring/SKILL.md
+++ b/templates/co-develop/skills/refactoring/SKILL.md
@@ -10,6 +10,9 @@ status: active
 owner: pm
 last_reviewed: 2026-07-19
 prerequisites: none
+relates_to:
+  - skill: code-review
+    type: composes_with
 gemini-parity: skip
 metadata:
   type: process

--- a/templates/co-export/docs/skill-graph.json
+++ b/templates/co-export/docs/skill-graph.json
@@ -645,6 +645,18 @@
     {
       "type": "composes_with",
       "from": "hs-classification-workflow",
+      "to": "landed-cost-calculation",
+      "source": "relates_to",
+      "symmetric": true,
+      "provenance": {
+        "file": "templates/co-export/skills/hs-classification-workflow/SKILL.md",
+        "field": "relates_to",
+        "index": 5
+      }
+    },
+    {
+      "type": "composes_with",
+      "from": "hs-classification-workflow",
       "to": "logistics-coordination",
       "source": "relates_to",
       "symmetric": true,
@@ -744,6 +756,18 @@
       "source": "skill_manifest"
     },
     {
+      "type": "composes_with",
+      "from": "landed-cost-calculation",
+      "to": "hs-classification-workflow",
+      "source": "relates_to",
+      "symmetric": true,
+      "provenance": {
+        "file": "templates/co-export/skills/landed-cost-calculation/SKILL.md",
+        "field": "relates_to",
+        "index": 0
+      }
+    },
+    {
       "type": "references",
       "from": "landed-cost-calculation",
       "to": "hs-classification-workflow",
@@ -757,6 +781,18 @@
       "provenance": {
         "file": "templates/co-export/skills/landed-cost-calculation/SKILL.md",
         "field": "prerequisites"
+      }
+    },
+    {
+      "type": "composes_with",
+      "from": "landed-cost-calculation",
+      "to": "logistics-coordination",
+      "source": "relates_to",
+      "symmetric": true,
+      "provenance": {
+        "file": "templates/co-export/skills/landed-cost-calculation/SKILL.md",
+        "field": "relates_to",
+        "index": 1
       }
     },
     {
@@ -800,6 +836,18 @@
       "from": "landed-cost-calculation",
       "to": "roo-qualification-worksheet",
       "source": "prose"
+    },
+    {
+      "type": "composes_with",
+      "from": "logistics-coordination",
+      "to": "landed-cost-calculation",
+      "source": "relates_to",
+      "symmetric": true,
+      "provenance": {
+        "file": "templates/co-export/skills/logistics-coordination/SKILL.md",
+        "field": "relates_to",
+        "index": 1
+      }
     },
     {
       "type": "used_by",

--- a/templates/co-export/skills/hs-classification-workflow/SKILL.md
+++ b/templates/co-export/skills/hs-classification-workflow/SKILL.md
@@ -22,6 +22,8 @@ relates_to:
     type: composes_with
   - skill: market-entry-strategy
     type: composes_with
+  - skill: landed-cost-calculation
+    type: composes_with
 ---
 
 ## Context

--- a/templates/co-export/skills/landed-cost-calculation/SKILL.md
+++ b/templates/co-export/skills/landed-cost-calculation/SKILL.md
@@ -12,6 +12,11 @@ last_reviewed: 2026-08-25
 status: active
 owner: logistics-coordinator
 prerequisites: hs-classification-workflow
+relates_to:
+  - skill: hs-classification-workflow
+    type: composes_with
+  - skill: logistics-coordination
+    type: composes_with
 metadata:
   type: domain
   triggers:

--- a/templates/co-export/skills/logistics-coordination/SKILL.md
+++ b/templates/co-export/skills/logistics-coordination/SKILL.md
@@ -14,6 +14,8 @@ prerequisites: none
 relates_to:
   - skill: market-entry-strategy
     type: follows
+  - skill: landed-cost-calculation
+    type: composes_with
 ---
 
 ## Context

--- a/templates/co-news/docs/skill-graph.json
+++ b/templates/co-news/docs/skill-graph.json
@@ -174,6 +174,18 @@
   ],
   "edges": [
     {
+      "type": "composes_with",
+      "from": "ai-tell-reduction",
+      "to": "financial-journalism-style",
+      "source": "relates_to",
+      "symmetric": true,
+      "provenance": {
+        "file": "templates/co-news/skills/ai-tell-reduction/SKILL.md",
+        "field": "relates_to",
+        "index": 0
+      }
+    },
+    {
       "type": "references",
       "from": "ai-tell-reduction",
       "to": "financial-journalism-style",
@@ -242,6 +254,18 @@
       "from": "financial-infographic-svg",
       "to": "visual-editor",
       "source": "skill_manifest"
+    },
+    {
+      "type": "composes_with",
+      "from": "financial-journalism-style",
+      "to": "ai-tell-reduction",
+      "source": "relates_to",
+      "symmetric": true,
+      "provenance": {
+        "file": "templates/co-news/skills/financial-journalism-style/SKILL.md",
+        "field": "relates_to",
+        "index": 2
+      }
     },
     {
       "type": "composes_with",

--- a/templates/co-news/skills/ai-tell-reduction/SKILL.md
+++ b/templates/co-news/skills/ai-tell-reduction/SKILL.md
@@ -14,6 +14,9 @@ last_reviewed: 2026-08-10
 status: active
 owner: style-editor
 prerequisites: none
+relates_to:
+  - skill: financial-journalism-style
+    type: composes_with
 ---
 
 ## Context

--- a/templates/co-news/skills/financial-journalism-style/SKILL.md
+++ b/templates/co-news/skills/financial-journalism-style/SKILL.md
@@ -20,6 +20,8 @@ relates_to:
     type: composes_with
   - skill: source-verification-ledger
     type: composes_with
+  - skill: ai-tell-reduction
+    type: composes_with
 ---
 
 ## Context

--- a/templates/common/.agents/skills/audit-workspace/SKILL.md
+++ b/templates/common/.agents/skills/audit-workspace/SKILL.md
@@ -11,6 +11,18 @@ prerequisites: PowerShell or Bash
 relates_to:
   - skill: security-scan
     type: composes_with
+  - skill: team-builder
+    type: composes_with
+  - skill: create-variant
+    type: composes_with
+  - skill: project-to-variant
+    type: composes_with
+  - skill: promote-variant
+    type: follows
+  - skill: sync
+    type: composes_with
+  - skill: upgrade-project
+    type: composes_with
 metadata:
   type: process
   triggers:

--- a/templates/common/.agents/skills/create-variant/SKILL.md
+++ b/templates/common/.agents/skills/create-variant/SKILL.md
@@ -12,6 +12,8 @@ last_reviewed: 2026-08-24
 relates_to:
   - skill: promote-variant
     type: enables
+  - skill: documentation-writing
+    type: follows
 metadata:
   type: process
   triggers:

--- a/templates/common/.agents/skills/documentation-writing/SKILL.md
+++ b/templates/common/.agents/skills/documentation-writing/SKILL.md
@@ -10,6 +10,11 @@ status: active
 owner: pm
 last_reviewed: 2026-07-19
 prerequisites: none
+relates_to:
+  - skill: team-builder
+    type: composes_with
+  - skill: audit-workspace
+    type: follows
 gemini-parity: skip
 metadata:
   type: implementation

--- a/templates/common/.agents/skills/meeting-facilitation/SKILL.md
+++ b/templates/common/.agents/skills/meeting-facilitation/SKILL.md
@@ -10,6 +10,9 @@ owner: pm
 version: 1.4.0
 last_reviewed: 2026-06-05
 prerequisites: []
+relates_to:
+  - skill: context-commonization-review
+    type: follows
 metadata:
   type: process
   triggers:

--- a/templates/common/.agents/skills/promote-variant/SKILL.md
+++ b/templates/common/.agents/skills/promote-variant/SKILL.md
@@ -12,6 +12,8 @@ last_reviewed: 2026-08-24
 relates_to:
   - skill: create-variant
     type: follows
+  - skill: sync
+    type: follows
 metadata:
   type: process
   triggers:

--- a/templates/common/.agents/skills/team-builder/SKILL.md
+++ b/templates/common/.agents/skills/team-builder/SKILL.md
@@ -10,6 +10,9 @@ status: active
 scope: common
 owner: pm
 prerequisites: none
+relates_to:
+  - skill: create-variant
+    type: follows
 last_reviewed: 2026-06-13
 metadata:
   type: process

--- a/templates/common/.claude/commands/meeting.md
+++ b/templates/common/.claude/commands/meeting.md
@@ -10,6 +10,9 @@ owner: pm
 version: 1.4.0
 last_reviewed: 2026-06-05
 prerequisites: []
+relates_to:
+  - skill: context-commonization-review
+    type: follows
 metadata:
   type: process
   triggers:

--- a/templates/common/.claude/skills/audit-workspace/SKILL.md
+++ b/templates/common/.claude/skills/audit-workspace/SKILL.md
@@ -11,6 +11,18 @@ prerequisites: PowerShell or Bash
 relates_to:
   - skill: security-scan
     type: composes_with
+  - skill: team-builder
+    type: composes_with
+  - skill: create-variant
+    type: composes_with
+  - skill: project-to-variant
+    type: composes_with
+  - skill: promote-variant
+    type: follows
+  - skill: sync
+    type: composes_with
+  - skill: upgrade-project
+    type: composes_with
 metadata:
   type: process
   triggers:

--- a/templates/common/.claude/skills/create-variant/SKILL.md
+++ b/templates/common/.claude/skills/create-variant/SKILL.md
@@ -12,6 +12,8 @@ last_reviewed: 2026-08-24
 relates_to:
   - skill: promote-variant
     type: enables
+  - skill: documentation-writing
+    type: follows
 metadata:
   type: process
   triggers:

--- a/templates/common/.claude/skills/documentation-writing/SKILL.md
+++ b/templates/common/.claude/skills/documentation-writing/SKILL.md
@@ -10,6 +10,11 @@ status: active
 owner: pm
 last_reviewed: 2026-07-19
 prerequisites: none
+relates_to:
+  - skill: team-builder
+    type: composes_with
+  - skill: audit-workspace
+    type: follows
 gemini-parity: skip
 metadata:
   type: implementation

--- a/templates/common/.claude/skills/meeting-facilitation/SKILL.md
+++ b/templates/common/.claude/skills/meeting-facilitation/SKILL.md
@@ -10,6 +10,9 @@ owner: pm
 version: 1.4.0
 last_reviewed: 2026-06-05
 prerequisites: []
+relates_to:
+  - skill: context-commonization-review
+    type: follows
 metadata:
   type: process
   triggers:

--- a/templates/common/.claude/skills/promote-variant/SKILL.md
+++ b/templates/common/.claude/skills/promote-variant/SKILL.md
@@ -12,6 +12,8 @@ last_reviewed: 2026-08-24
 relates_to:
   - skill: create-variant
     type: follows
+  - skill: sync
+    type: follows
 metadata:
   type: process
   triggers:

--- a/templates/common/.claude/skills/team-builder/SKILL.md
+++ b/templates/common/.claude/skills/team-builder/SKILL.md
@@ -10,6 +10,9 @@ status: active
 scope: common
 owner: pm
 prerequisites: none
+relates_to:
+  - skill: create-variant
+    type: follows
 last_reviewed: 2026-06-13
 metadata:
   type: process

--- a/templates/common/.gemini/commands/meeting.md
+++ b/templates/common/.gemini/commands/meeting.md
@@ -10,6 +10,9 @@ owner: pm
 version: 1.4.0
 last_reviewed: 2026-06-05
 prerequisites: []
+relates_to:
+  - skill: context-commonization-review
+    type: follows
 metadata:
   type: process
   triggers:

--- a/templates/common/.gemini/skills/audit-workspace/SKILL.md
+++ b/templates/common/.gemini/skills/audit-workspace/SKILL.md
@@ -11,6 +11,18 @@ prerequisites: PowerShell or Bash
 relates_to:
   - skill: security-scan
     type: composes_with
+  - skill: team-builder
+    type: composes_with
+  - skill: create-variant
+    type: composes_with
+  - skill: project-to-variant
+    type: composes_with
+  - skill: promote-variant
+    type: follows
+  - skill: sync
+    type: composes_with
+  - skill: upgrade-project
+    type: composes_with
 metadata:
   type: process
   triggers:

--- a/templates/common/.gemini/skills/create-variant/SKILL.md
+++ b/templates/common/.gemini/skills/create-variant/SKILL.md
@@ -12,6 +12,8 @@ last_reviewed: 2026-08-24
 relates_to:
   - skill: promote-variant
     type: enables
+  - skill: documentation-writing
+    type: follows
 metadata:
   type: process
   triggers:

--- a/templates/common/.gemini/skills/documentation-writing/SKILL.md
+++ b/templates/common/.gemini/skills/documentation-writing/SKILL.md
@@ -10,6 +10,11 @@ status: active
 owner: pm
 last_reviewed: 2026-07-19
 prerequisites: none
+relates_to:
+  - skill: team-builder
+    type: composes_with
+  - skill: audit-workspace
+    type: follows
 gemini-parity: skip
 metadata:
   type: implementation

--- a/templates/common/.gemini/skills/meeting-facilitation/SKILL.md
+++ b/templates/common/.gemini/skills/meeting-facilitation/SKILL.md
@@ -10,6 +10,9 @@ owner: pm
 version: 1.4.0
 last_reviewed: 2026-06-05
 prerequisites: []
+relates_to:
+  - skill: context-commonization-review
+    type: follows
 metadata:
   type: process
   triggers:

--- a/templates/common/.gemini/skills/promote-variant/SKILL.md
+++ b/templates/common/.gemini/skills/promote-variant/SKILL.md
@@ -12,6 +12,8 @@ last_reviewed: 2026-08-24
 relates_to:
   - skill: create-variant
     type: follows
+  - skill: sync
+    type: follows
 metadata:
   type: process
   triggers:

--- a/templates/common/.gemini/skills/team-builder/SKILL.md
+++ b/templates/common/.gemini/skills/team-builder/SKILL.md
@@ -10,6 +10,9 @@ status: active
 scope: common
 owner: pm
 prerequisites: none
+relates_to:
+  - skill: create-variant
+    type: follows
 last_reviewed: 2026-06-13
 metadata:
   type: process

--- a/templates/common/docs/skill-graph.json
+++ b/templates/common/docs/skill-graph.json
@@ -17,6 +17,21 @@
       "layer": "common"
     },
     {
+      "id": "audit-workspace",
+      "type": "skill",
+      "layer": "L0"
+    },
+    {
+      "id": "context-commonization-review",
+      "type": "skill",
+      "layer": "L0"
+    },
+    {
+      "id": "create-variant",
+      "type": "skill",
+      "layer": "L0"
+    },
+    {
       "id": "decision-record",
       "type": "skill",
       "layer": "common"
@@ -170,6 +185,29 @@
       "from": "decision-record",
       "to": "evidence-ledger",
       "source": "prose"
+    },
+    {
+      "type": "follows",
+      "from": "documentation-writing",
+      "to": "audit-workspace",
+      "source": "relates_to",
+      "provenance": {
+        "file": "templates/common/skills/documentation-writing/SKILL.md",
+        "field": "relates_to",
+        "index": 1
+      }
+    },
+    {
+      "type": "composes_with",
+      "from": "documentation-writing",
+      "to": "team-builder",
+      "source": "relates_to",
+      "symmetric": true,
+      "provenance": {
+        "file": "templates/common/skills/documentation-writing/SKILL.md",
+        "field": "relates_to",
+        "index": 0
+      }
     },
     {
       "type": "references",
@@ -334,6 +372,17 @@
       "source": "prose"
     },
     {
+      "type": "follows",
+      "from": "meeting-facilitation",
+      "to": "context-commonization-review",
+      "source": "relates_to",
+      "provenance": {
+        "file": "templates/common/skills/meeting-facilitation/SKILL.md",
+        "field": "relates_to",
+        "index": 0
+      }
+    },
+    {
       "type": "references",
       "from": "meeting-facilitation",
       "to": "project-review",
@@ -379,6 +428,17 @@
       "from": "team-builder",
       "to": "agent-lifecycle-manager",
       "source": "prose"
+    },
+    {
+      "type": "follows",
+      "from": "team-builder",
+      "to": "create-variant",
+      "source": "relates_to",
+      "provenance": {
+        "file": "templates/common/skills/team-builder/SKILL.md",
+        "field": "relates_to",
+        "index": 0
+      }
     },
     {
       "type": "references",

--- a/templates/common/skills/documentation-writing/SKILL.md
+++ b/templates/common/skills/documentation-writing/SKILL.md
@@ -10,6 +10,11 @@ status: active
 owner: pm
 last_reviewed: 2026-07-19
 prerequisites: none
+relates_to:
+  - skill: team-builder
+    type: composes_with
+  - skill: audit-workspace
+    type: follows
 gemini-parity: skip
 metadata:
   type: implementation

--- a/templates/common/skills/meeting-facilitation/SKILL.md
+++ b/templates/common/skills/meeting-facilitation/SKILL.md
@@ -10,6 +10,9 @@ owner: pm
 version: 1.4.0
 last_reviewed: 2026-06-05
 prerequisites: []
+relates_to:
+  - skill: context-commonization-review
+    type: follows
 metadata:
   type: process
   triggers:

--- a/templates/common/skills/team-builder/SKILL.md
+++ b/templates/common/skills/team-builder/SKILL.md
@@ -10,6 +10,9 @@ status: active
 scope: common
 owner: pm
 prerequisites: none
+relates_to:
+  - skill: create-variant
+    type: follows
 last_reviewed: 2026-06-13
 metadata:
   type: process


### PR DESCRIPTION
## Why
feat(graph): apply Amendment 8 agent co-use derivation to workspace and all variant templates

## What Changed
- .agents/skills/audit-workspace/SKILL.md
- .agents/skills/context-commonization-review/SKILL.md
- .agents/skills/create-variant/SKILL.md
- .agents/skills/documentation-writing/SKILL.md
- .agents/skills/meeting-facilitation/SKILL.md
- .agents/skills/promote-variant/SKILL.md
- .agents/skills/team-builder/SKILL.md
- .claude/commands/meeting.md
- .claude/skills/audit-workspace/SKILL.md
- .claude/skills/context-commonization-review/SKILL.md
- .claude/skills/create-variant/SKILL.md
- .claude/skills/documentation-writing/SKILL.md
- .claude/skills/meeting-facilitation/SKILL.md
- .claude/skills/promote-variant/SKILL.md
- .claude/skills/team-builder/SKILL.md
- .gemini/commands/meeting.md
- .gemini/skills/audit-workspace/SKILL.md
- .gemini/skills/context-commonization-review/SKILL.md
- .gemini/skills/create-variant/SKILL.md
- .gemini/skills/documentation-writing/SKILL.md
- .gemini/skills/meeting-facilitation/SKILL.md
- .gemini/skills/promote-variant/SKILL.md
- .gemini/skills/team-builder/SKILL.md
- docs/VERSION_MANIFEST.md
- docs/constitution/06-skill-lifecycle.md
- docs/designs/2026-08-29-amendment-8-agent-co-use-design.md
- docs/skill-graph.json
- docs/skill-graph.md
- memory/2026-08-29.md
- skills/audit-workspace/SKILL.md

## Test Plan
- [ ] `bun scripts/audit.ts` passes
- [ ] CHANGELOG.md updated under `[Unreleased]`

## Security Checklist
- [ ] No secrets, credentials, or API keys committed
- [ ] No `.env` files staged (use `.env.sample` for templates)
- [ ] Dependencies unchanged or reviewed for new CVEs

## Notes
None

---