### PR TITLE
fix(templates): sync scaffold audit fixes into L1/L2 templates — register handbook scripts in L1 SCRIPTS.md, add @version headers, prune stale relates_to edges, fix i18n-specialist lifecycle frontmatter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - **[2026-08-29]**: feat(graph): **ADR-0060 Amendment 8 — agent co-use `composes_with` derivation + project backfill mode.** `tests/add-variant-relations.ts` gains `--project <path>` mode (recursive procedure walk incl. entity/region overrides; inline `[a, b]` and block `required_skills` both parsed; CRLF-normalized) and the Amendment 8 derivation: skills co-declared in one agent's `required_skills` gain a symmetric `composes_with`, declared on both sides. Applied: co-newbiz coverage 52 → 72/125 skills (+400 edges; 232n/1,029e), co-architect 4 → 10/32 (+9 edges); both graphs verify clean, co-newbiz's `graph-map --check` bidirectional contract holds; two legacy bare-string `relates_to` entries normalized to typed form. ADR-0060 Amendment 8 section added.
 
 ### Fixed
+- **[2026-08-30]**: fix(templates): **Scaffold audit fixes propagated into L1/L2 templates after the co-consult post-scaffold audit found 7 failures.** Registered the 23 `handbook/*.ts` + 3 `tests/*.test.ts` scripts in `templates/common/scripts/SCRIPTS.md` (never present in the L1 registry, so every scaffold produced unregistered-script audit failures) and stamped `// @version` headers on the 7 scripts missing them; pruned stale `relates_to` edges in `documentation-writing` (→ `audit-workspace`), `meeting-facilitation` (→ `context-commonization-review`), and `team-builder` (→ `create-variant`) — all three target L0-only skills absent from L2; added required `lifecycle.phase`/`lifecycle.governance` frontmatter to `templates/common/agents/i18n-specialist.md` plus its governance record in `templates/co-consult/docs/lifecycle/agents/`; replaced fullwidth `！` (U+FF01) in `handbook` `copy-code.js` ja labels to satisfy the homoglyph audit. Verified: scaffolded `co-consult` audit 7 fails → 0; root `validate-templates` 0 errors.
 - **[2026-08-29]**: fix(upgrade): **`upgrade-project.ts` 1.17.1 → 1.17.2 — equal-version core-script drift reconciliation.** SYNC_IF_NEWER skipped scripts whose version matched the project's even when content differed, so locally forked core scripts stayed invisible to every future upgrade (audit across Projects/co-* found drifted forks in 7 of 8 projects, e.g. `sync-md`, `team-builder`, `dispatch`, `gen-pr-body`). Same-version scripts are now hash-compared and the canonical L1 copy is restored with a `⚠️ DRIFT … restored to canonical` notice. This closes the promotion-integrity hole: drifted core scripts hard-fail the L3→variant pipeline's integrity check.
 
 ### Fixed
@@ -1439,7 +1440,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ---
 
-*Last Updated: 2026-08-29*
+*Last Updated: 2026-08-30*
 
 
 

--- a/docs/VERSION_MANIFEST.md
+++ b/docs/VERSION_MANIFEST.md
@@ -1,6 +1,6 @@
 # VERSION_MANIFEST.md
 
-**Generated**: 2026-08-29T21:54:20.860Z
+**Generated**: 2026-08-30T05:25:00.971Z
 **Manifest Version**: 1.0
 **Location**: docs\VERSION_MANIFEST.md
 

--- a/memory/2026-08-30.md
+++ b/memory/2026-08-30.md
@@ -237,3 +237,31 @@ feat(skills): promote handbook and handbook-sync-audit skills from co-deck to co
 
 ## Open Issues
 - None
+
+---
+
+## Session Summary
+fix(templates): sync scaffold audit fixes into L1/L2 templates — register handbook scripts in L1 SCRIPTS.md, add @version headers, prune stale relates_to edges, fix i18n-specialist lifecycle frontmatter
+
+## Changes
+- `M CHANGELOG.md` — modified
+- `templates/common/agents/i18n-specialist.md` — modified
+- `templates/common/scripts/SCRIPTS.md` — modified
+- `templates/common/scripts/handbook/build-search-index.ts` — modified
+- `templates/common/scripts/handbook/check-a11y.ts` — modified
+- `templates/common/scripts/handbook/check-lint.ts` — modified
+- `templates/common/scripts/handbook/check-spell.ts` — modified
+- `templates/common/scripts/handbook/check-structure.ts` — modified
+- `templates/common/scripts/handbook/extract-copycode.ts` — modified
+- `templates/common/scripts/handbook/update-footers.ts` — modified
+- `templates/common/skills/documentation-writing/SKILL.md` — modified
+- `templates/common/skills/handbook/assets/js/copy-code.js` — modified
+- `templates/common/skills/meeting-facilitation/SKILL.md` — modified
+- `templates/common/skills/team-builder/SKILL.md` — modified
+- `templates/co-consult/docs/lifecycle/agents/i18n-specialist.md` — modified
+
+## Decisions
+- None
+
+## Open Issues
+- None

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -342,4 +342,4 @@ writeFileSync('file.txt', content, 'utf-8');
 ```
 
 ---
-*Last Updated: 2026-08-29*
+*Last Updated: 2026-08-30*

--- a/templates/co-consult/docs/lifecycle/agents/i18n-specialist.md
+++ b/templates/co-consult/docs/lifecycle/agents/i18n-specialist.md
@@ -1,0 +1,17 @@
+# Agent Governance Record — i18n-specialist
+
+## Overview
+
+- **Agent Name**: i18n-specialist
+- **Role**: Internationalization and localization specialist (locale config, formatting, text layout)
+- **Phase**: production
+
+## Phase History
+
+- **2026-08-30**: Governance record created to satisfy `scripts/validate-agents.ts` governance-record validation for the L1 `i18n-specialist` agent.
+
+## Acceptance Criteria
+
+- [x] Defined in `agents/i18n-specialist.md`
+- [x] Follows standard agent structure
+- [x] Validated by `scripts/validate-agents.ts`

--- a/templates/common/agents/i18n-specialist.md
+++ b/templates/common/agents/i18n-specialist.md
@@ -9,6 +9,11 @@ tier:
   antigravity: medium   # gemini-3.7-flash
   gemini-cli: medium    # gemini-3.7-flash
 model: inherit
+lifecycle:
+  phase: production
+  created: "2026-08-24"
+  last_updated: "2026-08-24"
+  governance: docs/lifecycle/agents/i18n-specialist.md
 version: "1.0.0"
 last_reviewed: "2026-08-24"
 color: cyan

--- a/templates/common/scripts/README.md
+++ b/templates/common/scripts/README.md
@@ -342,4 +342,4 @@ writeFileSync('file.txt', content, 'utf-8');
 ```
 
 ---
-*Last Updated: 2026-08-29*
+*Last Updated: 2026-08-30*

--- a/templates/common/scripts/SCRIPTS.md
+++ b/templates/common/scripts/SCRIPTS.md
@@ -88,6 +88,29 @@ bun run <alias>                     # via package.json alias (preferred for CI)
 | `generate-l3-readme.ts` | L0 | 1.0.3 | active | —| —| L0 | —|
 | `generate-scripts-readme.ts` | L0 | 1.0.3 | active | —| —| L0 | —|
 | `generate-version-manifest.ts` | L0 | 1.2.0 | active | —| —| L0 | —|
+| `handbook/apply-handbook-theme.ts` | L0 | 1.0.0 | active | — | — | common | — |
+| `handbook/build-search-index.ts` | L0 | 1.0.0 | active | — | — | common | — |
+| `handbook/check-a11y.ts` | L0 | 1.0.0 | active | — | — | common | — |
+| `handbook/check-authoring.ts` | L0 | 1.2.0 | active | — | — | common | — |
+| `handbook/check-external-links.ts` | L0 | 1.2.0 | active | — | — | common | — |
+| `handbook/check-i18n-parity.ts` | L0 | 1.0.0 | active | — | — | common | — |
+| `handbook/check-labels.ts` | L0 | 1.0.0 | active | — | — | common | — |
+| `handbook/check-links.ts` | L0 | 1.0.0 | active | — | — | common | — |
+| `handbook/check-lint.ts` | L0 | 1.0.0 | active | — | — | common | — |
+| `handbook/check-search.ts` | L0 | 2.0.0 | active | — | — | common | — |
+| `handbook/check-spell.ts` | L0 | 1.0.0 | active | — | — | common | — |
+| `handbook/check-structure.ts` | L0 | 1.0.0 | active | — | — | common | — |
+| `handbook/check-symmetry.ts` | L0 | 1.0.0 | active | — | — | common | — |
+| `handbook/check-tables.ts` | L0 | 1.0.0 | active | — | — | common | — |
+| `handbook/deploy-handbook.ts` | L0 | 1.1.0 | active | — | — | common | — |
+| `handbook/extract-copycode.ts` | L0 | 1.0.0 | active | — | — | common | — |
+| `handbook/handbook-doctor.ts` | L0 | 1.0.0 | active | — | — | common | — |
+| `handbook/handbook-sync-audit.ts` | L0 | 1.0.0 | active | — | — | common | — |
+| `handbook/nav-utils.ts` | L0 | 1.0.0 | active | — | — | common | — |
+| `handbook/scaffold-handbook.ts` | L0 | 1.2.0 | active | — | — | common | — |
+| `handbook/update-footers.ts` | L0 | 1.0.0 | active | — | — | common | — |
+| `handbook/validate-handbook.ts` | L0 | 1.1.0 | active | — | — | common | — |
+| `handbook/validate-nav.ts` | L0 | 1.0.0 | active | — | — | common | — |
 | `helpers/beta-lifecycle.ts` | L0 | 1.2.0 | active | —| —| L0 | —|
 | `helpers/generate-variant.ts` | L0 | 1.13.1 | active | —| —| L0 | —|
 | `helpers/agent-promote.ts` | L0 | 0.1.1 | experimental | —| —| L0 | —|
@@ -133,6 +156,9 @@ bun run <alias>                     # via package.json alias (preferred for CI)
 | `helpers/validate-platform-parity.ts` | L0 | 1.1.1 | active | —| —| L0 | —|
 | `helpers/ticket-schema.ts` | L0 | 1.1.0 | active | —| —| L0 | —|
 | `helpers/ticket-store.ts` | L0 | 1.1.0 | active | —| —| L0 | —|
+| `tests/apply-handbook-theme.test.ts` | L0 | 1.0.1 | active | — | — | common | — |
+| `tests/check-structure.test.ts` | L0 | 1.0.0 | active | — | — | common | — |
+| `tests/deploy-readme-patch.test.ts` | L0 | 1.0.0 | active | — | — | common | — |
 | `validators/types.ts` | L0 | 1.0.0 | active | —| —| L0 | —|
 | `validators/variant-json-validator.ts` | L0 | 1.0.0 | active | —| —| L0 | —|
 | `validators/extends-validator-wrapper.ts` | L0 | 1.0.0 | active | —| —| L0 | —|

--- a/templates/common/scripts/handbook/build-search-index.ts
+++ b/templates/common/scripts/handbook/build-search-index.ts
@@ -1,4 +1,5 @@
 #!/usr/bin/env bun
+// @version 1.0.0
 // scripts/handbook/build-search-index.ts
 // Reads docs/search-manifest.json and generates docs/assets/search-data.js
 // containing the DOCS array and LABELS object consumed by site-search.js.

--- a/templates/common/scripts/handbook/check-a11y.ts
+++ b/templates/common/scripts/handbook/check-a11y.ts
@@ -1,4 +1,5 @@
 #!/usr/bin/env bun
+// @version 1.0.0
 // scripts/handbook/check-a11y.ts
 // L2 — Accessibility checks for handbook HTML files.
 // Validates basic a11y requirements without external tools:

--- a/templates/common/scripts/handbook/check-lint.ts
+++ b/templates/common/scripts/handbook/check-lint.ts
@@ -1,4 +1,5 @@
 #!/usr/bin/env bun
+// @version 1.0.0
 // scripts/handbook/check-lint.ts
 // L5 — Basic HTML lint for handbook files without stylelint/eslint.
 // Validates HTML quality using only regex-based checks:

--- a/templates/common/scripts/handbook/check-spell.ts
+++ b/templates/common/scripts/handbook/check-spell.ts
@@ -1,4 +1,5 @@
 #!/usr/bin/env bun
+// @version 1.0.0
 // scripts/handbook/check-spell.ts
 // L3 — Basic spell checker for English handbook HTML files.
 // Validates visible text content against a built-in list of common

--- a/templates/common/scripts/handbook/check-structure.ts
+++ b/templates/common/scripts/handbook/check-structure.ts
@@ -1,4 +1,5 @@
 #!/usr/bin/env bun
+// @version 1.0.0
 // scripts/handbook/check-structure.ts
 // HTML structure validator — the well-formedness layer of the handbook toolkit.
 // Ported from intro-to-ai-harness/scripts/validate-structure.py (stack-based).

--- a/templates/common/scripts/handbook/extract-copycode.ts
+++ b/templates/common/scripts/handbook/extract-copycode.ts
@@ -1,3 +1,4 @@
+// @version 1.0.0
 /**
  * extract-copycode.ts
  *

--- a/templates/common/scripts/handbook/update-footers.ts
+++ b/templates/common/scripts/handbook/update-footers.ts
@@ -1,4 +1,5 @@
 #!/usr/bin/env bun
+// @version 1.0.0
 // scripts/handbook/update-footers.ts
 // Syncs the localized site footer into every HTML page under docs/.
 // Vendored from Handbooks/multi-agent-harness-handbook/scripts/update-footers.ts

--- a/templates/common/skills/handbook/assets/js/copy-code.js
+++ b/templates/common/skills/handbook/assets/js/copy-code.js
@@ -3,7 +3,7 @@ var COPY_LABELS = {
   en: ['Copied!', 'Failed'],
   ko: ['완료!', '실패!'],
   es: ['¡Copiado!', 'Error'],
-  ja: ['コピーしました！', '失敗！']
+  ja: ['コピーしました', '失敗']
 };
 var COPY_LABEL = COPY_LABELS[document.documentElement.lang] || COPY_LABELS.en;
 


### PR DESCRIPTION
## Why
The `co-consult` post-scaffold audit reported 7 failures, all traced to gaps in the L1/L2 source templates rather than the scaffold itself. Fixing them at the template level prevents every future scaffold of any variant from reproducing the same failures.

## What Changed
- Registered 23 `handbook/*.ts` + 3 `tests/*.test.ts` scripts in `templates/common/scripts/SCRIPTS.md` (rows were absent from the L1 registry, so scaffolds produced "unregistered script" failures) with versions matching each script's `@version` header
- Added missing `// @version 1.0.0` headers to 7 `templates/common/scripts/handbook/` scripts (`build-search-index`, `check-a11y`, `check-lint`, `check-spell`, `check-structure`, `extract-copycode`, `update-footers`)
- Pruned stale `relates_to` edges targeting L0-only skills: `documentation-writing` -> `audit-workspace`, `meeting-facilitation` -> `context-commonization-review`, `team-builder` -> `create-variant` in `templates/common/skills/*/SKILL.md`
- Added required `lifecycle.phase`/`lifecycle.governance` frontmatter to `templates/common/agents/i18n-specialist.md` and created its governance record at `templates/co-consult/docs/lifecycle/agents/i18n-specialist.md`
- Replaced fullwidth `！` (U+FF01) with plain text in `templates/common/skills/handbook/assets/js/copy-code.js` Japanese labels to satisfy the homoglyph audit
- Added CHANGELOG [Unreleased] entry

## Test Plan
- [x] `bun scripts/audit.ts` passes (scaffolded `co-consult`: 7 fails -> 0)
- [x] `bun scripts/validate-templates.ts` — 0 errors
- [x] `bun scripts/validate-skills.ts` / `validate-agents.ts` / `verify-scripts.ts --verify` — all pass at workspace root

## Security Checklist
- [x] No secrets, credentials, or API keys committed
- [x] No `.env` files staged (use `.env.sample` for templates)
- [x] Dependencies unchanged or reviewed for new CVEs

## Notes
No new-project.ts changes were needed — the filter was not at fault; the L1 registry rows simply never existed. The `co-consult` working project at `C:\git\ai_workspace\co-consult` already carries the equivalent project-local fixes.

---
